### PR TITLE
Run WSL Neovim inside a login shell

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -29,8 +29,12 @@ fn set_windows_creation_flags(cmd: &mut Command) {
     cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
 }
 
-#[cfg(windows)]
-fn platform_build_nvim_cmd(bin: &str) -> Option<Command> {
+fn build_nvim_cmd_with_args(bin: &str) -> Command {
+    let mut args = Vec::<String>::new();
+    args.push("--embed".to_string());
+    args.extend(SETTINGS.get::<CmdLineSettings>().neovim_args);
+
+    #[cfg(windows)]
     if SETTINGS.get::<CmdLineSettings>().wsl {
         let mut cmd = Command::new("wsl");
         cmd.args(&[
@@ -38,18 +42,48 @@ fn platform_build_nvim_cmd(bin: &str) -> Option<Command> {
             "-c",
             "let \\$PATH=system(\"\\$SHELL -lic 'echo \\$PATH' 2>/dev/null\")",
         ]);
-        Some(cmd)
-    } else if Path::new(&bin).exists() {
-        Some(Command::new(bin))
-    } else {
-        None
+        cmd.args(args);
+        return cmd;
     }
+    let mut cmd = Command::new(bin);
+    cmd.args(args);
+    cmd
 }
 
-#[cfg(unix)]
-fn platform_build_nvim_cmd(bin: &str) -> Option<Command> {
-    if Path::new(&bin).exists() {
-        Some(Command::new(bin))
+fn platform_exists(bin: &str) -> bool {
+    #[cfg(windows)]
+    if SETTINGS.get::<CmdLineSettings>().wsl {
+        if let Ok(output) = std::process::Command::new("wsl")
+            .args(&["$SHELL", "-lic"])
+            .arg(format!("exists -x {}", bin))
+            .output()
+        {
+            return output.status.success();
+        } else {
+            error!("wsl exists failed");
+            std::process::exit(1);
+        }
+    }
+    Path::new(&bin).exists()
+}
+
+fn platform_which(bin: &str) -> Option<String> {
+    #[cfg(windows)]
+    if SETTINGS.get::<CmdLineSettings>().wsl {
+        if let Ok(output) = std::process::Command::new("wsl")
+            .args(&["$SHELL", "-lic"])
+            .arg(format!("which {}", bin))
+            .output()
+        {
+            if output.status.success() {
+                return Some(String::from_utf8(output.stdout).unwrap());
+            } else {
+                return None;
+            }
+        }
+    }
+    if let Ok(path) = which::which(bin) {
+        path.into_os_string().into_string().ok()
     } else {
         None
     }
@@ -57,43 +91,14 @@ fn platform_build_nvim_cmd(bin: &str) -> Option<Command> {
 
 fn build_nvim_cmd() -> Command {
     if let Some(path) = SETTINGS.get::<CmdLineSettings>().neovim_bin {
-        if let Some(cmd) = platform_build_nvim_cmd(&path) {
-            return cmd;
+        if platform_exists(&path) {
+            return build_nvim_cmd_with_args(&path);
         } else {
             warn!("NEOVIM_BIN is invalid falling back to first bin in PATH");
         }
     }
-    #[cfg(windows)]
-    if SETTINGS.get::<CmdLineSettings>().wsl {
-        if let Ok(output) = std::process::Command::new("wsl")
-            .args(&["$SHELL", "-lic", "which nvim"])
-            .output()
-        {
-            if output.status.success() {
-                let path = String::from_utf8(output.stdout).unwrap();
-                let mut cmd = Command::new("wsl");
-                cmd.args(&[
-                    path.trim(),
-                    "-c",
-                    "let \\$PATH=system(\"\\$SHELL -lic 'echo \\$PATH' 2>/dev/null\")",
-                ]);
-                return cmd;
-            } else {
-                error!("nvim not found in WSL path");
-                std::process::exit(1);
-            }
-        } else {
-            error!("wsl which nvim failed");
-            std::process::exit(1);
-        }
-    }
-    if let Ok(path) = which::which("nvim") {
-        if let Some(cmd) = platform_build_nvim_cmd(path.to_str().unwrap()) {
-            cmd
-        } else {
-            error!("nvim does not have proper permissions!");
-            std::process::exit(1);
-        }
+    if let Some(path) = platform_which("nvim") {
+        build_nvim_cmd_with_args(&path)
     } else {
         error!("nvim not found!");
         std::process::exit(1);
@@ -122,9 +127,6 @@ pub fn build_neovide_command(channel: u64, num_args: u64, command: &str, event: 
 
 pub fn create_nvim_command() -> Command {
     let mut cmd = build_nvim_cmd();
-
-    cmd.arg("--embed")
-        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter());
 
     info!("Starting neovim with: {:?}", cmd);
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -37,12 +37,8 @@ fn build_nvim_cmd_with_args(bin: &str) -> Command {
     #[cfg(windows)]
     if SETTINGS.get::<CmdLineSettings>().wsl {
         let mut cmd = Command::new("wsl");
-        cmd.args(&[
-            bin.trim(),
-            "-c",
-            "let \\$PATH=system(\"\\$SHELL -lic 'echo \\$PATH' 2>/dev/null\")",
-        ]);
-        cmd.args(args);
+        let argstring = format!("{} {}", bin.trim(), args.join(" "));
+        cmd.args(&["$SHELL", "-lc", &argstring]);
         return cmd;
     }
     let mut cmd = Command::new(bin);


### PR DESCRIPTION
Currently WSL is launched with a hack to launch a temporary interactive shell in order to fix the path inside Neovim, but it leaves all other environment variables unset, and does not correctly load all your login scripts.  See this flowchart from https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/

![flowchart](https://shreevatsa.files.wordpress.com/2008/03/bashstartupfiles1.png)

This  pull request changes that, so that Neovim is launched inside an interactive shell, and all settings and scripts are read correctly, at least I haven't seen any problems on my system. 

I also refactored the command line processing to unify the code paths taken on different systems and to avoid duplicating the code.

Note that there's a tiny problem, it does not necessarily work if you spawn another shell from within your bash scripts, like the Genie instructions here for example suggests https://github.com/arkane-systems/genie/wiki/Automatically-start-genie-on-every-shell-session. I had that problem when using Zsh as the default shell, but not when using Bash. I'm not sure if that problem can be solved at all, but I got rid of the problem by switching to https://github.com/nullpo-head/wsl-distrod, which is superior to Genie in many other ways too IMO.

My suggested fix for this is to document this, and instruct the users to fix their shell scripts to not start any subshells, another option is to add some command line parameter to choose between interactive and login shell.

Fixes https://github.com/neovide/neovide/issues/950
Fixes https://github.com/neovide/neovide/issues/983