### PR TITLE
Fix floating windows transparency

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -106,13 +106,12 @@ impl GridRenderer {
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
 
-        if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON
-            && self.paint.color() == self.get_default_background()
-        {
+        // Only make background color transparent
+        if self.paint.color() == self.get_default_background() {
             if is_floating {
                 self.paint
                     .set_alpha((255.0 * SETTINGS.get::<RendererSettings>().floating_opacity) as u8);
-            } else {
+            } else if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON {
                 self.paint.set_alpha(0);
             }
         }

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -279,7 +279,7 @@ impl RenderedWindow {
         paint.set_color(default_background.with_a(a));
         root_canvas.draw_rect(pixel_region, &paint);
 
-        paint.set_color(Color::from_argb(a, 255, 255, 255));
+        paint.set_color(Color::from_argb(255, 255, 255, 255));
 
         let font_height = font_dimensions.height;
 


### PR DESCRIPTION
Floating windows were not rendered transparent with `neovide_transparency=1.0`.