### PR TITLE
tweak pr template and fix build pipeline on windows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.yml
+++ b/.github/PULL_REQUEST_TEMPLATE.yml
@@ -1,13 +1,13 @@
 <!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->
 
 ## What kind of change does this PR introduce?
-- [ ] Fix
-- [ ] Feature
-- [ ] Codestyle
-- [ ] Refactor
-- [ ] Other
+- Fix
+- Feature
+- Codestyle
+- Refactor
+- Other
 
-## Did this PR introduce a breaking change?
+## Did this PR introduce a breaking change? 
 _A breaking change includes anything that breaks backwards compatibility either at compile or run time._
-- [ ] Yes, please list breaking changes
-- [ ] No
+- Yes, please list breaking changes
+- No

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
         
     - name: Archive Windows artifact
       run: |
+        powershell rm ./target/release/neovide.zip
         powershell Compress-Archive ./target/release/neovide.exe ./target/release/neovide.zip 
 
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Fixes the pr template to not use todo markers, and fixes an intermittent failure in the windows build and test workflow

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
