### PR TITLE
feat: Allow float font sizes if requested

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -94,25 +94,28 @@ impl CachingShaper {
     }
 
     fn reset_font_loader(&mut self) {
-        // Calculate the new fudge factor required to scale the font width to the nearest exact pixel
-        // NOTE: This temporarily loads the font without any fudge factor, since the interface
-        // needs a size and we don't know the exact one until it's calculated.
         self.fudge_factor = 1.0;
         let mut font_size = self.current_size();
         debug!("Original font_size: {:.2}px", font_size);
-        self.font_loader = FontLoader::new(font_size);
-        let (metrics, font_width) = self.info();
-        debug!(
-            "Font width: {:.2}px (avg: {:.2}px)",
-            font_width, metrics.average_width
-        );
-        self.fudge_factor = font_width.round() / font_width;
-        debug!("Fudge factor: {:.2}", self.fudge_factor);
-        font_size = self.current_size();
-        debug!("Fudged font size: {:.2}px", font_size);
-        debug!("Fudged font width: {:.2}px", self.info().1);
 
         self.font_loader = FontLoader::new(font_size);
+        let (metrics, font_width) = self.info();
+
+        debug!("Original font_width: {:.2}px", font_width);
+
+        if !self.options.allow_float_size {
+            // Calculate the new fudge factor required to scale the font width to the nearest exact pixel
+            debug!(
+                "Font width: {:.2}px (avg: {:.2}px)",
+                font_width, metrics.average_width
+            );
+            self.fudge_factor = font_width.round() / font_width;
+            debug!("Fudge factor: {:.2}", self.fudge_factor);
+            font_size = self.current_size();
+            debug!("Fudged font size: {:.2}px", font_size);
+            debug!("Fudged font width: {:.2}px", self.info().1);
+            self.font_loader = FontLoader::new(font_size);
+        }
         self.blob_cache.clear();
     }
 

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -6,6 +6,7 @@ pub struct FontOptions {
     pub size: f32,
     pub bold: bool,
     pub italic: bool,
+    pub allow_float_size: bool,
 }
 
 impl FontOptions {
@@ -14,6 +15,7 @@ impl FontOptions {
         let mut size = DEFAULT_FONT_SIZE;
         let mut bold = false;
         let mut italic = false;
+        let mut allow_float_size = false;
 
         let mut parts = guifont_setting.split(':').filter(|part| !part.is_empty());
 
@@ -31,6 +33,9 @@ impl FontOptions {
 
         for part in parts {
             if part.starts_with('h') && part.len() > 1 {
+                if part.contains('.') {
+                    allow_float_size = true;
+                }
                 if let Ok(parsed_size) = part[1..].parse::<f32>() {
                     size = parsed_size
                 }
@@ -45,6 +50,7 @@ impl FontOptions {
             font_list,
             bold,
             italic,
+            allow_float_size,
             size: points_to_pixels(size),
         }
     }
@@ -60,6 +66,7 @@ impl Default for FontOptions {
             font_list: Vec::new(),
             bold: false,
             italic: false,
+            allow_float_size: false,
             size: points_to_pixels(DEFAULT_FONT_SIZE),
         }
     }


### PR DESCRIPTION
To use float font size, define it with dot, example:

monospace:h11 - uses integer size
monospace:h11.0 - uses float font size

---

This adds optional support for float font sizes.

- https://github.com/neovide/neovide/pull/1116#pullrequestreview-862861964

This PR has broken my ideal font size, so i'm adding this as a fix.

It should work seamlessly for anyone, if someone wants integer fonts - with default syntax `h11` gives integer scaling, with `h11.0` fonts will not use fudging.

---

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No
