### PR TITLE
Address performance issue in font fallback

### DIFF
--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -31,7 +31,7 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
             quote! {{
                 fn update_func(value: rmpv::Value) {
                     let mut s = crate::settings::SETTINGS.get::<#name>();
-                    s.#ident.from_value(value);
+                    s.#ident.parse_from_value(value);
                     crate::settings::SETTINGS.set(&s);
                 }
 

--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -7,17 +7,17 @@ use clipboard::ClipboardProvider;
 
 pub fn get_remote_clipboard(format: Option<&str>) -> Result<Value, Box<dyn Error>> {
     let mut ctx: ClipboardContext = ClipboardProvider::new()?;
-    let clipboard_raw = ctx.get_contents()?.replace("\r", "");
+    let clipboard_raw = ctx.get_contents()?.replace('\r', "");
 
     let lines = if let Some("dos") = format {
         // add \r to lines of current file format is dos
-        clipboard_raw.replace("\n", "\r\n")
+        clipboard_raw.replace('\n', "\r\n")
     } else {
         // else, \r is stripped, leaving only \n
         clipboard_raw
     }
-    .split("\n")
-    .map(|line| Value::from(line))
+    .split('\n')
+    .map(Value::from)
     .collect::<Vec<Value>>();
 
     let lines = Value::from(lines);
@@ -45,7 +45,7 @@ pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<(), Box<dyn Error>>
         .map(|arr| {
             arr.iter()
                 .filter_map(|x| x.as_str().map(String::from))
-                .map(|s| s.replace("\r", "")) // strip \r
+                .map(|s| s.replace('\r', "")) // strip \r
                 .collect::<Vec<String>>()
                 .join(endline)
         })

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -49,7 +49,7 @@ impl Handler for NeovimHandler {
                     });
 
                 get_remote_clipboard(endline_type.as_deref())
-                    .or(Err(Value::from("cannot get remote clipboard content")))
+                    .map_err(|_| Value::from("cannot get remote clipboard content"))
             }
             _ => Ok(Value::from("rpcrequest not handled")),
         }

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -42,7 +42,7 @@ pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<TxWrapper>, neovide_ch
           'cache_enabled': 0
         }
         "#
-    .replace("\n", "") // make one-liner, because multiline is not accepted (?)
+    .replace('\n', "") // make one-liner, because multiline is not accepted (?)
     .replace("neovide_channel", &neovide_channel.to_string());
     nvim.command(&custom_clipboard).await.ok();
 }

--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -48,8 +48,8 @@ pub enum VfxMode {
     Disabled,
 }
 
-impl FromValue for VfxMode {
-    fn from_value(&mut self, value: Value) {
+impl ParseFromValue for VfxMode {
+    fn parse_from_value(&mut self, value: Value) {
         if value.is_str() {
             *self = match value.as_str().unwrap() {
                 "sonicboom" => VfxMode::Highlight(HighlightMode::SonicBoom),

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     redraw_scheduler::REDRAW_SCHEDULER,
     renderer::animation_utils::*,
     renderer::{GridRenderer, RenderedWindow},
-    settings::{FromValue, SETTINGS},
+    settings::{ParseFromValue, SETTINGS},
 };
 
 use blink::*;

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -3,13 +3,8 @@ use std::sync::Arc;
 use log::{trace, warn};
 use lru::LruCache;
 use skia_safe::{
-    graphics::{
-        font_cache_used,
-        font_cache_limit,
-        set_font_cache_limit,
-    },
-    TextBlob, 
-    TextBlobBuilder,
+    graphics::{font_cache_limit, font_cache_used, set_font_cache_limit},
+    TextBlob, TextBlobBuilder,
 };
 use swash::{
     shape::ShapeContext,
@@ -56,16 +51,17 @@ impl CachingShaper {
     }
 
     fn current_font_pair(&mut self) -> Arc<FontPair> {
-        let default_key = FontKey::default();
-        let font_key = FontKey::from(&self.options);
-
-        if let Some(font_pair) = self.font_loader.get_or_load(&font_key) {
-            return font_pair;
-        }
-
         self.font_loader
-            .get_or_load(&default_key)
-            .expect("Could not load font")
+            .get_or_load(&FontKey {
+                bold: false,
+                italic: false,
+                family_name: self.options.primary_font(),
+            })
+            .unwrap_or_else(|| {
+                self.font_loader
+                    .get_or_load(&FontKey::default())
+                    .expect("Could not load default font")
+            })
     }
 
     pub fn current_size(&self) -> f32 {
@@ -82,7 +78,11 @@ impl CachingShaper {
         trace!("Updating font: {}", guifont_setting);
 
         let options = FontOptions::parse(guifont_setting);
-        let font_key = FontKey::from(&options);
+        let font_key = FontKey {
+            bold: false,
+            italic: false,
+            family_name: options.primary_font(),
+        };
 
         if self.font_loader.get_or_load(&font_key).is_some() {
             trace!("Font updated to: {}", guifont_setting);
@@ -202,32 +202,20 @@ impl CachingShaper {
             font_fallback_keys.extend(self.options.font_list.iter().map(|font_name| FontKey {
                 italic: self.options.italic || italic,
                 bold: self.options.bold || bold,
-                font_selection: font_name.into(),
+                family_name: Some(font_name.clone()),
             }));
 
             // Add default font
             font_fallback_keys.push(FontKey {
                 italic: self.options.italic || italic,
                 bold: self.options.bold || bold,
-                font_selection: FontSelection::Default,
+                family_name: None,
             });
 
-            // Add skia fallback
-            font_fallback_keys.push(FontKey {
-                italic,
-                bold,
-                font_selection: cluster.chars()[0].ch.into(),
-            });
-
-            // Add last resort
-            font_fallback_keys.push(FontKey {
-                italic: false,
-                bold: false,
-                font_selection: FontSelection::LastResort,
-            });
+            // Use the cluster.map function to select a viable font from the fallback list and loaded fonts
 
             let mut best = None;
-            // Use the cluster.map function to select a viable font from the fallback list
+            // Search through the configured and default fonts for a match
             for fallback_key in font_fallback_keys.iter() {
                 if let Some(font_pair) = self.font_loader.get_or_load(fallback_key) {
                     let charmap = font_pair.swash_font.as_ref().charmap();
@@ -242,9 +230,36 @@ impl CachingShaper {
                 }
             }
 
+            // Configured font/default didn't work. Search through currently loaded ones
+            for loaded_font in self.font_loader.loaded_fonts() {
+                let charmap = loaded_font.swash_font.as_ref().charmap();
+                match cluster.map(|ch| charmap.map(ch)) {
+                    Status::Complete => {
+                        results.push((cluster.to_owned(), loaded_font.clone()));
+                        self.font_loader.refresh(loaded_font.as_ref());
+                        continue 'cluster;
+                    }
+                    Status::Keep => best = Some(loaded_font),
+                    Status::Discard => {}
+                }
+            }
+
             if let Some(best) = best {
-                // Last Resort covers all of the unicode space so we will always have a fallback
                 results.push((cluster.to_owned(), best.clone()));
+            } else {
+                let fallback_character = cluster.chars()[0].ch;
+                if let Some(fallback_font) =
+                    self.font_loader
+                        .load_font_for_character(bold, italic, fallback_character)
+                {
+                    results.push((cluster.to_owned(), fallback_font));
+                } else {
+                    // Last Resort covers all of the unicode space so we will always have a fallback
+                    results.push((
+                        cluster.to_owned(),
+                        self.font_loader.get_or_load_last_resort(),
+                    ));
+                }
             }
         }
 

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -1,5 +1,3 @@
-use super::font_loader::FontSelection;
-
 const DEFAULT_FONT_SIZE: f32 = 14.0;
 
 #[derive(Clone, Debug)]
@@ -51,11 +49,8 @@ impl FontOptions {
         }
     }
 
-    pub fn primary_font(&self) -> FontSelection {
-        self.font_list
-            .first()
-            .map(FontSelection::from)
-            .unwrap_or(FontSelection::Default)
+    pub fn primary_font(&self) -> Option<String> {
+        self.font_list.first().cloned()
     }
 }
 

--- a/src/settings/from_value.rs
+++ b/src/settings/from_value.rs
@@ -4,13 +4,13 @@ use log::error;
 // Trait to allow for conversion from rmpv::Value to any other data type.
 // Note: Feel free to implement this trait for custom types in each subsystem.
 // The reverse conversion (MyType->Value) can be performed by implementing `From<MyType> for Value`
-pub trait FromValue {
-    fn from_value(&mut self, value: Value);
+pub trait ParseFromValue {
+    fn parse_from_value(&mut self, value: Value);
 }
 
 // FromValue implementations for most typical types
-impl FromValue for f32 {
-    fn from_value(&mut self, value: Value) {
+impl ParseFromValue for f32 {
+    fn parse_from_value(&mut self, value: Value) {
         if value.is_f64() {
             *self = value.as_f64().unwrap() as f32;
         } else if value.is_i64() {
@@ -23,8 +23,8 @@ impl FromValue for f32 {
     }
 }
 
-impl FromValue for u64 {
-    fn from_value(&mut self, value: Value) {
+impl ParseFromValue for u64 {
+    fn parse_from_value(&mut self, value: Value) {
         if value.is_u64() {
             *self = value.as_u64().unwrap();
         } else {
@@ -33,8 +33,8 @@ impl FromValue for u64 {
     }
 }
 
-impl FromValue for u32 {
-    fn from_value(&mut self, value: Value) {
+impl ParseFromValue for u32 {
+    fn parse_from_value(&mut self, value: Value) {
         if value.is_u64() {
             *self = value.as_u64().unwrap() as u32;
         } else {
@@ -43,8 +43,8 @@ impl FromValue for u32 {
     }
 }
 
-impl FromValue for i32 {
-    fn from_value(&mut self, value: Value) {
+impl ParseFromValue for i32 {
+    fn parse_from_value(&mut self, value: Value) {
         if value.is_i64() {
             *self = value.as_i64().unwrap() as i32;
         } else {
@@ -53,8 +53,8 @@ impl FromValue for i32 {
     }
 }
 
-impl FromValue for String {
-    fn from_value(&mut self, value: Value) {
+impl ParseFromValue for String {
+    fn parse_from_value(&mut self, value: Value) {
         if value.is_str() {
             *self = String::from(value.as_str().unwrap());
         } else {
@@ -63,8 +63,8 @@ impl FromValue for String {
     }
 }
 
-impl FromValue for bool {
-    fn from_value(&mut self, value: Value) {
+impl ParseFromValue for bool {
+    fn parse_from_value(&mut self, value: Value) {
         if value.is_bool() {
             *self = value.as_bool().unwrap();
         } else if value.is_u64() {
@@ -81,7 +81,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_from_value_f32() {
+    fn test_parse_from_value_f32() {
         let mut v0: f32 = 0.0;
         let v1 = Value::from(1.0);
         let v2 = Value::from(-1);
@@ -90,76 +90,76 @@ mod tests {
         let v2p = -1.0;
         let v3p = std::u64::MAX as f32;
 
-        v0.from_value(v1);
+        v0.parse_from_value(v1);
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
-        v0.from_value(v2);
+        v0.parse_from_value(v2);
         assert_eq!(v0, v2p, "v0 should equal {} but is actually {}", v2p, v0);
-        v0.from_value(v3);
+        v0.parse_from_value(v3);
         assert_eq!(v0, v3p, "v0 should equal {} but is actually {}", v3p, v0);
 
         // This is a noop and prints an error
-        v0.from_value(Value::from("asd"));
+        v0.parse_from_value(Value::from("asd"));
         assert_eq!(v0, v3p, "v0 should equal {} but is actually {}", v3p, v0);
     }
 
     #[test]
-    fn test_from_value_u64() {
+    fn test_parse_from_value_u64() {
         let mut v0: u64 = 0;
         let v1 = Value::from(std::u64::MAX);
         let v1p = std::u64::MAX;
 
-        v0.from_value(v1);
+        v0.parse_from_value(v1);
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
 
         // This is a noop and prints an error
-        v0.from_value(Value::from(-1));
+        v0.parse_from_value(Value::from(-1));
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
     }
 
     #[test]
-    fn test_from_value_u32() {
+    fn test_parse_from_value_u32() {
         let mut v0: u32 = 0;
         let v1 = Value::from(std::u64::MAX);
         let v1p = std::u64::MAX as u32;
 
-        v0.from_value(v1);
+        v0.parse_from_value(v1);
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
 
         // This is a noop and prints an error
-        v0.from_value(Value::from(-1));
+        v0.parse_from_value(Value::from(-1));
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
     }
 
     #[test]
-    fn test_from_value_i32() {
+    fn test_parse_from_value_i32() {
         let mut v0: i32 = 0;
         let v1 = Value::from(std::i64::MAX);
         let v1p = std::i64::MAX as i32;
 
-        v0.from_value(v1);
+        v0.parse_from_value(v1);
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
 
         // This is a noop and prints an error
-        v0.from_value(Value::from(-1));
+        v0.parse_from_value(Value::from(-1));
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
     }
 
     #[test]
-    fn test_from_value_string() {
+    fn test_parse_from_value_string() {
         let mut v0: String = "foo".to_string();
         let v1 = Value::from("bar");
         let v1p = "bar";
 
-        v0.from_value(v1);
+        v0.parse_from_value(v1);
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
 
         // This is a noop and prints an error
-        v0.from_value(Value::from(-1));
+        v0.parse_from_value(Value::from(-1));
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
     }
 
     #[test]
-    fn test_from_value_bool() {
+    fn test_parse_from_value_bool() {
         let mut v0: bool = false;
         let v1 = Value::from(true);
         let v1p = true;
@@ -168,15 +168,15 @@ mod tests {
         let v3 = Value::from(1);
         let v3p = true;
 
-        v0.from_value(v1);
+        v0.parse_from_value(v1);
         assert_eq!(v0, v1p, "v0 should equal {} but is actually {}", v1p, v0);
-        v0.from_value(v2);
+        v0.parse_from_value(v2);
         assert_eq!(v0, v2p, "v0 should equal {} but is actually {}", v2p, v0);
-        v0.from_value(v3);
+        v0.parse_from_value(v3);
         assert_eq!(v0, v3p, "v0 should equal {} but is actually {}", v3p, v0);
 
         // This is a noop and prints an error
-        v0.from_value(Value::from(-1));
+        v0.parse_from_value(Value::from(-1));
         assert_eq!(v0, v3p, "v0 should equal {} but is actually {}", v3p, v0);
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use crate::{bridge::TxWrapper, error_handling::ResultPanicExplanation};
-pub use from_value::FromValue;
+pub use from_value::ParseFromValue;
 pub use window_geometry::{
     load_last_window_settings, parse_window_geometry, save_window_geometry,
     PersistentWindowSettings, DEFAULT_WINDOW_GEOMETRY,


### PR DESCRIPTION
Before, a new font was constructed for every character not found in the configured fonts. Now, the system will loop over the loaded fonts after not finding a matching font.

Also reworks the font loader to only store fonts based on font name to encourage this architecture moving forward.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
