### PR TITLE
Add modifiers to mouse events and ensure correct mouse button is reported

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -30,6 +30,7 @@ pub enum UiCommand {
         direction: String,
         grid_id: u64,
         position: (u32, u32),
+        modifier_string: String,
     },
     Drag {
         grid_id: u64,
@@ -79,11 +80,12 @@ impl UiCommand {
                 direction,
                 grid_id,
                 position: (grid_x, grid_y),
+                modifier_string,
             } => {
                 nvim.input_mouse(
                     "wheel",
                     &direction,
-                    "",
+                    &modifier_string,
                     grid_id as i64,
                     grid_y as i64,
                     grid_x as i64,

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -25,6 +25,7 @@ pub enum UiCommand {
         action: String,
         grid_id: u64,
         position: (u32, u32),
+        modifier_string: String,
     },
     Scroll {
         direction: String,
@@ -33,8 +34,10 @@ pub enum UiCommand {
         modifier_string: String,
     },
     Drag {
+        button: String,
         grid_id: u64,
         position: (u32, u32),
+        modifier_string: String,
     },
     FileDrop(String),
     FocusLost,
@@ -64,11 +67,12 @@ impl UiCommand {
                 action,
                 grid_id,
                 position: (grid_x, grid_y),
+                modifier_string,
             } => {
                 nvim.input_mouse(
                     &button,
                     &action,
-                    "",
+                    &modifier_string,
                     grid_id as i64,
                     grid_y as i64,
                     grid_x as i64,
@@ -94,13 +98,15 @@ impl UiCommand {
                 .expect("Mouse Scroll Failed");
             }
             UiCommand::Drag {
+                button,
                 grid_id,
                 position: (grid_x, grid_y),
+                modifier_string,
             } => {
                 nvim.input_mouse(
-                    "left",
+                    &button,
                     "drag",
-                    "",
+                    &modifier_string,
                     grid_id as i64,
                     grid_y as i64,
                     grid_x as i64,

--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -129,13 +129,19 @@ impl KeyboardManager {
         let special = special || self.ctrl || use_alt(self.alt) || self.logo;
 
         let open = or_empty(special, "<");
+        let modifiers = self.format_modifier_string(use_shift);
+        let close = or_empty(special, ">");
+
+        open.to_owned() + &modifiers + text + close
+    }
+
+    pub fn format_modifier_string(&self, use_shift: bool) -> String {
         let shift = or_empty(self.shift && use_shift, "S-");
         let ctrl = or_empty(self.ctrl, "C-");
         let alt = or_empty(use_alt(self.alt), "M-");
         let logo = or_empty(self.logo, "D-");
-        let close = or_empty(special, ">");
 
-        format!("{}{}{}{}{}{}{}", open, shift, ctrl, alt, logo, text, close)
+        shift.to_owned() + ctrl + alt + logo
     }
 }
 

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -121,7 +121,11 @@ impl GlutinWindowWrapper {
     pub fn handle_event(&mut self, event: Event<()>, running: &Arc<AtomicBool>) {
         self.keyboard_manager.handle_event(&event);
         self.mouse_manager.handle_event(
-            &event, &self.keyboard_manager, &self.renderer, &self.windowed_context);
+            &event,
+            &self.keyboard_manager,
+            &self.renderer,
+            &self.windowed_context,
+        );
         match event {
             Event::LoopDestroyed => {
                 self.handle_quit(running);

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -120,8 +120,8 @@ impl GlutinWindowWrapper {
 
     pub fn handle_event(&mut self, event: Event<()>, running: &Arc<AtomicBool>) {
         self.keyboard_manager.handle_event(&event);
-        self.mouse_manager
-            .handle_event(&event, &self.renderer, &self.windowed_context);
+        self.mouse_manager.handle_event(
+            &event, &self.keyboard_manager, &self.renderer, &self.windowed_context);
         match event {
             Event::LoopDestroyed => {
                 self.handle_quit(running);

--- a/src/window/window_wrapper/mouse_manager.rs
+++ b/src/window/window_wrapper/mouse_manager.rs
@@ -8,10 +8,10 @@ use glutin::{
 };
 use skia_safe::Rect;
 
+use super::keyboard_manager::KeyboardManager;
 use crate::bridge::UiCommand;
 use crate::channel_utils::LoggingTx;
 use crate::renderer::{Renderer, WindowDrawDetails};
-use super::keyboard_manager::KeyboardManager;
 
 fn clamp_position(
     position: PhysicalPosition<f32>,
@@ -178,7 +178,12 @@ impl MouseManager {
         }
     }
 
-    fn handle_pointer_transition(&mut self, mouse_button: &MouseButton, down: bool, keyboard_manager: &KeyboardManager) {
+    fn handle_pointer_transition(
+        &mut self,
+        mouse_button: &MouseButton,
+        down: bool,
+        keyboard_manager: &KeyboardManager,
+    ) {
         // For some reason pointer down is handled differently from pointer up and drag.
         // Floating windows: relative coordinates are great.
         // Non floating windows: rather than global coordinates, relative are needed
@@ -210,7 +215,7 @@ impl MouseManager {
 
                 self.dragging = Some(button_text);
 
-                if !self.dragging.is_some() {
+                if self.dragging.is_none() {
                     self.has_moved = false;
                 }
             }
@@ -282,9 +287,10 @@ impl MouseManager {
         keyboard_manager: &KeyboardManager,
     ) {
         self.handle_line_scroll(
-            pixel_x / font_width as f32, 
-            pixel_y / font_height as f32, 
-            keyboard_manager);
+            pixel_x / font_width as f32,
+            pixel_y / font_height as f32,
+            keyboard_manager,
+        );
     }
 
     pub fn handle_event(
@@ -329,9 +335,10 @@ impl MouseManager {
                 event: WindowEvent::MouseInput { button, state, .. },
                 ..
             } => self.handle_pointer_transition(
-                button, 
-                state == &ElementState::Pressed, 
-                keyboard_manager),
+                button,
+                state == &ElementState::Pressed,
+                keyboard_manager,
+            ),
             _ => {}
         }
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->
Reports keyboard modifiers correctly for mouse events rather than ignoring them.
Also changes mouse input to report the correct mouse button rather than always left.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
