### PR TITLE
Fix cmdline args

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -124,7 +124,8 @@ pub fn create_nvim_command() -> Command {
     let mut cmd = build_nvim_cmd();
 
     cmd.arg("--embed")
-        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter());
+        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter())
+        .args(SETTINGS.get::<CmdLineSettings>().files_to_open.iter());
 
     info!("Starting neovim with: {:?}", cmd);
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -124,8 +124,7 @@ pub fn create_nvim_command() -> Command {
     let mut cmd = build_nvim_cmd();
 
     cmd.arg("--embed")
-        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter())
-        .args(SETTINGS.get::<CmdLineSettings>().files_to_open.iter());
+        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter());
 
     info!("Starting neovim with: {:?}", cmd);
 

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -231,6 +231,59 @@ mod tests {
     }
 
     #[test]
+    fn test_files_to_open() {
+        let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
+        handle_command_line_arguments(args).expect("Could not parse arguments");
+        assert_eq!(
+            SETTINGS.get::<CmdLineSettings>().neovim_args,
+            vec!["./foo.txt", "./bar.md"]
+        );
+    }
+
+    #[test]
+    fn test_files_to_open_with_passthrough() {
+        let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md", "--", "--clean"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
+        handle_command_line_arguments(args).expect("Could not parse arguments");
+        assert_eq!(
+            SETTINGS.get::<CmdLineSettings>().neovim_args,
+            vec!["--clean", "./foo.txt", "./bar.md"]
+        );
+    }
+
+    #[test]
+    fn test_files_to_open_with_flag() {
+        let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md", "--geometry=42x24"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
+        handle_command_line_arguments(args).expect("Could not parse arguments");
+        assert_eq!(
+            SETTINGS.get::<CmdLineSettings>().neovim_args,
+            vec!["./foo.txt", "./bar.md"]
+        );
+
+        assert_eq!(
+            SETTINGS.get::<CmdLineSettings>().geometry,
+            Dimensions {
+                width: 42,
+                height: 24
+            }
+        );
+    }
+
+    #[test]
     fn test_geometry() {
         let args: Vec<String> = vec!["neovide", "--geometry=42x24"]
             .iter()

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -7,6 +7,7 @@ use clap::{App, Arg};
 pub struct CmdLineSettings {
     // Pass through arguments
     pub neovim_args: Vec<String>,
+    pub files_to_open: Vec<String>,
     // Command-line arguments only
     pub geometry: Dimensions,
     pub verbosity: u64,
@@ -31,6 +32,7 @@ impl Default for CmdLineSettings {
         Self {
             // Pass through arguments
             neovim_args: vec![],
+            files_to_open: vec![],
             // Command-line arguments only
             geometry: DEFAULT_WINDOW_GEOMETRY,
             verbosity: 0,
@@ -59,6 +61,12 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
         .about(crate_description!())
         // Pass through arguments
         .arg(
+            Arg::with_name("files_to_open")
+                .multiple(true)
+                .takes_value(true)
+                .help("Files to open"),
+        )
+        .arg(
             Arg::with_name("neovim_args")
                 .multiple(true)
                 .takes_value(true)
@@ -66,7 +74,12 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
                 .help("Specify Arguments to pass down to neovim"),
         )
         // Command-line arguments only
-        .arg(Arg::with_name("verbosity").short("v"))
+        .arg(
+            Arg::with_name("verbosity")
+                .short("v")
+                .multiple(true)
+                .help("Increase verbosity level (repeatable up to 4 times; implies --nofork)"),
+        )
         .arg(
             Arg::with_name("geometry")
                 .long("geometry")
@@ -149,6 +162,10 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
         // Pass through arguments
         neovim_args: matches
             .values_of("neovim_args")
+            .map(|opt| opt.map(|v| v.to_owned()).collect())
+            .unwrap_or_default(),
+        files_to_open: matches
+            .values_of("files_to_open")
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
         // Command-line arguments only

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -168,7 +168,7 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
      */
     SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
         // Pass through arguments
-        neovim_args: neovim_args,
+        neovim_args,
         // Command-line arguments only
         verbosity: matches.occurrences_of("verbosity"),
         geometry: parse_window_geometry(matches.value_of("geometry").map(|i| i.to_owned()))?,

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -7,7 +7,6 @@ use clap::{App, Arg};
 pub struct CmdLineSettings {
     // Pass through arguments
     pub neovim_args: Vec<String>,
-    pub files_to_open: Vec<String>,
     // Command-line arguments only
     pub geometry: Dimensions,
     pub verbosity: u64,
@@ -32,7 +31,6 @@ impl Default for CmdLineSettings {
         Self {
             // Pass through arguments
             neovim_args: vec![],
-            files_to_open: vec![],
             // Command-line arguments only
             geometry: DEFAULT_WINDOW_GEOMETRY,
             verbosity: 0,
@@ -152,6 +150,16 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
         );
 
     let matches = clapp.get_matches_from(args);
+    let mut neovim_args: Vec<String> = matches
+        .values_of("neovim_args")
+        .map(|opt| opt.map(|v| v.to_owned()).collect())
+        .unwrap_or_default();
+    neovim_args.extend::<Vec<String>>(
+        matches
+            .values_of("files_to_open")
+            .map(|opt| opt.map(|v| v.to_owned()).collect())
+            .unwrap_or_default(),
+    );
 
     /*
      * Integrate Environment Variables as Defaults to the command-line ones.
@@ -160,14 +168,7 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
      */
     SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
         // Pass through arguments
-        neovim_args: matches
-            .values_of("neovim_args")
-            .map(|opt| opt.map(|v| v.to_owned()).collect())
-            .unwrap_or_default(),
-        files_to_open: matches
-            .values_of("files_to_open")
-            .map(|opt| opt.map(|v| v.to_owned()).collect())
-            .unwrap_or_default(),
+        neovim_args: neovim_args,
         // Command-line arguments only
         verbosity: matches.occurrences_of("verbosity"),
         geometry: parse_window_geometry(matches.value_of("geometry").map(|i| i.to_owned()))?,

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -9,6 +9,7 @@ pub struct CmdLineSettings {
     pub neovim_args: Vec<String>,
     // Command-line arguments only
     pub geometry: Dimensions,
+    pub verbosity: u64,
     pub log_to_file: bool,
     pub no_fork: bool,
     pub remote_tcp: Option<String>,
@@ -32,6 +33,7 @@ impl Default for CmdLineSettings {
             neovim_args: vec![],
             // Command-line arguments only
             geometry: DEFAULT_WINDOW_GEOMETRY,
+            verbosity: 0,
             log_to_file: false,
             no_fork: false,
             remote_tcp: None,
@@ -64,6 +66,7 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
                 .help("Specify Arguments to pass down to neovim"),
         )
         // Command-line arguments only
+        .arg(Arg::with_name("verbosity").short("v"))
         .arg(
             Arg::with_name("geometry")
                 .long("geometry")
@@ -149,9 +152,10 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
         // Command-line arguments only
+        verbosity: matches.occurrences_of("verbosity"),
         geometry: parse_window_geometry(matches.value_of("geometry").map(|i| i.to_owned()))?,
         log_to_file: matches.is_present("log_to_file"),
-        no_fork: matches.is_present("nofork"),
+        no_fork: matches.is_present("nofork") || matches.is_present("verbosity"),
         remote_tcp: matches.value_of("remote_tcp").map(|i| i.to_owned()),
         wsl: matches.is_present("wsl"),
         // Command-line flags with environment variable fallback

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,12 @@ fn main() {
 #[cfg(not(test))]
 pub fn init_logger() {
     let settings = SETTINGS.get::<CmdLineSettings>();
+    let verbosity = match settings.verbosity {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
 
     let logger = if settings.log_to_file {
         Logger::with_env_or_str("neovide")


### PR DESCRIPTION
Add back `--verbosity` and `files_to_open`, removed in https://github.com/neovide/neovide/pull/1016

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
