### PR TITLE
Properly export PATH on macOS when ran from Finder

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,6 @@ fn handle_macos() {
     if env::var_os("TERM").is_none() {
         let shell = env::var("SHELL").unwrap();
         let cmd = "printenv PATH";
-        
         if let Ok(path) = std::process::Command::new(shell)
             .arg("-lic")
             .arg(cmd)

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,15 +234,11 @@ fn handle_macos() {
     use std::env;
 
     if env::var_os("TERM").is_none() {
-        let mut profile_path = dirs::home_dir().unwrap();
-        profile_path.push(".profile");
         let shell = env::var("SHELL").unwrap();
-        let cmd = format!(
-            "(source /etc/profile && source {} && echo $PATH)",
-            profile_path.to_str().unwrap()
-        );
+        let cmd = "printenv PATH";
+        
         if let Ok(path) = std::process::Command::new(shell)
-            .arg("-c")
+            .arg("-lic")
             .arg(cmd)
             .output()
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,9 +235,10 @@ fn handle_macos() {
 
     if env::var_os("TERM").is_none() {
         let shell = env::var("SHELL").unwrap();
+        // printenv is the proper way to print env variables. using echo $PATH would break Fish.
         let cmd = "printenv PATH";
         if let Ok(path) = std::process::Command::new(shell)
-            .arg("-lic")
+            .arg("-lic") // interactive login shell, this simulates opening a real terminal emulator
             .arg(cmd)
             .output()
         {


### PR DESCRIPTION
Currently, it's impossible to launch Neovide from Finder when using Fish as login shell or when using non-standard environment configs (e.g. system managed by [Nix](https://github.com/NixOS/nix) and [nix-darwin](https://github.com/LnL7/nix-darwin)).

This PR removes hardcoded expectation that `~/.profile` exists or that `$SHELL` is POSIX-compatible.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
