### PR TITLE
Install cargo-bundle when building for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Install Utilities
         run: |
           cargo install cargo2junit
+          cargo install cargo-bundle
 
       - uses: Swatinem/rust-cache@v1
 


### PR DESCRIPTION
The previous [PR](https://github.com/neovide/neovide/pull/1074) broke CI because it doesn't install `cargo-bundle` before building.

I have no idea why it worked during my testing, probably caching.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
