### PR TITLE
There’s no need to reallocate characters grid and doing all these copying.

### DIFF
--- a/src/editor/grid.rs
+++ b/src/editor/grid.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{iter, sync::Arc};
 
 use super::style::Style;
 
@@ -31,19 +31,15 @@ impl CharacterGrid {
 
     pub fn resize(&mut self, (width, height): (u64, u64)) {
         let new_cell_count = (width * height) as usize;
-        let mut new_characters = vec![default_cell!(); new_cell_count];
-
-        for x in 0..self.width.min(width) {
-            for y in 0..self.height.min(height) {
-                if let Some(existing_cell) = self.get_cell(x, y) {
-                    new_characters[(x + y * width) as usize] = existing_cell.clone();
-                }
-            }
+        if new_cell_count > self.characters.len() {
+            let placeholders_count = new_cell_count - self.characters.len();
+            self.characters.reserve(placeholders_count);
+            self.characters
+                .extend(iter::repeat(default_cell!()).take(placeholders_count))
         }
 
         self.width = width;
         self.height = height;
-        self.characters = new_characters;
     }
 
     pub fn clear(&mut self) {


### PR DESCRIPTION
- Refactor
- No breaking changes.

Unless you want to save space when the grid is getting smaller you can avoid allocating new vector and copying data there.

I should have probably added `self.characters.set_len(width * height)` if you will want to use bounds checking from vector instead of doing it yourself in `get_index`.

And if you want to save memory when downsizing you should consider using `drain` 

https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.drain to avoid copying all this cells.

Pick any version I’ll update the PR accordingly If you’re interested.