### PR TITLE
fix: Fixed red color for underline

### DIFF
--- a/src/editor/style.rs
+++ b/src/editor/style.rs
@@ -54,7 +54,7 @@ impl Style {
     pub fn special(&self, default_colors: &Colors) -> Color4f {
         self.colors
             .special
-            .unwrap_or_else(|| default_colors.special.unwrap())
+            .unwrap_or_else(|| self.foreground(default_colors))
     }
 }
 


### PR DESCRIPTION
@Kethku i remember we talked about this, and that time we decided not to fix this, as red default color was provided by neovim.

But, i think that was incorrect decision. We're having access to all required data to make decision about underline color:

- fg color
- special color
- defaults (provided by neovim)

And when selecting special - if current area has explicit guisp - we're using it. If not - we fall back to fg color (becouse this gives better user expirience than using red from neovim, as neovim provides `generic defauls`, not specific for this area).

Closing #300

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
