### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ futures = "0.3.12"
 glutin = { git = "https://github.com/Kethku/glutin", branch = "new-keyboard-all" }
 winit = { git = "https://github.com/Kethku/winit", branch = "new-keyboard-all", default-features = false }
 gl = "0.14.0"
-regex = "1.5.4"
 swash = "0.1.4"
 clap="2.33.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", f
 tokio = { version = "1.1.1", features = ["full"] }
 tokio-util = "0.6.7"
 async-trait = "0.1.18"
-crossfire = "0.1"
 lazy_static = "1.4.0"
 unicode-segmentation = "1.6.0"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lru = "0.4.3"
 derive-new = "0.5"
 rmpv = "0.4.4"
 rust-embed = { version = "5.2.0", features = ["debug-embed"] }
-image = "0.22.3"
+image = { version = "0.22.3", default-features = false, features = ["ico"] }
 nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = ["use_tokio"] }
 tokio = { version = "1.1.1", features = ["full"] }
 tokio-util = "0.6.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ euclid = "0.20.7"
 lru = "0.4.3"
 derive-new = "0.5"
 rmpv = "0.4.4"
-rust-embed = { version = "5.2.0", features = ["debug-embed"] }
 image = { version = "0.22.3", default-features = false, features = ["ico"] }
 nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = ["use_tokio"] }
 tokio = { version = "1.1.1", features = ["full"] }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -14,7 +14,7 @@ use nvim_rs::UiAttachOptions;
 use rmpv::Value;
 use tokio::process::Command;
 use tokio::runtime::Runtime;
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::channel_utils::*;
 use crate::settings::*;
@@ -156,7 +156,7 @@ fn connection_mode() -> ConnectionMode {
 
 async fn start_neovim_runtime(
     ui_command_sender: LoggingTx<UiCommand>,
-    mut ui_command_receiver: mpsc::UnboundedReceiver<UiCommand>,
+    mut ui_command_receiver: UnboundedReceiver<UiCommand>,
     redraw_event_sender: LoggingTx<RedrawEvent>,
     running: Arc<AtomicBool>,
 ) {
@@ -317,7 +317,7 @@ pub struct Bridge {
 
 pub fn start_bridge(
     ui_command_sender: LoggingTx<UiCommand>,
-    ui_command_receiver: mpsc::UnboundedReceiver<UiCommand>,
+    ui_command_receiver: UnboundedReceiver<UiCommand>,
     redraw_event_sender: LoggingTx<RedrawEvent>,
     running: Arc<AtomicBool>,
 ) -> Bridge {

--- a/src/channel_utils.rs
+++ b/src/channel_utils.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::sync::mpsc::{SendError, Sender};
 
 use log::trace;
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{error::SendError as TokioSendError, UnboundedSender};
 
 #[derive(Clone)]
 pub struct LoggingSender<T>
@@ -35,7 +35,7 @@ pub struct LoggingTx<T>
 where
     T: Debug,
 {
-    tx: mpsc::UnboundedSender<T>,
+    tx: UnboundedSender<T>,
     channel_name: String,
 }
 
@@ -43,11 +43,11 @@ impl<T> LoggingTx<T>
 where
     T: Debug,
 {
-    pub fn attach(tx: mpsc::UnboundedSender<T>, channel_name: String) -> Self {
+    pub fn attach(tx: UnboundedSender<T>, channel_name: String) -> Self {
         Self { tx, channel_name }
     }
 
-    pub fn send(&self, message: T) -> Result<(), mpsc::error::SendError<T>> {
+    pub fn send(&self, message: T) -> Result<(), TokioSendError<T>> {
         trace!("{} {:?}", self.channel_name, &message);
         self.tx.send(message)
     }

--- a/src/channel_utils.rs
+++ b/src/channel_utils.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 use std::sync::mpsc::{SendError, Sender};
 
-use crossfire::mpsc::{SendError as TxError, TxUnbounded};
 use log::trace;
+use tokio::sync::mpsc;
 
 #[derive(Clone)]
 pub struct LoggingSender<T>
@@ -35,7 +35,7 @@ pub struct LoggingTx<T>
 where
     T: Debug,
 {
-    tx: TxUnbounded<T>,
+    tx: mpsc::UnboundedSender<T>,
     channel_name: String,
 }
 
@@ -43,11 +43,11 @@ impl<T> LoggingTx<T>
 where
     T: Debug,
 {
-    pub fn attach(tx: TxUnbounded<T>, channel_name: String) -> Self {
+    pub fn attach(tx: mpsc::UnboundedSender<T>, channel_name: String) -> Self {
         Self { tx, channel_name }
     }
 
-    pub fn send(&self, message: T) -> Result<(), TxError<T>> {
+    pub fn send(&self, message: T) -> Result<(), mpsc::error::SendError<T>> {
         trace!("{} {:?}", self.channel_name, &message);
         self.tx.send(message)
     }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
 
-use crossfire::mpsc::RxUnbounded;
 use log::{error, trace};
+use tokio::sync::mpsc;
 
 use crate::bridge::{EditorMode, GuiOption, RedrawEvent, WindowAnchor};
 use crate::channel_utils::*;
@@ -440,14 +440,14 @@ impl Editor {
 }
 
 pub fn start_editor(
-    redraw_event_receiver: RxUnbounded<RedrawEvent>,
+    mut redraw_event_receiver: mpsc::UnboundedReceiver<RedrawEvent>,
     batched_draw_command_sender: LoggingSender<Vec<DrawCommand>>,
     window_command_sender: LoggingSender<WindowCommand>,
 ) {
     thread::spawn(move || {
         let mut editor = Editor::new(batched_draw_command_sender, window_command_sender);
 
-        while let Ok(redraw_event) = redraw_event_receiver.recv_blocking() {
+        while let Some(redraw_event) = redraw_event_receiver.blocking_recv() {
             editor.handle_redraw_event(redraw_event);
         }
     });

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::thread;
 
 use log::{error, trace};
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::bridge::{EditorMode, GuiOption, RedrawEvent, WindowAnchor};
 use crate::channel_utils::*;
@@ -440,7 +440,7 @@ impl Editor {
 }
 
 pub fn start_editor(
-    mut redraw_event_receiver: mpsc::UnboundedReceiver<RedrawEvent>,
+    mut redraw_event_receiver: UnboundedReceiver<RedrawEvent>,
     batched_draw_command_sender: LoggingSender<Vec<DrawCommand>>,
     window_command_sender: LoggingSender<WindowCommand>,
 ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ extern crate lazy_static;
 
 use std::sync::{atomic::AtomicBool, mpsc::channel, Arc};
 
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::unbounded_channel;
 
 use bridge::start_bridge;
 use cmd_line::CmdLineSettings;
@@ -135,7 +135,7 @@ fn main() {
 
     let running = Arc::new(AtomicBool::new(true));
 
-    let (redraw_event_sender, redraw_event_receiver) = mpsc::unbounded_channel();
+    let (redraw_event_sender, redraw_event_receiver) = unbounded_channel();
     let logging_redraw_event_sender =
         LoggingTx::attach(redraw_event_sender, "redraw_event".to_owned());
 
@@ -145,7 +145,7 @@ fn main() {
         "batched_draw_command".to_owned(),
     );
 
-    let (ui_command_sender, ui_command_receiver) = mpsc::unbounded_channel();
+    let (ui_command_sender, ui_command_receiver) = unbounded_channel();
     let logging_ui_command_sender = LoggingTx::attach(ui_command_sender, "ui_command".to_owned());
 
     let (window_command_sender, window_command_receiver) = channel();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ extern crate lazy_static;
 
 use std::sync::{atomic::AtomicBool, mpsc::channel, Arc};
 
-use crossfire::mpsc::unbounded_future;
+use tokio::sync::mpsc;
 
 use bridge::start_bridge;
 use cmd_line::CmdLineSettings;
@@ -135,7 +135,7 @@ fn main() {
 
     let running = Arc::new(AtomicBool::new(true));
 
-    let (redraw_event_sender, redraw_event_receiver) = unbounded_future();
+    let (redraw_event_sender, redraw_event_receiver) = mpsc::unbounded_channel();
     let logging_redraw_event_sender =
         LoggingTx::attach(redraw_event_sender, "redraw_event".to_owned());
 
@@ -145,7 +145,7 @@ fn main() {
         "batched_draw_command".to_owned(),
     );
 
-    let (ui_command_sender, ui_command_receiver) = unbounded_future();
+    let (ui_command_sender, ui_command_receiver) = mpsc::unbounded_channel();
     let logging_ui_command_sender = LoggingTx::attach(ui_command_sender, "ui_command".to_owned());
 
     let (window_command_sender, window_command_receiver) = channel();

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,6 @@ pub mod windows_utils;
 #[macro_use]
 extern crate derive_new;
 #[macro_use]
-extern crate rust_embed;
-#[macro_use]
 extern crate lazy_static;
 
 use std::sync::{atomic::AtomicBool, mpsc::channel, Arc};

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -6,12 +6,8 @@ use skia_safe::{font::Edging, Data, Font, FontHinting, FontMgr, FontStyle, Typef
 use super::font_options::FontOptions;
 use super::swash_font::SwashFont;
 
-#[derive(RustEmbed)]
-#[folder = "assets/fonts/"]
-pub struct Asset;
-
-const DEFAULT_FONT: &str = "FiraCode-Regular.ttf";
-const LAST_RESORT_FONT: &str = "LastResort-Regular.ttf";
+static DEFAULT_FONT: &[u8] = include_bytes!("../../../assets/fonts/FiraCode-Regular.ttf");
+static LAST_RESORT_FONT: &[u8] = include_bytes!("../../../assets/fonts/LastResort-Regular.ttf");
 
 pub struct FontPair {
     pub skia_font: Font,
@@ -141,14 +137,12 @@ impl FontLoader {
                 FontPair::new(Font::from_typeface(typeface, self.font_size))
             }
             FontSelection::Default => {
-                let default_font_data = Asset::get(DEFAULT_FONT).unwrap();
-                let data = Data::new_copy(&default_font_data);
+                let data = Data::new_copy(DEFAULT_FONT);
                 let typeface = Typeface::from_data(data, 0).unwrap();
                 FontPair::new(Font::from_typeface(typeface, self.font_size))
             }
             FontSelection::LastResort => {
-                let default_font_data = Asset::get(LAST_RESORT_FONT).unwrap();
-                let data = Data::new_copy(&default_font_data);
+                let data = Data::new_copy(LAST_RESORT_FONT);
                 let typeface = Typeface::from_data(data, 0).unwrap();
                 FontPair::new(Font::from_typeface(typeface, self.font_size))
             }

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -40,9 +40,7 @@ use keyboard_manager::KeyboardManager;
 use mouse_manager::MouseManager;
 use renderer::SkiaRenderer;
 
-#[derive(RustEmbed)]
-#[folder = "assets/"]
-struct Asset;
+static ICON: &[u8] = include_bytes!("../../../assets/neovide.ico");
 
 pub struct GlutinWindowWrapper {
     windowed_context: WindowedContext<glutin::PossiblyCurrent>,
@@ -217,8 +215,7 @@ pub fn create_window(
     running: Arc<AtomicBool>,
 ) {
     let icon = {
-        let icon_data = Asset::get("neovide.ico").expect("Failed to read icon data");
-        let icon = load_from_memory(&icon_data).expect("Failed to parse icon data");
+        let icon = load_from_memory(ICON).expect("Failed to parse icon data");
         let (width, height) = icon.dimensions();
         let mut rgba = Vec::with_capacity((width * height) as usize * 4);
         for (_, _, pixel) in icon.pixels() {


### PR DESCRIPTION
This reduces the number of dependencies to 345 (from 391) without any major impact on the code. I can break the commits up into separate PRs if you think that's better.

## I've made the following changes:
- Changed `image`: Only use the `ico` feature since that's the only one that's needed.
- Removed `rust-embed`: Was only used for embedding two fonts and an icon. Since it uses a proc-macro it's a rather heavy dependency for what it does. If there are plans to embed more things in the near future you might want to keep this anyway though.
- Removed `crossfire`: Was presumably used because it supports both blocking and async on the same channel. Since  #867 the version of tokio used also supports this so lets use that one instead.
- Removed `regex`: Was only used to check nvims version string, but vim has a built-in version check that can be used instead. 

## What kind of change does this PR introduce?
- Refactor

## Did this PR introduce a breaking change? 
- No