### PR TITLE
Fix compiler warnings on non-Windows

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -9,8 +9,7 @@ use tokio::task;
 
 use super::events::{parse_redraw_event, RedrawEvent};
 #[cfg(windows)]
-use super::ui_commands::ParallelCommand;
-use super::ui_commands::UiCommand;
+use super::ui_commands::{ParallelCommand, UiCommand};
 use crate::bridge::TxWrapper;
 use crate::channel_utils::*;
 use crate::error_handling::ResultPanicExplanation;
@@ -18,16 +17,18 @@ use crate::settings::SETTINGS;
 
 #[derive(Clone)]
 pub struct NeovimHandler {
+    #[cfg(windows)]
     ui_command_sender: Arc<Mutex<LoggingTx<UiCommand>>>,
     redraw_event_sender: Arc<Mutex<LoggingTx<RedrawEvent>>>,
 }
 
 impl NeovimHandler {
     pub fn new(
-        ui_command_sender: LoggingTx<UiCommand>,
+        #[cfg(windows)] ui_command_sender: LoggingTx<UiCommand>,
         redraw_event_sender: LoggingTx<RedrawEvent>,
     ) -> NeovimHandler {
         NeovimHandler {
+            #[cfg(windows)]
             ui_command_sender: Arc::new(Mutex::new(ui_command_sender)),
             redraw_event_sender: Arc::new(Mutex::new(redraw_event_sender)),
         }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -154,11 +154,14 @@ fn connection_mode() -> ConnectionMode {
 }
 
 async fn start_neovim_runtime(
-    ui_command_sender: LoggingTx<UiCommand>,
+    #[cfg(windows)] ui_command_sender: LoggingTx<UiCommand>,
     ui_command_receiver: UnboundedReceiver<UiCommand>,
     redraw_event_sender: LoggingTx<RedrawEvent>,
 ) {
+    #[cfg(windows)]
     let handler = NeovimHandler::new(ui_command_sender.clone(), redraw_event_sender.clone());
+    #[cfg(not(windows))]
+    let handler = NeovimHandler::new(redraw_event_sender.clone());
     let (nvim, io_handler) = match connection_mode() {
         ConnectionMode::Child => create::new_child_cmd(&mut create_nvim_command(), handler).await,
         ConnectionMode::RemoteTcp(address) => create::new_tcp(address, handler).await,
@@ -291,12 +294,13 @@ pub struct Bridge {
 }
 
 pub fn start_bridge(
-    ui_command_sender: LoggingTx<UiCommand>,
+    #[cfg(windows)] ui_command_sender: LoggingTx<UiCommand>,
     ui_command_receiver: UnboundedReceiver<UiCommand>,
     redraw_event_sender: LoggingTx<RedrawEvent>,
 ) -> Bridge {
     let runtime = Runtime::new().unwrap();
     runtime.spawn(start_neovim_runtime(
+        #[cfg(windows)]
         ui_command_sender,
         ui_command_receiver,
         redraw_event_sender,

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ fn main() {
 
     // We need to keep the bridge reference around to prevent the tokio runtime from getting freed
     let _bridge = start_bridge(
+        #[cfg(windows)]
         logging_ui_command_sender.clone(),
         ui_command_receiver,
         logging_redraw_event_sender,


### PR DESCRIPTION
Supersedes  #1065 
Closes #1064 

As @jeremycostanzo said, ui_command_sender isn't used on linux, so it needs to be cfg-ed away.
Not sure if this is the prettiest way, but it only uses a few `#cfg` and didn't require any refactoring/splitting into windows and linux.