### PR TITLE
refactor(font): conditional compilation on macos

### DIFF
--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -90,13 +90,12 @@ fn points_to_pixels(value: f32) -> f32 {
     //
     // In reality, this depends on DPI/PPI of monitor, but here we only care about converting
     // from points to pixels, so this is standard constant values.
-    let pixels_per_inch = 96.0;
-    let points_per_inch = 72.0;
-    // On macos points == pixels
-    #[cfg(target_os = "macos")]
-    let points_per_inch = 96.0;
-
-    let pixels_per_point = pixels_per_inch / points_per_inch;
-
-    value * pixels_per_point
+    if cfg!(target_os = "macos") {
+        // On macos points == pixels
+        value
+    } else {
+        let pixels_per_inch = 96.0;
+        let points_per_inch = 72.0;
+        value * (pixels_per_inch / points_per_inch)
+    }
 }


### PR DESCRIPTION
Avoids 
```
warning: unused variable: `points_per_inch`
  --> src/renderer/fonts/font_options.rs:94:9
   |
94 |     let points_per_inch = 72.0;
   |         ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_points_per_inch`
   |
   = note: `#[warn(unused_variables)]` on by default
```
when compiling `neovide` on macOS, which is innocuous but has been bugging me for a while.
