### PR TITLE
website: Move to neovide.dev

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://neovide.github.io/neovide"
+base_url = "https://neovide.dev"
 theme = "juice"
 
 # Whether to automatically compile all Sass files in the sass directory

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+neovide.dev


### PR DESCRIPTION
* Make Zola generate the website for the URL https://neovide.dev
* Create the CNAME file at the root of the static site, as GitHub Pages
  expects.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Other

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
