### PR TITLE
Fix to sending key signals when window focus lost

### DIFF
--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -32,12 +32,12 @@ impl KeyboardManager {
     pub fn handle_event(&mut self, event: &Event<()>) {
         match event {
             Event::WindowEvent {
-                event: WindowEvent::Focused(focused),
+                event: WindowEvent::Focused(_focused),
                 ..
             } => {
-                // The window was just focused, so ignore keyboard events that were submitted this
-                // frame.
-                self.ignore_input_this_frame = *focused;
+                // When window is just focused or lost it's focus, ignore keyboard events 
+                // that were submitted this frame
+                self.ignore_input_this_frame = true;
             }
             Event::WindowEvent {
                 event:


### PR DESCRIPTION
When window focus has just been lost, key pressed events aren't ignored


I tried to track issue #826, I've found that input are been handled as normal when window lost focus, instead of been ignored, and, because of that, handling unnecessary events (such as Alt+Tab, Super+other keys, etc).

I don't have tested with every combination, but I think it solves the problem, as I have myself been facing this issue while using neovide.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- [X] Fix


## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [X] No
