### PR TITLE
Refactor startup

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -274,15 +274,13 @@ async fn start_neovim_runtime(
         .await
         .ok();
 
-    let WindowGeometry { width, height } = SETTINGS.get::<CmdLineSettings>().geometry;
+    let settings = SETTINGS.get::<CmdLineSettings>();
+    let geometry = settings.geometry;
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
-
-    if SETTINGS.get::<CmdLineSettings>().multi_grid {
-        options.set_multigrid_external(true);
-    }
+    options.set_multigrid_external(settings.multi_grid);
     options.set_rgb(true);
-    nvim.ui_attach(width as i64, height as i64, &options)
+    nvim.ui_attach(geometry.width as i64, geometry.height as i64, &options)
         .await
         .unwrap_or_explained_panic("Could not attach ui to neovim process");
 

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -16,8 +16,8 @@ use crate::windows_utils::{
 pub enum UiCommand {
     Quit,
     Resize {
-        width: u32,
-        height: u32,
+        width: u64,
+        height: u64,
     },
     Keyboard(String),
     MouseButton {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -236,7 +236,6 @@ impl Editor {
     }
 
     fn resize_window(&mut self, grid: u64, width: u64, height: u64) {
-        trace!("editor resize {}", grid);
         if let Some(window) = self.windows.get_mut(&grid) {
             window.resize((width, height));
         } else {

--- a/src/settings/window_geometry.rs
+++ b/src/settings/window_geometry.rs
@@ -1,7 +1,5 @@
-use crate::renderer::Renderer;
 use crate::settings::SETTINGS;
 use crate::window::WindowSettings;
-use glutin::dpi::PhysicalSize;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -36,12 +34,10 @@ pub const DEFAULT_WINDOW_GEOMETRY: WindowGeometry = WindowGeometry {
     height: 50,
 };
 
-pub fn maybe_save_window_size(window_size: PhysicalSize<u32>, renderer: &Renderer) {
+pub fn maybe_save_window_size(grid_size: (u64, u64)) {
     let saved_window_size = if SETTINGS.get::<WindowSettings>().remember_window_size {
-        WindowGeometry {
-            width: (window_size.width as f32 / renderer.font_width as f32) as u64,
-            height: (window_size.height as f32 / renderer.font_height as f32) as u64,
-        }
+        let (width, height) = grid_size;
+        WindowGeometry { width, height }
     } else {
         WindowGeometry {
             width: DEFAULT_WINDOW_GEOMETRY.width as u64,


### PR DESCRIPTION
I tried to delay window creation until we have guifont, but that way was too obscure, and i tried something different.

Actually, we don't care when window is created, what we do care about - is when window is resized to it's desired size.

So, this PR moves setting initial size into draw_frame, behind `first_render_pass` boolean flag. And then, instead of resizing grid to window size, resizes window to grid size.

Startup process now looks like this:
```
cargo r -- -vvvv --geometry 80x40 2> >(egrep -i '(Resize|First|font upd|dimens|matched)')
...
TRACE [neovide::channel_utils] redraw_event Resize { grid: 1, width: 80, height: 40 }
TRACE [neovide::renderer::fonts::caching_shaper] Font updated to: JetBrainsMono Nerd Font:h11
TRACE [neovide::renderer] Updating font dimensions: 29x14
TRACE [neovide::renderer::fonts::caching_shaper] Font updated to: JetBrainsMono Nerd Font:h11
TRACE [neovide::renderer] Updating font dimensions: 29x14
TRACE [neovide::window::window_wrapper] Grid matched saved size, skip update.
```

One problem i haven't fixed yet, is this black line at the bottom. 
![image](https://user-images.githubusercontent.com/301015/128599101-f764b601-fe81-4b8a-b319-8ba11cf36e51.png)

But now we can see startup screen :)

I'll refactor it a little, before it's ready for merge. Suggestions welcomed.

## What kind of change does this PR introduce?
- Fix
- Refactor

## Did this PR introduce a breaking change?
- No