### PR TITLE
Fix transparency

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -100,8 +100,9 @@ impl GridRenderer {
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
 
-        let transparency = {SETTINGS.get::<WindowSettings>().transparency};
-        self.paint.set_alpha_f(transparency);
+        if self.paint.color() == Color::BLACK {
+            self.paint.set_alpha(0);
+        }
         canvas.draw_rect(region, &self.paint);
     }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -103,7 +103,7 @@ impl GridRenderer {
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
 
-        if self.paint.color() == Color::BLACK {
+        if self.paint.color() == self.get_default_background().with_a(255) {
             self.paint.set_alpha(0);
         }
         canvas.draw_rect(region, &self.paint);

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -75,7 +75,10 @@ impl GridRenderer {
     }
 
     pub fn get_default_background(&self) -> Color {
-        let transparency = {SETTINGS.get::<WindowSettings>().transparency};
+        let mut transparency = {SETTINGS.get::<WindowSettings>().transparency};
+        if transparency < 1.0 {
+            transparency = 0.0;
+        }
         self.default_style.colors.background.unwrap().to_color().with_a((255.0 * transparency) as u8)
     }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -1,4 +1,3 @@
-use crate::WindowSettings;
 use std::sync::Arc;
 
 use glutin::dpi::PhysicalSize;
@@ -75,16 +74,7 @@ impl GridRenderer {
     }
 
     pub fn get_default_background(&self) -> Color {
-        let mut transparency = { SETTINGS.get::<WindowSettings>().transparency };
-        if transparency < 1.0 {
-            transparency = 0.0;
-        }
-        self.default_style
-            .colors
-            .background
-            .unwrap()
-            .to_color()
-            .with_a((255.0 * transparency) as u8)
+        self.default_style.colors.background.unwrap().to_color()
     }
 
     pub fn draw_background(
@@ -108,7 +98,7 @@ impl GridRenderer {
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
 
-        if self.paint.color() == self.get_default_background().with_a(255) {
+        if self.paint.color() == self.get_default_background() {
             self.paint.set_alpha(0);
         }
         canvas.draw_rect(region, &self.paint);

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -1,3 +1,4 @@
+use crate::WindowSettings;
 use std::sync::Arc;
 
 use glutin::dpi::PhysicalSize;
@@ -74,7 +75,8 @@ impl GridRenderer {
     }
 
     pub fn get_default_background(&self) -> Color {
-        self.default_style.colors.background.unwrap().to_color()
+        let transparency = {SETTINGS.get::<WindowSettings>().transparency};
+        self.default_style.colors.background.unwrap().to_color().with_a((255.0 * transparency) as u8)
     }
 
     pub fn draw_background(
@@ -97,6 +99,9 @@ impl GridRenderer {
             self.paint
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
+
+        let transparency = {SETTINGS.get::<WindowSettings>().transparency};
+        self.paint.set_alpha_f(transparency);
         canvas.draw_rect(region, &self.paint);
     }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -75,11 +75,16 @@ impl GridRenderer {
     }
 
     pub fn get_default_background(&self) -> Color {
-        let mut transparency = {SETTINGS.get::<WindowSettings>().transparency};
+        let mut transparency = { SETTINGS.get::<WindowSettings>().transparency };
         if transparency < 1.0 {
             transparency = 0.0;
         }
-        self.default_style.colors.background.unwrap().to_color().with_a((255.0 * transparency) as u8)
+        self.default_style
+            .colors
+            .background
+            .unwrap()
+            .to_color()
+            .with_a((255.0 * transparency) as u8)
     }
 
     pub fn draw_background(

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -83,6 +83,7 @@ impl GridRenderer {
         grid_position: (u64, u64),
         cell_width: u64,
         style: &Option<Arc<Style>>,
+        is_floating: bool,
     ) {
         self.paint.set_blend_mode(BlendMode::Src);
 
@@ -99,7 +100,12 @@ impl GridRenderer {
         }
 
         if self.paint.color() == self.get_default_background() {
-            self.paint.set_alpha(0);
+            if is_floating {
+                self.paint
+                    .set_alpha((255.0 * SETTINGS.get::<RendererSettings>().floating_opacity) as u8);
+            } else {
+                self.paint.set_alpha(0);
+            }
         }
         canvas.draw_rect(region, &self.paint);
     }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -137,7 +137,7 @@ impl Renderer {
                 window.draw(
                     root_canvas,
                     &settings,
-                    default_background,
+                    default_background.with_a((255.0 * transparency) as u8),
                     font_dimensions,
                     dt,
                 )

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -5,6 +5,7 @@ pub mod grid_renderer;
 mod rendered_window;
 
 use crate::WindowSettings;
+use std::cmp::Ordering;
 use std::collections::{hash_map::Entry, HashMap};
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;
@@ -98,7 +99,7 @@ impl Renderer {
         let default_background = self.grid_renderer.get_default_background();
         let font_dimensions = self.grid_renderer.font_dimensions;
 
-        let transparency = {SETTINGS.get::<WindowSettings>().transparency};
+        let transparency = { SETTINGS.get::<WindowSettings>().transparency };
         root_canvas.clear(default_background.with_a((255.0 * transparency) as u8));
         root_canvas.save();
         root_canvas.reset_matrix();
@@ -120,13 +121,8 @@ impl Renderer {
 
             root_windows
                 .sort_by(|window_a, window_b| window_a.id.partial_cmp(&window_b.id).unwrap());
-            floating_windows.sort_by(|window_a, window_b| {
-                window_a
-                    .floating_order
-                    .unwrap()
-                    .partial_cmp(&window_b.floating_order.unwrap())
-                    .unwrap()
-            });
+
+            floating_windows.sort_by(floating_sort);
 
             root_windows
                 .into_iter()
@@ -211,4 +207,31 @@ impl Renderer {
             _ => {}
         }
     }
+}
+
+/// Defines how floating windows are sorted.
+fn floating_sort(window_a: &&mut RenderedWindow, window_b: &&mut RenderedWindow) -> Ordering {
+    // First, compare floating order
+    let mut ord = window_a
+        .floating_order
+        .unwrap()
+        .partial_cmp(&window_b.floating_order.unwrap())
+        .unwrap();
+    if ord == Ordering::Equal {
+        // If equal, compare grid pos x
+        ord = window_a
+            .grid_current_position
+            .x
+            .partial_cmp(&window_b.grid_current_position.x)
+            .unwrap();
+        if ord == Ordering::Equal {
+            // If equal, compare grid pos z
+            ord = window_a
+                .grid_current_position
+                .y
+                .partial_cmp(&window_b.grid_current_position.y)
+                .unwrap();
+        }
+    }
+    ord
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -87,6 +87,9 @@ impl Renderer {
             .collect();
         let mut font_changed = false;
 
+        let default_background = self.grid_renderer.get_default_background();
+        root_canvas.clear(default_background);
+
         for draw_command in draw_commands.into_iter() {
             if let DrawCommand::FontChanged(_) = draw_command {
                 font_changed = true;
@@ -94,10 +97,8 @@ impl Renderer {
             self.handle_draw_command(root_canvas, draw_command);
         }
 
-        let default_background = self.grid_renderer.get_default_background();
         let font_dimensions = self.grid_renderer.font_dimensions;
 
-        root_canvas.clear(default_background);
         root_canvas.save();
         root_canvas.reset_matrix();
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,6 +4,7 @@ mod fonts;
 pub mod grid_renderer;
 mod rendered_window;
 
+use crate::WindowSettings;
 use std::collections::{hash_map::Entry, HashMap};
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;
@@ -97,7 +98,8 @@ impl Renderer {
         let default_background = self.grid_renderer.get_default_background();
         let font_dimensions = self.grid_renderer.font_dimensions;
 
-        root_canvas.clear(default_background);
+        let transparency = {SETTINGS.get::<WindowSettings>().transparency};
+        root_canvas.clear(default_background.with_a((255.0 * transparency) as u8));
         root_canvas.save();
         root_canvas.reset_matrix();
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -87,9 +87,6 @@ impl Renderer {
             .collect();
         let mut font_changed = false;
 
-        let default_background = self.grid_renderer.get_default_background();
-        root_canvas.clear(default_background);
-
         for draw_command in draw_commands.into_iter() {
             if let DrawCommand::FontChanged(_) = draw_command {
                 font_changed = true;
@@ -97,8 +94,10 @@ impl Renderer {
             self.handle_draw_command(root_canvas, draw_command);
         }
 
+        let default_background = self.grid_renderer.get_default_background();
         let font_dimensions = self.grid_renderer.font_dimensions;
 
+        root_canvas.clear(default_background);
         root_canvas.save();
         root_canvas.reset_matrix();
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -291,6 +291,8 @@ impl RenderedWindow {
                 grid_size,
                 floating_order,
             } => {
+                let grid_left = grid_left.max(0.0);
+                let grid_top = grid_top.max(0.0);
                 let new_destination: Point = (grid_left as f32, grid_top as f32).into();
                 let new_grid_size: Dimensions = grid_size.into();
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -213,6 +213,10 @@ impl RenderedWindow {
         root_canvas.save();
         root_canvas.clip_rect(&pixel_region, None, Some(false));
 
+        if self.floating_order.is_none() {
+            root_canvas.clear(default_background);
+        }
+
         if self.floating_order.is_some() && settings.floating_blur {
             let blur = blur((2.0, 2.0), None, None, None).unwrap();
             let save_layer_rec = SaveLayerRec::default()

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -354,7 +354,13 @@ impl RenderedWindow {
                         ..
                     } = line_fragment;
                     let grid_position = (*window_left, *window_top);
-                    grid_renderer.draw_background(canvas, grid_position, *width, style);
+                    grid_renderer.draw_background(
+                        canvas,
+                        grid_position,
+                        *width,
+                        style,
+                        self.floating_order.is_some(),
+                    );
                 }
 
                 for line_fragment in line_fragments.into_iter() {

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -238,7 +238,7 @@ impl RenderedWindow {
         paint.set_color(default_background.with_a(a));
         root_canvas.draw_rect(pixel_region, &paint);
 
-        paint.set_color(Color::from_argb(a, 255, 255, 255));
+        paint.set_color(Color::from_argb(255, 255, 255, 255));
 
         let font_height = font_dimensions.height;
 

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -54,6 +54,7 @@ pub struct GlutinWindowWrapper {
     mouse_manager: MouseManager,
     title: String,
     fullscreen: bool,
+    transparency: f32,
     saved_inner_size: PhysicalSize<u32>,
     saved_grid_size: Option<Dimensions>,
     ui_command_sender: LoggingTx<UiCommand>,
@@ -79,6 +80,13 @@ impl GlutinWindowWrapper {
         if self.fullscreen != fullscreen {
             self.toggle_fullscreen();
         }
+
+        let transparency = { SETTINGS.get::<WindowSettings>().transparency };
+        if self.transparency != transparency {
+            self.transparency = transparency;
+            self.toggle_fullscreen();
+        }
+
     }
 
     #[allow(clippy::needless_collect)]
@@ -261,6 +269,7 @@ pub fn create_window(
         .with_title("Neovide")
         .with_window_icon(Some(icon))
         .with_maximized(cmd_line_settings.maximized)
+        .with_transparent(true)
         .with_decorations(!cmd_line_settings.frameless);
 
     #[cfg(target_os = "linux")]
@@ -303,6 +312,7 @@ pub fn create_window(
         mouse_manager: MouseManager::new(ui_command_sender.clone()),
         title: String::from("Neovide"),
         fullscreen: false,
+        transparency: 1.0,
         saved_inner_size,
         saved_grid_size: None,
         ui_command_sender,

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -54,7 +54,6 @@ pub struct GlutinWindowWrapper {
     mouse_manager: MouseManager,
     title: String,
     fullscreen: bool,
-    transparency: f32,
     saved_inner_size: PhysicalSize<u32>,
     saved_grid_size: Option<Dimensions>,
     ui_command_sender: LoggingTx<UiCommand>,
@@ -80,12 +79,6 @@ impl GlutinWindowWrapper {
         if self.fullscreen != fullscreen {
             self.toggle_fullscreen();
         }
-
-        let transparency = { SETTINGS.get::<WindowSettings>().transparency };
-        if self.transparency != transparency {
-            //TODO: HERE REDRAW WINDOW
-        }
-
     }
 
     #[allow(clippy::needless_collect)]
@@ -311,7 +304,6 @@ pub fn create_window(
         mouse_manager: MouseManager::new(ui_command_sender.clone()),
         title: String::from("Neovide"),
         fullscreen: false,
-        transparency: 1.0,
         saved_inner_size,
         saved_grid_size: None,
         ui_command_sender,

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -83,8 +83,7 @@ impl GlutinWindowWrapper {
 
         let transparency = { SETTINGS.get::<WindowSettings>().transparency };
         if self.transparency != transparency {
-            self.transparency = transparency;
-            self.toggle_fullscreen();
+            //TODO: HERE REDRAW WINDOW
         }
 
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

# Description
Transparency is broken (I think since c76945? Not sure tho). This PR tries to fix that.
There are still some issues and I could use some help. 

Mainly:
- Transparency not fully updating after changing `g:neovide_transparency` (it refreshes after toggling fullscreen for example).
I tried doing a redraw or something, but unsuccessfully.
- Some backgrounds maybe shouldn't be transparent? Maybe making only `Normal guibg` transparent would look better? Or just make only black color transparent? (that's what my terminal emulator does afaik, and it looks good)
- What exactly should be semi-transparent? You could make window canvas fully transparent and make line background semi-transparent, but then parts inside window but outside nvim canvas are fully transparent. But if you make window canvas semi-transparent then it stacks with line opacity making it darker than it should be.

(I don't have experience with rust or this codebase, so maybe there is something I missed)
