### PR TITLE
List Available Fonts when guifont=*

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use log::error;
 use log::trace;
 
-use nvim_rs::{Neovim, call_args, rpc::model::IntoVal};
+use nvim_rs::{call_args, rpc::model::IntoVal, Neovim};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
 use crate::bridge::TxWrapper;
@@ -172,14 +172,11 @@ impl ParallelCommand {
                 nvim.command("\"lcd ~").await.ok();
                 nvim.command("file scratch").await.ok();
                 nvim.call(
-                    "nvim_buf_set_lines", 
-                    call_args![
-                        0i64,
-                        0i64,
-                        -1i64,
-                        false,
-                        content
-                    ]).await.ok();
+                    "nvim_buf_set_lines",
+                    call_args![0i64, 0i64, -1i64, false, content],
+                )
+                .await
+                .ok();
             }
             #[cfg(windows)]
             ParallelCommand::RegisterRightClick => {

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -154,7 +154,7 @@ impl ParallelCommand {
                     "",
                     "    :set guifont=Cascadia\\ Code\\ PL:h12",
                     "",
-                    "You may specify multiple fonts separated by commas like so:",
+                    "You may specify multiple fonts for fallback purposes separated by commas like so:",
                     "",
                     "    :set guifont=Cascadia\\ Code\\ PL,Delugia\\ Nerd\\ Font:h12",
                     "",

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -145,7 +145,9 @@ impl ParallelCommand {
             }
             ParallelCommand::DisplayAvailableFonts(fonts) => {
                 let mut content: Vec<String> = vec![
-                    "What follows are the font names available for guifont. To use one of these, type:",
+                    "What follows are the font names available for guifont. You can try any of them with <CR> in normal mode.",
+                    "",
+                    "To switch to one of them, use one of them, type:",
                     "",
                     "    :set guifont=<font name>:h<font size>",
                     "",
@@ -158,6 +160,7 @@ impl ParallelCommand {
                     "",
                     "    :set guifont=Cascadia\\ Code\\ PL,Delugia\\ Nerd\\ Font:h12",
                     "",
+                    "Make sure to add the above command when you're happy with it to your .vimrc file or similar config to make it permanent.",
                     "------------------------------",
                     "Available Fonts on this System",
                     "------------------------------",
@@ -174,6 +177,11 @@ impl ParallelCommand {
                 nvim.call(
                     "nvim_buf_set_lines",
                     call_args![0i64, 0i64, -1i64, false, content],
+                )
+                .await
+                .ok();
+                nvim.command(
+                    "nnoremap <buffer> <CR> <cmd>lua vim.opt.guifont=vim.fn.getline('.')<CR>",
                 )
                 .await
                 .ok();

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -63,6 +63,7 @@ pub enum DrawCommand {
 pub enum WindowCommand {
     TitleChanged(String),
     SetMouseEnabled(bool),
+    ListAvailableFonts,
 }
 
 pub struct Editor {
@@ -421,9 +422,16 @@ impl Editor {
     fn set_option(&mut self, gui_option: GuiOption) {
         trace!("Option set {:?}", &gui_option);
         if let GuiOption::GuiFont(guifont) = gui_option {
+            if guifont == "*".to_owned() {
+                self.window_command_sender
+                    .send(WindowCommand::ListAvailableFonts)
+                    .ok();
+            }
+
             self.draw_command_batcher
                 .queue(DrawCommand::FontChanged(guifont))
                 .ok();
+
             for window in self.windows.values() {
                 window.redraw();
             }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -422,7 +422,7 @@ impl Editor {
     fn set_option(&mut self, gui_option: GuiOption) {
         trace!("Option set {:?}", &gui_option);
         if let GuiOption::GuiFont(guifont) = gui_option {
-            if guifont == "*".to_owned() {
+            if guifont == *"*" {
                 self.window_command_sender
                     .send(WindowCommand::ListAvailableFonts)
                     .ok();

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -106,6 +106,10 @@ impl CachingShaper {
         self.blob_cache.clear();
     }
 
+    pub fn font_names(&self) -> Vec<String> {
+        self.font_loader.font_names()
+    }
+
     fn info(&mut self) -> (Metrics, f32) {
         let font_pair = self.current_font_pair();
         let size = self.current_size();

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -162,4 +162,8 @@ impl FontLoader {
 
         Some(font_arc)
     }
+
+    pub fn font_names(&self) -> Vec<String> {
+        self.font_mgr.family_names().collect()
+    }
 }

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -41,6 +41,10 @@ impl GridRenderer {
         }
     }
 
+    pub fn font_names(&self) -> Vec<String> {
+        self.shaper.font_names()
+    }
+
     /// Convert PhysicalSize to grid size
     pub fn convert_physical_to_grid(&self, physical: PhysicalSize<u32>) -> Dimensions {
         Dimensions::from(physical) / self.font_dimensions

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -75,6 +75,10 @@ impl Renderer {
         }
     }
 
+    pub fn font_names(&self) -> Vec<String> {
+        self.grid_renderer.font_names()
+    }
+
     /// Draws frame
     ///
     /// # Returns

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -88,7 +88,8 @@ impl GlutinWindowWrapper {
                 WindowCommand::TitleChanged(new_title) => self.handle_title_changed(new_title),
                 WindowCommand::SetMouseEnabled(mouse_enabled) => {
                     self.mouse_manager.enabled = mouse_enabled
-                }
+                },
+                WindowCommand::ListAvailableFonts => self.send_font_names(),
             }
         }
     }
@@ -96,6 +97,11 @@ impl GlutinWindowWrapper {
     pub fn handle_title_changed(&mut self, new_title: String) {
         self.title = new_title;
         self.windowed_context.window().set_title(&self.title);
+    }
+
+    pub fn send_font_names(&self) {
+        let font_names = self.renderer.font_names();
+        self.ui_command_sender.send(UiCommand::Parallel(ParallelCommand::DisplayAvailableFonts(font_names))).unwrap();
     }
 
     pub fn handle_quit(&mut self) {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -88,7 +88,7 @@ impl GlutinWindowWrapper {
                 WindowCommand::TitleChanged(new_title) => self.handle_title_changed(new_title),
                 WindowCommand::SetMouseEnabled(mouse_enabled) => {
                     self.mouse_manager.enabled = mouse_enabled
-                },
+                }
                 WindowCommand::ListAvailableFonts => self.send_font_names(),
             }
         }
@@ -101,7 +101,11 @@ impl GlutinWindowWrapper {
 
     pub fn send_font_names(&self) {
         let font_names = self.renderer.font_names();
-        self.ui_command_sender.send(UiCommand::Parallel(ParallelCommand::DisplayAvailableFonts(font_names))).unwrap();
+        self.ui_command_sender
+            .send(UiCommand::Parallel(ParallelCommand::DisplayAvailableFonts(
+                font_names,
+            )))
+            .unwrap();
     }
 
     pub fn handle_quit(&mut self) {


### PR DESCRIPTION
Display documentation for the guifont option, and list available fonts in a scratch buffer when the user sets guifont equal to "*".

![guifont_list](https://user-images.githubusercontent.com/3323631/145781335-a8a7664b-4461-4753-82de-b97fe26926fe.gif)

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
