### PR TITLE
Update apt in linux ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Update apt
+        run: |
+          sudo apt-get update
+
       - name: Install Nightly Toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Linux build were failing because of outdated repos.
Adding `sudo apt-get update` to the beginning of the build command fixes this.