### PR TITLE
chore: Update glutin dependency to use neovide/winit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "glutin"
 version = "0.26.0"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#cf509674b403e0f90f2db41a084e303cbd90fbf5"
+source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "android_glue",
  "cgl",
@@ -921,13 +921,13 @@ dependencies = [
  "wayland-client",
  "wayland-egl",
  "winapi",
- "winit 0.24.0 (git+https://github.com/Kethku/winit?branch=new-keyboard-all)",
+ "winit",
 ]
 
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#cf509674b403e0f90f2db41a084e303cbd90fbf5"
+source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
  "winapi",
@@ -936,12 +936,12 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.1"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#cf509674b403e0f90f2db41a084e303cbd90fbf5"
+source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#cf509674b403e0f90f2db41a084e303cbd90fbf5"
+source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
  "objc",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.7"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#cf509674b403e0f90f2db41a084e303cbd90fbf5"
+source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
  "x11-dl",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#cf509674b403e0f90f2db41a084e303cbd90fbf5"
+source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
 ]
@@ -1367,7 +1367,7 @@ dependencies = [
  "unicode-segmentation",
  "which",
  "winapi",
- "winit 0.24.0 (git+https://github.com/neovide/winit?branch=new-keyboard-all)",
+ "winit",
  "winres",
  "xdg",
 ]
@@ -2604,42 +2604,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winit"
 version = "0.24.0"
-source = "git+https://github.com/Kethku/winit?branch=new-keyboard-all#fc49a506ed255059ccdb72885b5f525fb4ed2510"
-dependencies = [
- "bitflags",
- "cocoa",
- "core-foundation 0.9.2",
- "core-graphics 0.22.3",
- "core-video-sys",
- "dispatch",
- "instant",
- "lazy_static",
- "libc",
- "log",
- "memmap2 0.2.3",
- "mio",
- "mio-misc",
- "nameof",
- "ndk",
- "ndk-glue",
- "ndk-sys",
- "objc",
- "parking_lot 0.11.2",
- "percent-encoding",
- "raw-window-handle 0.3.4",
- "scopeguard",
- "serde",
- "smithay-client-toolkit",
- "unicode-segmentation",
- "wayland-client",
- "winapi",
- "x11-dl",
- "xkbcommon-dl",
-]
-
-[[package]]
-name = "winit"
-version = "0.24.0"
 source = "git+https://github.com/neovide/winit?branch=new-keyboard-all#fc49a506ed255059ccdb72885b5f525fb4ed2510"
 dependencies = [
  "bitflags",
@@ -2664,6 +2628,7 @@ dependencies = [
  "percent-encoding",
  "raw-window-handle 0.3.4",
  "scopeguard",
+ "serde",
  "smithay-client-toolkit",
  "unicode-segmentation",
  "wayland-client",


### PR DESCRIPTION
After merging this PR https://github.com/neovide/glutin/pull/1,
which changed dependency in glutin from Kethku/winit to neovide/winit
we need to update Cargo.lock here.

## What kind of change does this PR introduce?
- Other

## Did this PR introduce a breaking change? 
- No
