### PR TITLE
fix: Fix opening files on linux

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -115,7 +115,7 @@ fn build_nvim_cmd_with_args(bin: &str) -> TokioCommand {
         cmd
     } else {
         let mut cmd = TokioCommand::new(bin);
-        cmd.arg(args_str);
+        cmd.args(args);
         cmd
     }
 }


### PR DESCRIPTION
I don't know how about other OS where you using SHELL, but on linux you should
pass arguments like this, or this happens:
```
[src/bridge/command.rs:26] cmd = Command {
    std: "/usr/bin/nvim" "--embed README.md",
    kill_on_drop: false,
}
nvim: Unknown option argument: "--embed README.md"
```
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
