### PR TITLE
fix: Trigger grid resize after font change

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -230,7 +230,7 @@ impl Renderer {
         canvas.restore();
     }
 
-    pub fn handle_draw_command(&mut self, root_canvas: &mut Canvas, draw_command: DrawCommand) {
+    fn handle_draw_command(&mut self, root_canvas: &mut Canvas, draw_command: DrawCommand) {
         match draw_command {
             DrawCommand::Window {
                 grid_id,
@@ -276,16 +276,19 @@ impl Renderer {
         }
     }
 
+    /// Draws frame
+    ///
+    /// # Returns
+    /// `bool` indicating whether or not font was changed during this frame.
     #[allow(clippy::needless_collect)]
     pub fn draw_frame(&mut self, root_canvas: &mut Canvas, dt: f32) -> bool {
-        let mut font_changed = false;
-
         let draw_commands: Vec<_> = self
             .batched_draw_command_receiver
             .try_iter() // Iterator of Vec of DrawCommand
             .map(|batch| batch.into_iter()) // Iterator of Iterator of DrawCommand
             .flatten() // Iterator of DrawCommand
             .collect();
+        let mut font_changed = false;
 
         for draw_command in draw_commands.into_iter() {
             if let DrawCommand::FontChanged(_) = draw_command {

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -164,9 +164,10 @@ impl GlutinWindowWrapper {
 
     pub fn draw_frame(&mut self, dt: f32) {
         let window = self.windowed_context.window();
+        let mut font_changed = false;
 
         if REDRAW_SCHEDULER.should_draw() || SETTINGS.get::<WindowSettings>().no_idle {
-            self.renderer.draw_frame(self.skia_renderer.canvas(), dt);
+            font_changed = self.renderer.draw_frame(self.skia_renderer.canvas(), dt);
             self.skia_renderer.gr_context.flush(None);
             self.windowed_context.swap_buffers().unwrap();
         }
@@ -180,11 +181,13 @@ impl GlutinWindowWrapper {
             let size = SETTINGS.get::<CmdLineSettings>().geometry;
             window.set_inner_size(self.renderer.convert_grid_to_physical(size));
             self.saved_grid_size = Some(size);
+            // Font change at startup is ignored, so grid size (and startup screen) could be preserved.
+            font_changed = false;
         }
 
         let new_size = window.inner_size();
 
-        if self.saved_inner_size != new_size {
+        if self.saved_inner_size != new_size || font_changed {
             self.saved_inner_size = new_size;
             self.handle_new_grid_size(new_size);
             self.skia_renderer.resize(&self.windowed_context);


### PR DESCRIPTION
Right now when you change font, window or grid not resized, so window is larger or smaller than picture inside it.

This PR triggers grid resize after font change. Maybe it's better to change window size, but I decided to resize grid (picture), becouse it's simpler in our case.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
