### PR TITLE
Correctly apply opacity to floating windows

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -106,14 +106,14 @@ impl GridRenderer {
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
 
-        // Only make background color transparent
-        if self.paint.color() == self.get_default_background() {
-            if is_floating {
-                self.paint
-                    .set_alpha((255.0 * SETTINGS.get::<RendererSettings>().floating_opacity) as u8);
-            } else if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON {
-                self.paint.set_alpha(0);
-            }
+        if is_floating {
+            self.paint
+                .set_alpha((255.0 * SETTINGS.get::<RendererSettings>().floating_opacity) as u8);
+        } else if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON
+            // Only make background color transparent
+            && self.paint.color() == self.get_default_background()
+        {
+            self.paint.set_alpha(0);
         }
         canvas.draw_rect(region, &self.paint);
     }


### PR DESCRIPTION
Until now only `Normal guibg` color was made transparent. This isn't correct for floating windows. This PR fixes this.
(It will still work like this for non-floating windows, because IMO it looks better and I don't think there is a defined behavior for that. But it can still be up to debate).
