### PR TITLE
Fix recursion when using -- to pass args to nvim.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -208,8 +208,8 @@ fn maybe_disown() {
 
     if let Ok(current_exe) = env::current_exe() {
         assert!(process::Command::new(current_exe)
-            .args(env::args().skip(1))
             .arg("--nofork")
+            .args(env::args().skip(1))
             .spawn()
             .is_ok());
         process::exit(0);


### PR DESCRIPTION
After #852 passing arguments to neovim (ex. `neovide -- --clean`) stopped working because the `--nofork` was added to the end of the argument list causing the disowned process to ignore it since it comes after `--`. This is repeated indefinitely causing the following situation:
```
$ pgrep -a neovide
237212 neovide -- --clean --nofork --nofork --nofork --nofork --nofork --nofork
--nofork --nofork --nofork --nofork --nofork --nofork --nofork --nofork --nofork
--nofork --nofork --nofork --nofork --nofork --nofork --nofork --nofork --nofork
--nofork --nofork ...
```
The fix is simply to put `--nofork` as the first arg.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change?
- No
