### PR TITLE
Enable default features on winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rand = "0.7"
 pin-project = "0.4.27"
 futures = "0.3.12"
 glutin = { git = "https://github.com/neovide/glutin", branch = "new-keyboard-all" }
-winit = { git = "https://github.com/neovide/winit", branch = "new-keyboard-all", default-features = false }
+winit = { git = "https://github.com/neovide/winit", branch = "new-keyboard-all" }
 gl = "0.14.0"
 swash = "0.1.4"
 clap="2.33.3"


### PR DESCRIPTION
Currently neovide does not compile on Ubuntu (closes #1092).
If the second solution in #1092 is preferred, i.e. having x11 and wayland as features in neovide, I can also do that.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
