### PR TITLE
Remove compiler warning on non windows platforms

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -8,7 +8,9 @@ use rmpv::Value;
 use tokio::task;
 
 use super::events::{parse_redraw_event, RedrawEvent};
-use super::ui_commands::{ParallelCommand, UiCommand};
+#[cfg(windows)]
+use super::ui_commands::ParallelCommand;
+use super::ui_commands::UiCommand;
 use crate::bridge::TxWrapper;
 use crate::channel_utils::*;
 use crate::error_handling::ResultPanicExplanation;


### PR DESCRIPTION
Related to: #1064 
ParallelCommand was only used on windows but it was imported for every distro

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Refactor

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
