### PR TITLE
Potential fix for #870

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   but it should act functionally like the terminal UI.
 
 grade: stable # must be 'stable' to release into candidate/stable channels
-confinement: strict # use 'strict' once you have the right plugs and slots
+confinement: classic # use 'strict' once you have the right plugs and slots
 build-packages:
   - cmake
   - freeglut3-dev


### PR DESCRIPTION
This should give neovide permissions to access the appropriate drawing libraries for #870. As a possible long-term enhancement/fix, we could look into adding the permissions for the necessary components and revert the containment to "strict".