### PR TITLE
use u64 when register channel

### DIFF
--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -63,17 +63,13 @@ pub async fn setup_neovide_specific_state(nvim: &Neovim<TxWrapper>, is_remote: b
     }
 
     // Set details about the neovide version
+    let major = env!("CARGO_PKG_VERSION_MAJOR").parse::<u64>().unwrap_or(0);
+    let minor = env!("CARGO_PKG_VERSION_MINOR").parse::<u64>().unwrap_or(0);
     nvim.set_client_info(
         "neovide",
         vec![
-            (
-                Value::from("major"),
-                Value::from(env!("CARGO_PKG_VERSION_MAJOR")),
-            ),
-            (
-                Value::from("minor"),
-                Value::from(env!("CARGO_PKG_VERSION_MINOR")),
-            ),
+            (Value::from("major"), Value::from(major)),
+            (Value::from("minor"), Value::from(minor)),
         ],
         "ui",
         vec![],


### PR DESCRIPTION
Neovide parses the channel using struct `ClientVersion`, which requires a `u64`. This fixes remote channel used by #1003 and #1163.

Please merge this **before** testing the remote copy/paste.

https://github.com/neovide/neovide/blob/ab0394ae40a466c5e4c7c53fd4ece85fc52f0c24/src/bridge/events.rs#L307-L313

I was careless in #1161, and didn't parse as `u64`. I'm sorry.