### PR TITLE
Fix for Windows artifact doublezip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,15 +48,10 @@ jobs:
         run: |
           cargo build --release
 
-      - name: Archive Windows artifact
-        run: |
-          powershell rm ./target/release/neovide.zip
-          powershell Compress-Archive ./target/release/neovide.exe ./target/release/neovide.zip
-
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: neovide-windows.zip
-          path: ./target/release/neovide.zip
+          path: ./target/release/neovide.exe
 
   build-mac:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: neovide-windows.zip
+          name: neovide-windows
           path: ./target/release/neovide.exe
 
   build-mac:


### PR DESCRIPTION


<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- fix for #946 


Following are my findings regarding this issue

Many projects facing this same issue. But it seems this the intended behavior. 
On download, a zip is dynamically created with all the file contents that were uploaded, which is explained here in upload-artifact repo [readme](https://github.com/actions/upload-artifact#zipped-artifact-downloads).

Workaround:
- Instead of zipping and uploading, now we directly upload the executable which resolves the issue.

REF : [upload-artifact double-zips a zip](https://github.com/actions/upload-artifact/issues/39)