### PR TITLE
Fix special style

### DIFF
--- a/src/editor/style.rs
+++ b/src/editor/style.rs
@@ -144,7 +144,7 @@ mod tests {
         style.colors.special = None;
         assert_eq!(
             style.special(&DEFAULT_COLORS),
-            DEFAULT_COLORS.special.unwrap()
+            style.foreground(&DEFAULT_COLORS),
         );
     }
 }


### PR DESCRIPTION
`Style.special()` was returning foreground instead of default special if `special` was `None`. 
(If that was intended then the test at line 145 should be fixed instead).