### PR TITLE
attach and detach the windows console

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -203,7 +203,6 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
     Ok(())
 }
 
-
 #[cfg(target_os = "windows")]
 fn windows_attach_to_console() {
     // Attach to parent console tip found here: https://github.com/rust-lang/rust/issues/67159#issuecomment-987882771

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -143,7 +143,6 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
                 .help("Specify an X11 WM class"),
         );
 
-    windows_attach_to_console();
     let matches = clapp.get_matches_from(args);
     let mut neovim_args: Vec<String> = matches
         .values_of("neovim_args")
@@ -155,7 +154,6 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
     );
-    windows_detach_from_console();
 
     /*
      * Integrate Environment Variables as Defaults to the command-line ones.
@@ -201,23 +199,6 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
             .unwrap_or_else(|| "neovide".to_owned()),
     });
     Ok(())
-}
-
-#[cfg(target_os = "windows")]
-fn windows_attach_to_console() {
-    // Attach to parent console tip found here: https://github.com/rust-lang/rust/issues/67159#issuecomment-987882771
-    use winapi::um::wincon::{AttachConsole, ATTACH_PARENT_PROCESS};
-    unsafe {
-        AttachConsole(ATTACH_PARENT_PROCESS);
-    }
-}
-
-#[cfg(target_os = "windows")]
-fn windows_detach_from_console() {
-    use winapi::um::wincon::FreeConsole;
-    unsafe {
-        FreeConsole();
-    }
 }
 
 #[cfg(test)]

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -143,6 +143,7 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
                 .help("Specify an X11 WM class"),
         );
 
+    windows_attach_to_console();
     let matches = clapp.get_matches_from(args);
     let mut neovim_args: Vec<String> = matches
         .values_of("neovim_args")
@@ -154,6 +155,7 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
     );
+    windows_detach_from_console();
 
     /*
      * Integrate Environment Variables as Defaults to the command-line ones.
@@ -199,6 +201,24 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
             .unwrap_or_else(|| "neovide".to_owned()),
     });
     Ok(())
+}
+
+
+#[cfg(target_os = "windows")]
+fn windows_attach_to_console() {
+    // Attach to parent console tip found here: https://github.com/rust-lang/rust/issues/67159#issuecomment-987882771
+    use winapi::um::wincon::{AttachConsole, ATTACH_PARENT_PROCESS};
+    unsafe {
+        AttachConsole(ATTACH_PARENT_PROCESS);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_detach_from_console() {
+    use winapi::um::wincon::FreeConsole;
+    unsafe {
+        FreeConsole();
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ mod renderer;
 mod running_tracker;
 mod settings;
 mod window;
+
+#[cfg(target_os = "windows")]
 mod windows_utils;
 
 #[macro_use]
@@ -45,6 +47,7 @@ use window::{create_window, KeyboardSettings, WindowSettings};
 pub use channel_utils::*;
 pub use event_aggregator::*;
 pub use running_tracker::*;
+#[cfg(target_os = "windows")]
 pub use windows_utils::*;
 
 fn main() {
@@ -113,6 +116,9 @@ fn main() {
     //   Multiple other parts of the app "queue_next_frame" function to ensure animations continue
     //   properly or updates to the graphics are pushed to the screen.
 
+    #[cfg(target_os = "windows")]
+    windows_attach_to_console();
+
     //Will exit if -h or -v
     if let Err(err) = cmd_line::handle_command_line_arguments(args().collect()) {
         eprintln!("{}", err);
@@ -168,6 +174,9 @@ fn maybe_disown() {
         return;
     }
 
+    #[cfg(target_os = "windows")]
+    windows_detach_from_console();
+
     if let Ok(current_exe) = env::current_exe() {
         assert!(process::Command::new(current_exe)
             .stdin(process::Stdio::null())
@@ -183,11 +192,3 @@ fn maybe_disown() {
     }
 }
 
-#[cfg(target_os = "windows")]
-fn windows_fix_dpi() {
-    use winapi::shared::windef::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
-    use winapi::um::winuser::SetProcessDpiAwarenessContext;
-    unsafe {
-        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,4 +191,3 @@ fn maybe_disown() {
         eprintln!("error in disowning process, cannot obtain the path for the current executable, continuing without disowning...");
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,8 +113,8 @@ fn main() {
     //   Multiple other parts of the app "queue_next_frame" function to ensure animations continue
     //   properly or updates to the graphics are pushed to the screen.
 
-    #[cfg(target_os = "windows")]
-    windows_attach_to_console();
+    // #[cfg(target_os = "windows")]
+    // windows_attach_to_console();
 
     //Will exit if -h or -v
     if let Err(err) = cmd_line::handle_command_line_arguments(args().collect()) {
@@ -192,14 +192,5 @@ fn windows_fix_dpi() {
     use winapi::um::winuser::SetProcessDpiAwarenessContext;
     unsafe {
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-    }
-}
-
-#[cfg(target_os = "windows")]
-fn windows_attach_to_console() {
-    // Attach to parent console tip found here: https://github.com/rust-lang/rust/issues/67159#issuecomment-987882771
-    use winapi::um::wincon::{AttachConsole, ATTACH_PARENT_PROCESS};
-    unsafe {
-        AttachConsole(ATTACH_PARENT_PROCESS);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,9 +113,6 @@ fn main() {
     //   Multiple other parts of the app "queue_next_frame" function to ensure animations continue
     //   properly or updates to the graphics are pushed to the screen.
 
-    // #[cfg(target_os = "windows")]
-    // windows_attach_to_console();
-
     //Will exit if -h or -v
     if let Err(err) = cmd_line::handle_command_line_arguments(args().collect()) {
         eprintln!("{}", err);

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -6,7 +6,7 @@ use std::{
 use winapi::{
     shared::{
         minwindef::{DWORD, HKEY, MAX_PATH},
-        windef::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+        windef::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
     },
     um::{
         libloaderapi::GetModuleFileNameA,

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -1,21 +1,22 @@
-#[cfg(target_os = "windows")]
 use std::{
     ffi::CString,
     ptr::{null, null_mut},
 };
 
-#[cfg(windows)]
 use winapi::{
-    shared::minwindef::{DWORD, HKEY, MAX_PATH},
+    shared::{
+        minwindef::{DWORD, HKEY, MAX_PATH},
+        windef::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+    },
     um::{
         libloaderapi::GetModuleFileNameA,
-        wincon::{AttachConsole, ATTACH_PARENT_PROCESS},
+        wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS},
         winnt::{KEY_WRITE, REG_OPTION_NON_VOLATILE, REG_SZ},
         winreg::{RegCloseKey, RegCreateKeyExA, RegDeleteTreeA, RegSetValueExA, HKEY_CURRENT_USER},
+        winuser::SetProcessDpiAwarenessContext,
     },
 };
 
-#[cfg(target_os = "windows")]
 fn get_binary_path() -> String {
     let mut buffer = vec![0u8; MAX_PATH];
     unsafe {
@@ -32,7 +33,6 @@ fn get_binary_path() -> String {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn unregister_rightclick() -> bool {
     let str_registry_path_1 =
         CString::new("Software\\Classes\\Directory\\Background\\shell\\Neovide").unwrap();
@@ -44,7 +44,6 @@ pub fn unregister_rightclick() -> bool {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn register_rightclick_directory() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();
@@ -133,7 +132,6 @@ pub fn register_rightclick_directory() -> bool {
     true
 }
 
-#[cfg(target_os = "windows")]
 pub fn register_rightclick_file() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();
@@ -221,9 +219,21 @@ pub fn register_rightclick_file() -> bool {
     true
 }
 
-pub fn attach_parent_console() {
-    #[cfg(target_os = "windows")]
+pub fn windows_fix_dpi() {
+    unsafe {
+        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    }
+}
+
+pub fn windows_attach_to_console() {
+    // Attach to parent console tip found here: https://github.com/rust-lang/rust/issues/67159#issuecomment-987882771
     unsafe {
         AttachConsole(ATTACH_PARENT_PROCESS);
+    }
+}
+
+pub fn windows_detach_from_console() {
+    unsafe {
+        FreeConsole();
     }
 }


### PR DESCRIPTION
Fixes issue where app is still parented to the parent console and closed when that console closes on windows.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
