### PR TITLE
ci: allow skipping failing publish step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,7 @@ jobs:
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
       if: always()
+      continue-on-error: true
       with:
         files: results.xml
 


### PR DESCRIPTION
Should allow M1 artifacts to be built and published even though `EnricoMi/publish-unit-test-result-action/composite@v1` is broken on M1 due to broken `PyNaCl` dependency.
