### PR TITLE
Trim newlines from end of path on macOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,10 @@ fn handle_macos() {
             .arg(cmd)
             .output()
         {
-            env::set_var("PATH", std::str::from_utf8(&path.stdout).unwrap());
+            env::set_var(
+                "PATH",
+                std::str::from_utf8(&path.stdout).unwrap().trim_end(),
+            );
         }
     }
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Fix

## Did this PR introduce a breaking change? 
No

Fixes #1140