### PR TITLE
Detach stdin, stdout and stderr from terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,9 @@ fn maybe_disown() {
 
     if let Ok(current_exe) = env::current_exe() {
         assert!(process::Command::new(current_exe)
+            .stdin(process::Stdio::null())
+            .stdout(process::Stdio::null())
+            .stderr(process::Stdio::null())
             .arg("--nofork")
             .args(env::args().skip(1))
             .spawn()


### PR DESCRIPTION
Previously, stdin/stdout/stderr would remain attached to the terminal, meaning the terminal session could not be closed until neovide was closed. This fixes #1122.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
