### PR TITLE
remove "-complete=expression" with -nargs=0

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -109,7 +109,7 @@ pub fn build_neovide_command(channel: u64, num_args: u64, command: &str, event: 
     };
     if num_args == 0 {
         return format!(
-            "command! -nargs={} -complete=expression {} call rpcnotify({}, 'neovide.{}')",
+            "command! -nargs={} {} call rpcnotify({}, 'neovide.{}')",
             nargs, command, channel, event
         );
     } else {


### PR DESCRIPTION
Newer versions of Vim/Neovim throw error when using `-complete` with `-nargs=0`

https://github.com/neoclide/coc.nvim/issues/3414
https://github.com/neoclide/coc.nvim/pull/3210