### PR TITLE
Upgrade skia-safe dependency to build on Apple silicon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.58.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -126,7 +126,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
@@ -187,11 +187,11 @@ checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 5.1.2",
+ "nom",
 ]
 
 [[package]]
@@ -625,9 +625,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -1349,7 +1349,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "unicode-segmentation",
- "which 4.2.2",
+ "which",
  "winapi",
  "winit",
  "winres",
@@ -1385,16 +1385,6 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -2004,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.40.2"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e49c0905fe8fa4a4fe348f0ec33a3b3fc78e73f4602c7154d8fb70d4b0aaee2"
+checksum = "3902fb99982774025e9270b0c9109e89b05a8f26bd77adc53a2beae9f470a5e2"
 dependencies = [
  "bindgen",
  "cc",
@@ -2022,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.40.2"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147b9ab328c7c40dbf590151313df9cd721be8c418cfefa2533c9a0c056ef21b"
+checksum = "d6ed1a71dc04e63cb755a77eaf3f4cb9baa26dbe67a6a54f372bcadf2af83023"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -2532,15 +2522,6 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
@@ -2652,7 +2633,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
 dependencies = [
- "nom 7.0.0",
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,11 @@ winres = "0.1.11"
 
 [target.'cfg(linux)'.dependencies.skia-safe]
 features = ["gl", "egl"]
-version = "^0.40.2"
+version = "^0.42.1"
 
 [target.'cfg(not(linux))'.dependencies.skia-safe]
 features = ["gl"]
-version = "^0.40.2"
+version = "^0.42.1"
 
 [profile.release]
 debug = true


### PR DESCRIPTION
Following the build instructions on M1 causes the following error:

```
thread 'main' panicked at 'Unable to generate bindings: ()', /Users/.../.cargo/registry/src/github.com-1ecc6299db9ec823/skia-bindings-0.40.2/build_support/skia_bindgen.rs:255:39
```

The fix detailed in #1054 by @cyz1901 has been confirmed to work by @Sduby22 and me. I'm submitting this PR to hopefully upstream this fix. The remaining question is whether this upgrade breaks the build on other platforms.

## What kind of change does this PR introduce?
Fix #1054.

## Did this PR introduce a breaking change? 
Technically yes: `skia-safe` was upgraded from `0.40.2` → `0.42.1`. Under semver all `0.X` changes are breaking, but I haven't observed any API incompatibility between these two versions wrt neovim.