### PR TITLE
Touch support (scrolling, click-by-tap, visual selection by dragging)

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -313,7 +313,7 @@ impl MouseManager {
                 // not updating the position would cause the movement to "escalate" from the
                 // starting point
                 if let Some(last_location) = self.touch_position.insert(finger_id, location) {
-                    let delta = (location.x - last_location.x, location.y - last_location.y);
+                    let delta = (last_location.x - location.x, location.y - last_location.y);
                     self.handle_pixel_scroll(font_size, delta, keyboard_manager);
                 }
             }

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -356,7 +356,7 @@ impl MouseManager {
                         }
                     }
 
-                    if self.dragging.is_some() {
+                    if self.dragging.is_some() || dragging_just_now {
                         self.handle_pointer_motion(
                             location.x.round() as i32,
                             location.y.round() as i32,

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -363,7 +363,7 @@ impl MouseManager {
                             keyboard_manager,
                             renderer,
                             windowed_context,
-                        )
+                        );
                     }
                     // the double check might seem useless, but the if branch above might set
                     // trace.left_deadzone_once - which urges to check again
@@ -380,6 +380,13 @@ impl MouseManager {
                 }
 
                 if dragging_just_now {
+                    self.handle_pointer_motion(
+                        location.x.round() as i32,
+                        location.y.round() as i32,
+                        keyboard_manager,
+                        renderer,
+                        windowed_context,
+                    );
                     self.handle_pointer_transition(&MouseButton::Left, true, keyboard_manager);
                 }
             }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -10,6 +10,7 @@ pub struct WindowSettings {
     pub remember_window_size: bool,
     pub remember_window_position: bool,
     pub hide_mouse_when_typing: bool,
+    pub touch_deadzone: f32,
 }
 
 impl Default for WindowSettings {
@@ -23,6 +24,7 @@ impl Default for WindowSettings {
             remember_window_size: true,
             remember_window_position: true,
             hide_mouse_when_typing: false,
+            touch_deadzone: 10.0, // TODO add to config docs
         }
     }
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -11,6 +11,7 @@ pub struct WindowSettings {
     pub remember_window_position: bool,
     pub hide_mouse_when_typing: bool,
     pub touch_deadzone: f32,
+    pub touch_drag_timeout: f32,
 }
 
 impl Default for WindowSettings {
@@ -24,7 +25,8 @@ impl Default for WindowSettings {
             remember_window_size: true,
             remember_window_position: true,
             hide_mouse_when_typing: false,
-            touch_deadzone: 10.0, // TODO add to config docs
+            touch_deadzone: 10.0,    // TODO add to config docs
+            touch_drag_timeout: 0.6, //
         }
     }
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -25,8 +25,8 @@ impl Default for WindowSettings {
             remember_window_size: true,
             remember_window_position: true,
             hide_mouse_when_typing: false,
-            touch_deadzone: 10.0,    // TODO add to config docs
-            touch_drag_timeout: 0.6, //
+            touch_deadzone: 6.0,
+            touch_drag_timeout: 0.17,
         }
     }
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature
  - Touch scrolling
  - Clicking by touch tapping
  - Creating a visual selection through touch dragging (hold down finger for a bit and move)

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, please list breaking changes
  - Touch input is actually handled now instead of ignored

This PR introduces general touch support (despite the branch name). From what I understood this has been supported in the past already, but was broken by a move to `sdl2` _and back to `winit`?_

While the new setting values (namely `touch_deadzone` and `touch_drag_timeout`) are undocumented yet, I'd be happy to do that in the `Wiki` tab, but I can't seem to edit there. It should probably belong to the `Input Settings` section though.