### PR TITLE
Remote copy/paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
+dependencies = [
+ "clipboard-win",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "x11-clipboard",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1339,7 @@ dependencies = [
  "async-trait",
  "cfg-if 0.1.10",
  "clap",
+ "clipboard",
  "derive-new",
  "dirs 2.0.2",
  "euclid",
@@ -1501,6 +1524,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -2639,6 +2682,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-clipboard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
+dependencies = [
+ "xcb",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,6 +2708,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xcb"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ gl = "0.14.0"
 swash = "0.1.4"
 clap="2.33.3"
 xdg="2.4.0"
+clipboard="0.5.0"
 
 [dev-dependencies]
 mockall = "0.7.0"

--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -5,19 +5,30 @@ use rmpv::Value;
 use clipboard::ClipboardContext;
 use clipboard::ClipboardProvider;
 
-pub fn get_remote_clipboard() -> Result<Value, Box<dyn Error>> {
+pub fn get_remote_clipboard(format: Option<&str>) -> Result<Value, Box<dyn Error>> {
     let mut ctx: ClipboardContext = ClipboardProvider::new()?;
-    let lines = ctx
-        .get_contents()?
-        .replace("\r", "")
+    let clipboard_raw = ctx.get_contents()?.replace("\r", "");
+
+    let lines = if let Some("dos") = format {
+        // add \r to lines of current file format is dos
+        clipboard_raw.replace("\n", "\r\n")
+    } else {
+        // else, \r is stripped, leaving only \n
+        clipboard_raw
+    }
         .split("\n")
         .map(|line| Value::from(line))
         .collect::<Vec<Value>>();
 
-    // returns a [[String], RegType]
+    let lines = Value::from(lines);
+    // v paste is normal paste (everything in lines is pasted)
+    // V paste is paste with extra endline (line paste)
+    // If you want V paste, copy text with extra endline
+    let paste_mode = Value::from("v");
+
+    // returns [content: [String], paste_mode: v or V]
     Ok(Value::from(vec![
-        Value::from(lines),
-        Value::from("v"), // default to normal paste
+        lines, paste_mode,
     ]))
 }
 
@@ -25,20 +36,23 @@ pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<(), Box<dyn Error>>
     if arguments.len() != 3 {
         return Err("expected exactly 3 arguments to set_remote_clipboard".into());
     }
+
+    #[cfg(not(windows))]
+    let endline = "\n";
+    #[cfg(windows)]
+    let endline = "\r\n";
+
     let lines = arguments[0]
         .as_array()
         .map(|arr| {
             arr.iter()
                 .filter_map(|x| x.as_str().map(String::from))
+                .map(|s| s.replace("\r", "")) // strip \r
                 .collect::<Vec<String>>()
-                .join("\n")
+                .join(endline)
         })
-        .ok_or("can't build string from clipboard")?;
+        .ok_or("can't build string from provided text")?;
 
-    let register = arguments[2].as_str();
-    if register != Some("+") {
-        return Err("incompatible register to set remote clipboard".into());
-    }
     let mut ctx: ClipboardContext = ClipboardProvider::new()?;
     ctx.set_contents(lines)
 }

--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -1,0 +1,44 @@
+use std::error::Error;
+
+use rmpv::Value;
+
+use clipboard::ClipboardContext;
+use clipboard::ClipboardProvider;
+
+pub fn get_remote_clipboard() -> Result<Value, Box<dyn Error>> {
+    let mut ctx: ClipboardContext = ClipboardProvider::new()?;
+    let lines = ctx
+        .get_contents()?
+        .replace("\r", "")
+        .split("\n")
+        .map(|line| Value::from(line))
+        .collect::<Vec<Value>>();
+
+    // returns a [[String], RegType]
+    Ok(Value::from(vec![
+        Value::from(lines),
+        Value::from("v"), // default to normal paste
+    ]))
+}
+
+pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<(), Box<dyn Error>> {
+    if arguments.len() != 3 {
+        return Err("expected exactly 3 arguments to set_remote_clipboard".into());
+    }
+    let lines = arguments[0]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect::<Vec<String>>()
+                .join("\n")
+        })
+        .ok_or("can't build string from clipboard")?;
+
+    let register = arguments[2].as_str();
+    if register != Some("+") {
+        return Err("incompatible register to set remote clipboard".into());
+    }
+    let mut ctx: ClipboardContext = ClipboardProvider::new()?;
+    ctx.set_contents(lines)
+}

--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -16,9 +16,9 @@ pub fn get_remote_clipboard(format: Option<&str>) -> Result<Value, Box<dyn Error
         // else, \r is stripped, leaving only \n
         clipboard_raw
     }
-        .split("\n")
-        .map(|line| Value::from(line))
-        .collect::<Vec<Value>>();
+    .split("\n")
+    .map(|line| Value::from(line))
+    .collect::<Vec<Value>>();
 
     let lines = Value::from(lines);
     // v paste is normal paste (everything in lines is pasted)
@@ -27,9 +27,7 @@ pub fn get_remote_clipboard(format: Option<&str>) -> Result<Value, Box<dyn Error
     let paste_mode = Value::from("v");
 
     // returns [content: [String], paste_mode: v or V]
-    Ok(Value::from(vec![
-        lines, paste_mode,
-    ]))
+    Ok(Value::from(vec![lines, paste_mode]))
 }
 
 pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<(), Box<dyn Error>> {

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -30,6 +30,19 @@ impl NeovimHandler {
 impl Handler for NeovimHandler {
     type Writer = TxWrapper;
 
+    async fn handle_request(
+        &self,
+        event_name: String,
+        arguments: Vec<Value>,
+        _neovim: Neovim<TxWrapper>,
+    ) -> Result<Value, Value> {
+        match event_name.as_ref() {
+            _ => {
+                Ok(Value::from("rpcrequest not handled"))
+            }
+        }
+    }
+
     async fn handle_notify(
         &self,
         event_name: String,

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -38,8 +38,10 @@ impl Handler for NeovimHandler {
 
         match event_name.as_ref() {
             "neovide.get_clipboard" => {
-                let endline_type = neovim.command_output("set ff")
-                    .await.ok()
+                let endline_type = neovim
+                    .command_output("set ff")
+                    .await
+                    .ok()
                     .and_then(|format| {
                         let mut s = format.split('=');
                         s.next();

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -37,6 +37,21 @@ impl Handler for NeovimHandler {
         _neovim: Neovim<TxWrapper>,
     ) -> Result<Value, Value> {
         match event_name.as_ref() {
+            "neovide.get_clipboard" => {
+                let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
+                let lines = ctx
+                    .get_contents()
+                    .unwrap()
+                    .replace("\r", "")
+                    .split("\n")
+                    .map(|line| Value::from(line))
+                    .collect::<Vec<Value>>();
+                // returns a [[String], RegType]
+                Ok(Value::from(vec![
+                    Value::from(lines),
+                    Value::from("V") // default regtype as Line paste
+                ]))
+            }
             _ => {
                 Ok(Value::from("rpcrequest not handled"))
             }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -18,7 +18,10 @@ use crate::{
 
 pub use events::*;
 use handler::NeovimHandler;
-use setup::setup_neovide_specific_state;
+use setup::{
+    setup_neovide_specific_state,
+    setup_neovide_remote_clipboard
+};
 pub use tx_wrapper::{TxWrapper, WrapTx};
 pub use ui_commands::{start_ui_command_handler, ParallelCommand, SerialCommand, UiCommand};
 
@@ -59,7 +62,11 @@ async fn start_neovim_runtime() {
         }
     }
 
-    setup_neovide_specific_state(&nvim).await;
+    if let ConnectionMode::RemoteTcp(_) = connection_mode() {
+        setup_neovide_specific_state(&nvim, true).await;
+    } else {
+        setup_neovide_specific_state(&nvim, false).await;
+    }
 
     let settings = SETTINGS.get::<CmdLineSettings>();
     let geometry = settings.geometry;

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -1,3 +1,4 @@
+mod clipboard;
 pub mod create;
 mod events;
 mod handler;

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -19,10 +19,7 @@ use crate::{
 
 pub use events::*;
 use handler::NeovimHandler;
-use setup::{
-    setup_neovide_specific_state,
-    setup_neovide_remote_clipboard
-};
+use setup::setup_neovide_specific_state;
 pub use tx_wrapper::{TxWrapper, WrapTx};
 pub use ui_commands::{start_ui_command_handler, ParallelCommand, SerialCommand, UiCommand};
 


### PR DESCRIPTION
Closes #914 

- [x] Setup rpcrequest
- [x] Set `g:clipboard` when remote
- [x] Copy handler `+` register
- [x] Paste handler `+` register
- [x] Copy handler `*` register
- [x] Paste handler `*` register
- [ ] Toggle command
- [x] Variable to override on init

I decided to hook the `*` register to same remote clipboard (A quick solution). A variable `g:neovide_no_custom_clipboard` is introduced and disable custom clipboard hook.

Tests to be done:
- [x] Remote headless
- [ ] WSL

Though it should work with WSL, but I don't have WSL configured. SSH instances, and `same host, same client` are tested.

Edge cases:
- [x] Empty clipboard
- [x] Clipboard is not text (picture)
- [ ] Copy race condition (hardly, but should handle) (1)

Empty clipboard and clipboard not text will returns Error, and neovim outputs `Nothing in register +`.

Haven't done anything related to race condition, I assume it has problem, however never checked. Current PR is suffice.

Note:
1. Because copy issue `rpcnotify`, we need to move into Parallel/Serial command to handle race condition. Race only when record/replay or manually copy many times in a small time frame. Paste don't have this problem, since paste is `rpcrequest`, which neovim waits until the request returns.