### PR TITLE
[windows] Right click menu setup with no Admin

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -143,7 +143,8 @@ impl ParallelCommand {
             #[cfg(windows)]
             ParallelCommand::RegisterRightClick => {
                 if unregister_rightclick() {
-                    let msg = "Could not unregister previous menu item. Possibly already registered.";
+                    let msg =
+                        "Could not unregister previous menu item. Possibly already registered.";
                     nvim.err_writeln(msg).await.ok();
                     error!("{}", msg);
                 }
@@ -153,7 +154,8 @@ impl ParallelCommand {
                     error!("{}", msg);
                 }
                 if !register_rightclick_file() {
-                    let msg = "Could not register file context menu item. Possibly already registered.";
+                    let msg =
+                        "Could not register file context menu item. Possibly already registered.";
                     nvim.err_writeln(msg).await.ok();
                     error!("{}", msg);
                 }

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -143,17 +143,17 @@ impl ParallelCommand {
             #[cfg(windows)]
             ParallelCommand::RegisterRightClick => {
                 if unregister_rightclick() {
-                    let msg = "Could not unregister previous menu item. Possibly already registered or not running as Admin?";
+                    let msg = "Could not unregister previous menu item. Possibly already registered.";
                     nvim.err_writeln(msg).await.ok();
                     error!("{}", msg);
                 }
                 if !register_rightclick_directory() {
-                    let msg = "Could not register directory context menu item. Possibly already registered or not running as Admin?";
+                    let msg = "Could not register directory context menu item. Possibly already registered.";
                     nvim.err_writeln(msg).await.ok();
                     error!("{}", msg);
                 }
                 if !register_rightclick_file() {
-                    let msg = "Could not register file context menu item. Possibly already registered or not running as Admin?";
+                    let msg = "Could not register file context menu item. Possibly already registered.";
                     nvim.err_writeln(msg).await.ok();
                     error!("{}", msg);
                 }
@@ -161,7 +161,7 @@ impl ParallelCommand {
             #[cfg(windows)]
             ParallelCommand::UnregisterRightClick => {
                 if !unregister_rightclick() {
-                    let msg = "Could not remove context menu items. Possibly already removed or not running as Admin?";
+                    let msg = "Could not remove context menu items. Possibly already removed.";
                     nvim.err_writeln(msg).await.ok();
                     error!("{}", msg);
                 }

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -11,7 +11,7 @@ use winapi::{
         libloaderapi::GetModuleFileNameA,
         wincon::{AttachConsole, ATTACH_PARENT_PROCESS},
         winnt::{KEY_WRITE, REG_OPTION_NON_VOLATILE, REG_SZ},
-        winreg::{RegCloseKey, RegCreateKeyExA, RegDeleteTreeA, RegSetValueExA, HKEY_CLASSES_ROOT},
+        winreg::{RegCloseKey, RegCreateKeyExA, RegDeleteTreeA, RegSetValueExA, HKEY_CURRENT_USER},
     },
 };
 
@@ -34,11 +34,11 @@ fn get_binary_path() -> String {
 
 #[cfg(target_os = "windows")]
 pub fn unregister_rightclick() -> bool {
-    let str_registry_path_1 = CString::new("Directory\\Background\\shell\\Neovide").unwrap();
-    let str_registry_path_2 = CString::new("*\\shell\\Neovide").unwrap();
+    let str_registry_path_1 = CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide").unwrap();
+    let str_registry_path_2 = CString::new("Software\\Classes\\*\\shell\\Neovide").unwrap();
     unsafe {
-        let s1 = RegDeleteTreeA(HKEY_CLASSES_ROOT, str_registry_path_1.as_ptr());
-        let s2 = RegDeleteTreeA(HKEY_CLASSES_ROOT, str_registry_path_2.as_ptr());
+        let s1 = RegDeleteTreeA(HKEY_CURRENT_USER, str_registry_path_1.as_ptr());
+        let s2 = RegDeleteTreeA(HKEY_CURRENT_USER, str_registry_path_2.as_ptr());
         s1 == 0 && s2 == 0
     }
 }
@@ -47,16 +47,16 @@ pub fn unregister_rightclick() -> bool {
 pub fn register_rightclick_directory() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();
-    let str_registry_path = CString::new("Directory\\Background\\shell\\Neovide").unwrap();
+    let str_registry_path = CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide").unwrap();
     let str_registry_command_path =
-        CString::new("Directory\\Background\\shell\\Neovide\\command").unwrap();
+        CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide\\command").unwrap();
     let str_icon = CString::new("Icon").unwrap();
     let str_command = CString::new(format!("{} \"%V\"", neovide_path).as_bytes()).unwrap();
     let str_description = CString::new("Open with Neovide").unwrap();
     let str_neovide_path = CString::new(neovide_path.as_bytes()).unwrap();
     unsafe {
         if RegCreateKeyExA(
-            HKEY_CLASSES_ROOT,
+            HKEY_CURRENT_USER,
             str_registry_path.as_ptr(),
             0,
             null_mut(),
@@ -97,7 +97,7 @@ pub fn register_rightclick_directory() -> bool {
         RegCloseKey(registry_key);
 
         if RegCreateKeyExA(
-            HKEY_CLASSES_ROOT,
+            HKEY_CURRENT_USER,
             str_registry_command_path.as_ptr(),
             0,
             null_mut(),
@@ -135,15 +135,15 @@ pub fn register_rightclick_directory() -> bool {
 pub fn register_rightclick_file() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();
-    let str_registry_path = CString::new("*\\shell\\Neovide").unwrap();
-    let str_registry_command_path = CString::new("*\\shell\\Neovide\\command").unwrap();
+    let str_registry_path = CString::new("Software\\Classes\\*\\shell\\Neovide").unwrap();
+    let str_registry_command_path = CString::new("Software\\Classes\\*\\shell\\Neovide\\command").unwrap();
     let str_icon = CString::new("Icon").unwrap();
     let str_command = CString::new(format!("{} \"%1\"", neovide_path).as_bytes()).unwrap();
     let str_description = CString::new("Open with Neovide").unwrap();
     let str_neovide_path = CString::new(neovide_path.as_bytes()).unwrap();
     unsafe {
         if RegCreateKeyExA(
-            HKEY_CLASSES_ROOT,
+            HKEY_CURRENT_USER,
             str_registry_path.as_ptr(),
             0,
             null_mut(),
@@ -184,7 +184,7 @@ pub fn register_rightclick_file() -> bool {
         RegCloseKey(registry_key);
 
         if RegCreateKeyExA(
-            HKEY_CLASSES_ROOT,
+            HKEY_CURRENT_USER,
             str_registry_command_path.as_ptr(),
             0,
             null_mut(),

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -34,7 +34,8 @@ fn get_binary_path() -> String {
 
 #[cfg(target_os = "windows")]
 pub fn unregister_rightclick() -> bool {
-    let str_registry_path_1 = CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide").unwrap();
+    let str_registry_path_1 =
+        CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide").unwrap();
     let str_registry_path_2 = CString::new("Software\\Classes\\*\\shell\\Neovide").unwrap();
     unsafe {
         let s1 = RegDeleteTreeA(HKEY_CURRENT_USER, str_registry_path_1.as_ptr());
@@ -47,7 +48,8 @@ pub fn unregister_rightclick() -> bool {
 pub fn register_rightclick_directory() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();
-    let str_registry_path = CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide").unwrap();
+    let str_registry_path =
+        CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide").unwrap();
     let str_registry_command_path =
         CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide\\command").unwrap();
     let str_icon = CString::new("Icon").unwrap();
@@ -136,7 +138,8 @@ pub fn register_rightclick_file() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();
     let str_registry_path = CString::new("Software\\Classes\\*\\shell\\Neovide").unwrap();
-    let str_registry_command_path = CString::new("Software\\Classes\\*\\shell\\Neovide\\command").unwrap();
+    let str_registry_command_path =
+        CString::new("Software\\Classes\\*\\shell\\Neovide\\command").unwrap();
     let str_icon = CString::new("Icon").unwrap();
     let str_command = CString::new(format!("{} \"%1\"", neovide_path).as_bytes()).unwrap();
     let str_description = CString::new("Open with Neovide").unwrap();


### PR DESCRIPTION
The old code was using HKEY_CLASSES_ROOT, which requires Admin.
Fixed to use HKEY_CURRENT_USER to work without Admin.

Reference: https://stackoverflow.com/a/29769228/13173256

This emloys two right-click menu (context menu) for files, and background directory (open a directory, right click at an empty place).

It is possible to also add a right-click menu to folder (right click on a folder). Key will be: `Software\\Classes\\Directory\\shell\\Neovide` and . Although I don't use this right-click menu, I would still implement this if it's needed.

PS: I think we should update the readme. A while ago, a person contacted me through email asking for command, which is not documented.

---

If you already register right click menu in previous version of Neovim, open `regedit` and remove these keys:
- Computer\HKEY_CLASSES_ROOT\Directory\Background\shell\Neovide
- Computer\HKEY_CLASSES_ROOT\*\shell\Neovide