### PR TITLE
Prevent horizontal text clipping

### DIFF
--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -220,7 +220,6 @@ impl Window {
         (start + width, line_fragment)
     }
 
-
     // Redraw line by calling build_line_fragment starting at 0
     // until current_start is greater than the grid width and sending the resulting
     // fragments as a batch

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -371,9 +371,7 @@ impl CursorRenderer {
             canvas.clip_path(&path, None, Some(false));
 
             let y_adjustment = grid_renderer.shaper.y_adjustment();
-            let blobs = &grid_renderer
-                .shaper
-                .shape_cached(character, false, false);
+            let blobs = &grid_renderer.shaper.shape_cached(character, false, false);
 
             for blob in blobs.iter() {
                 canvas.draw_text_blob(

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -373,7 +373,7 @@ impl CursorRenderer {
             let y_adjustment = grid_renderer.shaper.y_adjustment();
             let blobs = &grid_renderer
                 .shaper
-                .shape_cached(&[character], false, false);
+                .shape_cached(character, false, false);
 
             for blob in blobs.iter() {
                 canvas.draw_text_blob(

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -14,7 +14,7 @@ use super::font_options::*;
 
 #[derive(new, Clone, Hash, PartialEq, Eq, Debug)]
 struct ShapeKey {
-    pub cells: Vec<String>,
+    pub text: String,
     pub bold: bool,
     pub italic: bool,
 }
@@ -229,13 +229,12 @@ impl CachingShaper {
         grouped_results
     }
 
-    pub fn shape(&mut self, cells: &[String], bold: bool, italic: bool) -> Vec<TextBlob> {
+    pub fn shape(&mut self, text: String, bold: bool, italic: bool) -> Vec<TextBlob> {
         let current_size = self.current_size();
         let (glyph_width, ..) = self.font_base_dimensions();
 
         let mut resulting_blobs = Vec::new();
 
-        let text = cells.concat();
         trace!("Shaping text: {}", text);
 
         for (cluster_group, font_pair) in self.build_clusters(&text, bold, italic) {
@@ -279,11 +278,11 @@ impl CachingShaper {
         resulting_blobs
     }
 
-    pub fn shape_cached(&mut self, cells: &[String], bold: bool, italic: bool) -> &Vec<TextBlob> {
-        let key = ShapeKey::new(cells.to_vec(), bold, italic);
+    pub fn shape_cached(&mut self, text: String, bold: bool, italic: bool) -> &Vec<TextBlob> {
+        let key = ShapeKey::new(text.clone(), bold, italic);
 
         if !self.blob_cache.contains(&key) {
-            let blobs = self.shape(cells, bold, italic);
+            let blobs = self.shape(text, bold, italic);
             self.blob_cache.put(key.clone(), blobs);
         }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -115,7 +115,11 @@ impl GridRenderer {
 
         canvas.save();
 
-        let region = self.compute_text_region(grid_position, cell_width);
+        // We don't want to clip text in the x position, only the y so we add a buffer of 1
+        // character on either side of the region so that we clip vertically but not horizontally
+        let (grid_x, grid_y) = grid_position;
+        let clip_position = (grid_x.checked_sub(1).unwrap_or(0), grid_y);
+        let region = self.compute_text_region(clip_position, cell_width + 2);
 
         canvas.clip_rect(region, None, Some(false));
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -103,7 +103,7 @@ impl GridRenderer {
     pub fn draw_foreground(
         &mut self,
         canvas: &mut Canvas,
-        cells: &[String],
+        text: String,
         grid_position: (u64, u64),
         cell_width: u64,
         style: &Option<Arc<Style>>,
@@ -163,7 +163,7 @@ impl GridRenderer {
 
         for blob in self
             .shaper
-            .shape_cached(cells, style.bold, style.italic)
+            .shape_cached(text, style.bold, style.italic)
             .iter()
         {
             canvas.draw_text_blob(blob, (x as f32, (y + y_adjustment) as f32), &self.paint);

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -118,7 +118,7 @@ impl GridRenderer {
         // We don't want to clip text in the x position, only the y so we add a buffer of 1
         // character on either side of the region so that we clip vertically but not horizontally
         let (grid_x, grid_y) = grid_position;
-        let clip_position = (grid_x.checked_sub(1).unwrap_or(0), grid_y);
+        let clip_position = (grid_x.saturating_sub(1), grid_y);
         let region = self.compute_text_region(clip_position, cell_width + 2);
 
         canvas.clip_rect(region, None, Some(false));

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -9,7 +9,7 @@ use skia_safe::{
 
 use super::animation_utils::*;
 use super::{GridRenderer, RendererSettings};
-use crate::editor::{WindowDrawCommand, LineFragment};
+use crate::editor::{LineFragment, WindowDrawCommand};
 use crate::redraw_scheduler::REDRAW_SCHEDULER;
 use crate::utils::Dimensions;
 
@@ -348,7 +348,7 @@ impl RenderedWindow {
                         ..
                     } = line_fragment;
                     let grid_position = (*window_left, *window_top);
-                    grid_renderer.draw_background(canvas, grid_position, *width, &style);
+                    grid_renderer.draw_background(canvas, grid_position, *width, style);
                 }
 
                 for line_fragment in line_fragments.into_iter() {
@@ -357,7 +357,7 @@ impl RenderedWindow {
                         window_left,
                         window_top,
                         width,
-                        style
+                        style,
                     } = line_fragment;
                     let grid_position = (window_left, window_top);
                     grid_renderer.draw_foreground(canvas, text, grid_position, width, &style);


### PR DESCRIPTION
Now that the renderer just draws the entire line at once, I was able to clean up the draw commands a bit to send the whole line at once rather than sending the text fragment by fragment. This in turn lets me draw the background and then the text on top of the background and relax the foreground clipping to no longer clip character by character. I believe this should make emojis render better among other things.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
