### PR TITLE
Logo/Meta/Super key hang / key ignore on focus change on Linux/Gnome/X11

### DIFF
--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -58,10 +58,13 @@ impl KeyboardManager {
             } => {
                 // Record the modifer states so that we can properly add them to the keybinding
                 // text
-                self.shift = modifiers.shift_key();
-                self.ctrl = modifiers.control_key();
-                self.alt = modifiers.alt_key();
-                self.logo = modifiers.super_key();
+                if !self.ignore_input_this_frame {
+                    self.shift = modifiers.shift_key();
+                    self.ctrl = modifiers.control_key();
+                    self.alt = modifiers.alt_key();
+                    self.logo = modifiers.super_key();
+                }
+
             }
             Event::MainEventsCleared => {
                 // And the window wasn't just focused.

--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -84,7 +84,7 @@ impl KeyboardManager {
                     }
                 }
 
-                // Regardless of whether this was a valid keyboard input or not, rest ignoring and
+                // Regardless of whether this was a valid keyboard input or not, reset ignoring and
                 // whatever event was queued.
                 self.ignore_input_this_frame = false;
                 self.queued_key_events.clear();

--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -58,13 +58,14 @@ impl KeyboardManager {
             } => {
                 // Record the modifer states so that we can properly add them to the keybinding
                 // text
-                if !self.ignore_input_this_frame {
-                    self.shift = modifiers.shift_key();
-                    self.ctrl = modifiers.control_key();
-                    self.alt = modifiers.alt_key();
-                    self.logo = modifiers.super_key();
+                if self.ignore_input_this_frame {
+                    return;
                 }
 
+                self.shift = modifiers.shift_key();
+                self.ctrl = modifiers.control_key();
+                self.alt = modifiers.alt_key();
+                self.logo = modifiers.super_key();
             }
             Event::MainEventsCleared => {
                 // And the window wasn't just focused.


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

## Purpose

This ~~fixes~~ describes an issue where Neovide held the logo/super/meta key in pressed state after a window focus change, even though the key was not pressed anymore. Therefor Neovide either ignores all further key presses when `neovide_input_use_logo=false` or registers all keys as `<D-*>` keys (with logo modifier) when `neovide_input_use_logo=true`.

## Environment
I experienced the issue on Arch Linux, Gnome/X11, Neovide 5047637.
Gnome uses the logo key when pressed and released without any further keys to show a dashboard with all windows.
I am using the logo key in combination with other keys to change window arrangements, e.g. logo+f to fullscreen a window.

## Steps to reproduce
- Open Neovide
- Ensure it is focused
- Press and hold the logo key 
  - Neovide will receive a modifier change event and in turn set the logo state [here](https://github.com/neovide/neovide/blob/main/src/window/window_wrapper/keyboard_manager.rs#L64)
  - Neovide will receive another modifier change event and in turn set the logo state to false again
  - Neovide will receive a focus lost event
- Press and release the f key
  - Neovide will resize
 - Release the logo key
   - Neovide will receive a gain focus event
   - Neovide will receive another modifier change event and in turn 🔥  set the logo state to true again 🔥 

This leaves Neovide in a wrong state where it either ignores further key presses when `neovide_input_use_logo=false` ([doc](https://github.com/neovide/neovide/wiki/Configuration#use-logo-key)) or registers all keys as `<D-*>` keys ([with logo modifier](https://github.com/neovide/neovide/commit/726539fbae34b693949d2fa08a6dba786a65a8b9)) when `neovide_input_use_logo=true`.

## ~~The fix~~
~~The code already had a mechanism to ignore non modifier key presses if the current frame also had a focus change event. This behavior was introduced [here](https://github.com/neovide/neovide/commit/fec2711b90b49ad3acaeeccf4c41746e01cf7fc7) and [here](https://github.com/neovide/neovide/commit/0d6cfd54cbe945e1693c9be576ddb26ee96e2d36). This fix uses this very mechanism to also ignore modifier change events under the same conditions.~~

## Related
~~Maybe this also fixes the issue @adsick described [here](https://github.com/neovide/neovide/issues/545#issuecomment-901382568).~~