### PR TITLE
fix(cmd_line): Renamed --multiGrid to --multigrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neovide [![Gitter](https://badges.gitter.im/neovide/community.svg)](https://gitter.im/neovide/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Discussions](https://img.shields.io/badge/GitHub-Discussions-green?logo=github)](https://github.com/Kethku/neovide/discussions)
 
-This is a simple graphical user interface for [Neovim](https://github.com/neovim/neovim) (an aggressively refactored and updated 
+This is a simple graphical user interface for [Neovim](https://github.com/neovim/neovim) (an aggressively refactored and updated
 Vim editor). Where possible there are some graphical improvements, but functionally it should act like the terminal UI.
 
 ![Basic Screen Cap](./assets/BasicScreenCap.png)
@@ -32,7 +32,7 @@ Cursor animates into position with a smear effect to improve tracking of cursor 
 
 Scroll operations on buffers in neovim will be animated smoothly pixel wise rather than line by line at a time. Note, multigrid must be
 enabled for this to work.
-https://github.com/Kethku/neovide/wiki/Configuration#multiGrid
+https://github.com/Kethku/neovide/wiki/Configuration#multigrid
 
 ![Smooth Scrolling](./assets/SmoothScrolling.gif)
 
@@ -40,7 +40,7 @@ https://github.com/Kethku/neovide/wiki/Configuration#multiGrid
 
 Windows animate into position when they are moved making it easier to see how layout changes happen. Note, multigrid must be enabled for
 this to work.
-https://github.com/Kethku/neovide/wiki/Configuration#multiGrid
+https://github.com/Kethku/neovide/wiki/Configuration#multigrid
 
 ![Animated Windows](./assets/AnimatedWindows.gif)
 
@@ -48,7 +48,7 @@ https://github.com/Kethku/neovide/wiki/Configuration#multiGrid
 
 The backgrounds of floating windows are blurred improving the visual separation between foreground and background from
 built in window transparency. Note, multigrid must be enabled for this to work.
-https://github.com/Kethku/neovide/wiki/Configuration#multiGrid
+https://github.com/Kethku/neovide/wiki/Configuration#multigrid
 
 ![Blurred Floating Windows](./assets/BlurredFloatingWindows.png)
 
@@ -199,7 +199,7 @@ sed "$REGEX" PKGBUILD
 makepkg -si
 ```
 #### With Snap
-Neovide is also available in the Snap Store. You can install it 
+Neovide is also available in the Snap Store. You can install it
 using the command below.
 
 ```

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -70,9 +70,7 @@ pub fn handle_command_line_arguments() -> Result<(), String> {
         )
         .arg(
             Arg::with_name("multi_grid")
-                //.long("multi-grid") TODO: multiGrid is the current way to call this, but I
-                //personally would prefer sticking to a unix-y way of naming things...
-                .long("multiGrid")
+                .long("multigrid")
                 .help("Enable Multigrid"),
         )
         .arg(
@@ -127,7 +125,7 @@ pub fn handle_command_line_arguments() -> Result<(), String> {
      * Integrate Environment Variables as Defaults to the command-line ones.
      *
      * NEOVIM_BIN
-     * NeovideMultiGrid || --multiGrid
+     * NEOVIDE_MULTIGRID || --multigrid
      */
     SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
         neovim_bin: std::env::var("NEOVIM_BIN").ok(),
@@ -142,9 +140,7 @@ pub fn handle_command_line_arguments() -> Result<(), String> {
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
         maximized: matches.is_present("maximized") || std::env::var("NEOVIDE_MAXIMIZED").is_ok(),
-        multi_grid: std::env::var("NEOVIDE_MULTIGRID").is_ok()
-            || std::env::var("NeovideMultiGrid").is_ok()
-            || matches.is_present("multi_grid"),
+        multi_grid: std::env::var("NEOVIDE_MULTIGRID").is_ok() || matches.is_present("multi_grid"),
         remote_tcp: matches.value_of("remote_tcp").map(|i| i.to_owned()),
         nofork: matches.is_present("nofork") || matches.is_present("verbosity"),
         wsl: matches.is_present("wsl"),


### PR DESCRIPTION
BREAKING CHANGE: Renamed --multiGrid to --multigrid
BREAKING CHANGE: Removed env var NeovideMultiGrid

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Other

## Did this PR introduce a breaking change?
- Yes, it renames --multiGrid to --multigrid and removes NeovideMultiGrid env var

Wiki should be updated after merge. I'll handle it.
