### PR TITLE
added option to enable font subpixel antialiasing

### DIFF
--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use lru::LruCache;
 use skia_safe::{font::Edging, Data, Font, FontHinting, FontMgr, FontStyle, Typeface};
 
-use crate::renderer::fonts::{font_options::FontOptions, swash_font::SwashFont};
+use crate::{
+    renderer::fonts::{font_options::FontOptions, swash_font::SwashFont},
+    settings::SETTINGS,
+    window::WindowSettings,
+};
 
 static DEFAULT_FONT: &[u8] = include_bytes!("../../../assets/fonts/FiraCode-Regular.ttf");
 static LAST_RESORT_FONT: &[u8] = include_bytes!("../../../assets/fonts/LastResort-Regular.ttf");
@@ -17,7 +21,13 @@ impl FontPair {
     fn new(mut skia_font: Font) -> Option<FontPair> {
         skia_font.set_subpixel(true);
         skia_font.set_hinting(FontHinting::Full);
-        skia_font.set_edging(Edging::AntiAlias);
+
+        let settings = SETTINGS.get::<WindowSettings>();
+        if settings.font_subpixel_antialiasing {
+            skia_font.set_edging(Edging::SubpixelAntiAlias);
+        } else {
+            skia_font.set_edging(Edging::AntiAlias);
+        };
 
         let (font_data, index) = skia_font.typeface().unwrap().to_font_data().unwrap();
         let swash_font = SwashFont::from_data(font_data, index)?;

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -10,6 +10,7 @@ pub struct WindowSettings {
     pub remember_window_size: bool,
     pub remember_window_position: bool,
     pub hide_mouse_when_typing: bool,
+    pub font_subpixel_antialiasing: bool,
 }
 
 impl Default for WindowSettings {
@@ -23,6 +24,7 @@ impl Default for WindowSettings {
             remember_window_size: true,
             remember_window_position: true,
             hide_mouse_when_typing: false,
+            font_subpixel_antialiasing: false,
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

## Other

I dont know if the default should be to leave it enabled as it was before or disabled. I copied the behaviour of current main branch, i.e., have it disabled by default.
The option is exposed as `g:neovide_font_subpixel_antialiasing` to make it clear that it does not concern cursor antialiasing.

Closes #1133 