### PR TITLE
Fix Full Disk Access for universal macOS app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Merge into a universal app
         run: |
           mkdir -p target/release/bundle/osx
+          rm -rf target/release/bundle/osx/Neovide.app || true
           cp -R target/x86_64-apple-darwin/release/bundle/osx/Neovide.app \
             target/release/bundle/osx/Neovide.app
           rm target/release/bundle/osx/Neovide.app/Contents/MacOS/neovide

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
             target/aarch64-apple-darwin/release/bundle/osx/Neovide.app/Contents/MacOS/neovide \
             -create -output \
             target/release/bundle/osx/Neovide.app/Contents/MacOS/neovide
+          codesign --force --deep -s - target/release/bundle/osx/Neovide.app
 
       - name: Create .dmg file
         run: |


### PR DESCRIPTION
The universal app bundle building process had some problems that prevented granting Full Disk Access to the app, those being:
- Due to build caching, there was a copy of `Neovide.app` inside the main `Neovide.app`
- Binary after `lipo` contained conflicting signatures, x86_64 segment having no signature, while aarch64 had an ad-hoc signature.

These problems resulted in macOS not being able to remember which binary was granted what permissions, so TCC prompt popped up on every file access. It was impossible to grant Full Disk Access to the app.

This PR removes the redundant copy of the `Neovide.app` and adds force Ad-Hoc codesign of the app bundle after `lipo`.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
