### PR TITLE
Fix to ensure provided gui font is valid

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -66,8 +66,16 @@ impl CachingShaper {
     pub fn update_font(&mut self, guifont_setting: &str) {
         trace!("Updating font: {}", guifont_setting);
 
-        self.options = FontOptions::parse(guifont_setting);
-        self.reset_font_loader();
+        let options = FontOptions::parse(guifont_setting);
+        let font_key = FontKey::from(&options);
+
+        if let Some(_) = self.font_loader.get_or_load(&font_key) {
+            trace!("Font updated to: {}", guifont_setting);
+            self.options = options;
+            self.reset_font_loader();
+        } else {
+            trace!("Font can't be updated to: {}", guifont_setting);
+        }
     }
 
     fn reset_font_loader(&mut self) {


### PR DESCRIPTION
Providing a wrong font was causing neovide to retry every time to load an
inexistent font, instead just trying to load once at it's setup should
be enough

Maybe this can fix #818

## What kind of change does this PR introduce?
- [X] Fix

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [X] No
