### PR TITLE
add neovide_input_use_logo to toggle logo handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use editor::start_editor;
 use renderer::{cursor_renderer::CursorSettings, RendererSettings};
 #[cfg(not(test))]
 use settings::SETTINGS;
-use window::{create_window, WindowSettings};
+use window::{create_window, KeyboardSettings, WindowSettings};
 
 pub use channel_utils::*;
 
@@ -163,6 +163,7 @@ fn main() {
     WindowSettings::register();
     RendererSettings::register();
     CursorSettings::register();
+    KeyboardSettings::register();
 
     let running = Arc::new(AtomicBool::new(true));
 

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -29,5 +29,5 @@ impl Default for WindowSettings {
 #[derive(Clone, Default, SettingGroup)]
 #[setting_prefix = "input"]
 pub struct KeyboardSettings {
-    pub use_logo: bool
+    pub use_logo: bool,
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -25,3 +25,9 @@ impl Default for WindowSettings {
         }
     }
 }
+
+#[derive(Clone, Default, SettingGroup)]
+#[setting_prefix = "input"]
+pub struct KeyboardSettings {
+    pub use_logo: bool
+}

--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -5,8 +5,8 @@ use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 
 use crate::bridge::UiCommand;
 use crate::channel_utils::LoggingTx;
-use crate::window::KeyboardSettings;
 use crate::settings::SETTINGS;
+use crate::window::KeyboardSettings;
 
 pub struct KeyboardManager {
     command_sender: LoggingTx<UiCommand>,


### PR DESCRIPTION
it also completely ignores keyboard inputs with D modifier

As already discussed at #763, it introduces `g:neovide_input_use_logo` to toggle between logo input handling or ignoring inputs using this modifier and, because of that, it's a feature to normalize usage with terminals (to what people are used to).

So isn't our problem anymore `<D->` been typed, if that option is active, because it works as any function key when using at insert mode.

I'm sure it can close both #763 and #826

About the code itself, if I've made any mistake about organization or something like that, please let me know
I can include documentation at wiki about the option too

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- [ ] Fix
- [X] Feature
- [ ] Codestyle
- [ ] Refactor
- [ ] Other

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [ ] Yes, please list breaking changes
- [X] No