### PR TITLE
Fix window settings load and save

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -10,8 +10,7 @@ use nvim_rs::Neovim;
 use parking_lot::RwLock;
 pub use rmpv::Value;
 pub use window_geometry::{
-    load_last_window_position, maybe_save_window_position, maybe_save_window_size,
-    parse_window_geometry, DEFAULT_WINDOW_GEOMETRY,
+    load_last_window_position, parse_window_geometry, save_window_geometry, DEFAULT_WINDOW_GEOMETRY,
 };
 
 use crate::bridge::TxWrapper;

--- a/src/settings/window_geometry.rs
+++ b/src/settings/window_geometry.rs
@@ -4,8 +4,6 @@ use crate::window::WindowSettings;
 use glutin::dpi::PhysicalPosition;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-#[cfg(unix)]
-use xdg;
 
 const SETTINGS_FILE: &str = "neovide-settings.json";
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -30,9 +30,7 @@ use crate::{
     redraw_scheduler::REDRAW_SCHEDULER,
     renderer::Renderer,
     running_tracker::*,
-    settings::{
-        load_last_window_position, maybe_save_window_position, maybe_save_window_size, SETTINGS,
-    },
+    settings::{load_last_window_position, save_window_geometry, SETTINGS},
     utils::Dimensions,
 };
 use image::{load_from_memory, GenericImageView, Pixel};
@@ -325,8 +323,8 @@ pub fn create_window(
 
     event_loop.run(move |e, _window_target, control_flow| {
         if !RUNNING_TRACKER.is_running() {
-            maybe_save_window_size(window_wrapper.saved_grid_size);
-            maybe_save_window_position(
+            save_window_geometry(
+                window_wrapper.saved_grid_size,
                 window_wrapper
                     .windowed_context
                     .window()


### PR DESCRIPTION
Some of the load and save paths that were broken in pull request https://github.com/neovide/neovide/pull/1111 and https://github.com/neovide/neovide/pull/1099 were fixed. And the JSON is now structured to properly support saving and loading of both position and size data, and is easily extendible for more fields and objects in the future.