### PR TITLE
Fix modifiers behaviour under X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "glutin"
 version = "0.26.0"
+source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
 dependencies = [
  "android_glue",
  "cgl",
@@ -926,6 +927,7 @@ dependencies = [
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.5"
+source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
 dependencies = [
  "gl_generator",
  "winapi",
@@ -934,10 +936,12 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.1"
+source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.5"
+source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
 dependencies = [
  "gl_generator",
  "objc",
@@ -946,6 +950,7 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.7"
+source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
 dependencies = [
  "gl_generator",
  "x11-dl",
@@ -954,6 +959,7 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.5"
+source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
 dependencies = [
  "gl_generator",
 ]
@@ -2598,6 +2604,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winit"
 version = "0.24.0"
+source = "git+https://github.com/neovide/winit?branch=fix-stuck-shift#0899a3db69c14cecb9507829a9e612a015940cbf"
 dependencies = [
  "bitflags",
  "cocoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,8 +909,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "glutin"
-version = "0.26.0"
-source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
+version = "0.27.0"
+source = "git+https://github.com/neovide/glutin?branch=neovide-x11-nt#e449e13b6bee62acac8a988c38ee4ac12d540fd6"
 dependencies = [
  "android_glue",
  "cgl",
@@ -922,12 +931,13 @@ dependencies = [
  "wayland-egl",
  "winapi",
  "winit",
+ "x11-dl",
 ]
 
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
+source = "git+https://github.com/neovide/glutin?branch=neovide-x11-nt#e449e13b6bee62acac8a988c38ee4ac12d540fd6"
 dependencies = [
  "gl_generator",
  "winapi",
@@ -936,12 +946,12 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.1"
-source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
+source = "git+https://github.com/neovide/glutin?branch=neovide-x11-nt#e449e13b6bee62acac8a988c38ee4ac12d540fd6"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
+source = "git+https://github.com/neovide/glutin?branch=neovide-x11-nt#e449e13b6bee62acac8a988c38ee4ac12d540fd6"
 dependencies = [
  "gl_generator",
  "objc",
@@ -950,7 +960,7 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.7"
-source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
+source = "git+https://github.com/neovide/glutin?branch=neovide-x11-nt#e449e13b6bee62acac8a988c38ee4ac12d540fd6"
 dependencies = [
  "gl_generator",
  "x11-dl",
@@ -959,7 +969,7 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=fix-stuck-shift#66207be03c506721ff2c77b691ff0de3aa4d3d2c"
+source = "git+https://github.com/neovide/glutin?branch=neovide-x11-nt#e449e13b6bee62acac8a988c38ee4ac12d540fd6"
 dependencies = [
  "gl_generator",
 ]
@@ -1054,6 +1064,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "isnt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7558cc96ddcaf0b4144d7149984ace2899bb29d4ee2999979d429efc305200"
 
 [[package]]
 name = "itoa"
@@ -2604,7 +2620,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winit"
 version = "0.24.0"
-source = "git+https://github.com/neovide/winit?branch=fix-stuck-shift#d8715b1d14ce052a6f6b7f46508a4bfdf7fe601f"
+source = "git+https://github.com/neovide/winit?branch=neovide-x11-nt#6f91c74bcb115eaa5a49882d8d6e4c8be2bfa8de"
 dependencies = [
  "bitflags",
  "cocoa",
@@ -2630,10 +2646,13 @@ dependencies = [
  "scopeguard",
  "serde",
  "smithay-client-toolkit",
+ "thiserror",
  "unicode-segmentation",
  "wayland-client",
  "winapi",
  "x11-dl",
+ "xcb-dl",
+ "xcb-dl-util",
  "xkbcommon-dl",
 ]
 
@@ -2686,6 +2705,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcb-dl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce37e57249f12cbdf43844a3c9b3162f528ec27a1dc1dd7c6f46826063f51e8"
+dependencies = [
+ "libc",
+ "libloading 0.7.2",
+]
+
+[[package]]
+name = "xcb-dl-util"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac09222229087f380311b876bf8651de4cfe78cf793ef8702932a81385c0f400"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "byteorder",
+ "isnt",
+ "libc",
+ "log",
+ "smallvec",
+ "thiserror",
+ "xcb-dl",
+]
+
+[[package]]
 name = "xcursor"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,13 +2752,12 @@ dependencies = [
 [[package]]
 name = "xkbcommon-dl"
 version = "0.1.0"
-source = "git+https://github.com/maroider/xkbcommon-dl?rev=900832888ad6f11011d1369befb344a9aa8a9610#900832888ad6f11011d1369befb344a9aa8a9610"
+source = "git+https://github.com/mahkoh/xkbcommon-dl?rev=dd6a9033b1e45a2668700f14c2d47e48aeb3194f#dd6a9033b1e45a2668700f14c2d47e48aeb3194f"
 dependencies = [
  "bitflags",
  "dlib 0.5.0",
  "lazy_static",
  "log",
- "x11-dl",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,6 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "glutin"
 version = "0.26.0"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "android_glue",
  "cgl",
@@ -927,7 +926,6 @@ dependencies = [
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
  "winapi",
@@ -936,12 +934,10 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.1"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
  "objc",
@@ -950,7 +946,6 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.7"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
  "x11-dl",
@@ -959,7 +954,6 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.5"
-source = "git+https://github.com/neovide/glutin?branch=new-keyboard-all#7c313d91584492961b9efab0d611e35b977c0fea"
 dependencies = [
  "gl_generator",
 ]
@@ -2604,7 +2598,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winit"
 version = "0.24.0"
-source = "git+https://github.com/neovide/winit?branch=new-keyboard-all#fc49a506ed255059ccdb72885b5f525fb4ed2510"
 dependencies = [
  "bitflags",
  "cocoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,7 +2604,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winit"
 version = "0.24.0"
-source = "git+https://github.com/neovide/winit?branch=fix-stuck-shift#0899a3db69c14cecb9507829a9e612a015940cbf"
+source = "git+https://github.com/neovide/winit?branch=fix-stuck-shift#d8715b1d14ce052a6f6b7f46508a4bfdf7fe601f"
 dependencies = [
  "bitflags",
  "cocoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ dirs = "2"
 rand = "0.7"
 pin-project = "0.4.27"
 futures = "0.3.12"
-glutin = { path = "/home/serg/src/glutin/glutin", features=["serde"] }
-winit = { path = "/home/serg/src/winit/" }
+glutin = { git = "https://github.com/neovide/glutin", branch = "fix-stuck-shift", features=["serde"] }
+winit = { git = "https://github.com/neovide/winit", branch = "fix-stuck-shift" }
 gl = "0.14.0"
 swash = "0.1.4"
 clap="2.33.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,19 @@ dirs = "2"
 rand = "0.7"
 pin-project = "0.4.27"
 futures = "0.3.12"
-glutin = { git = "https://github.com/neovide/glutin", branch = "fix-stuck-shift", features=["serde"] }
-winit = { git = "https://github.com/neovide/winit", branch = "fix-stuck-shift" }
+# We're using our own forks for winit and glutin,
+# to fix some keyboard-related issues.
+# This PR resolves issues with modifiers behaviour under X11
+# and currenctly our glutin#neovide-x11-nt is based on it.
+# https://github.com/maroider/winit/pull/6
+# Previouse PR should be merged into next one:
+# https://github.com/rust-windowing/winit/pull/1932
+# And after this one is merged, we can use official versions.
+winit = { git = "https://github.com/neovide/winit", branch = "neovide-x11-nt" }
+# glutin is using this branch https://github.com/mahkoh/glutin/tree/x11-nt
+# with added small patch to support KeyEvent.text_with_all_modifiers
+# After it's merged upstream we should make PR with this small change.
+glutin = { git = "https://github.com/neovide/glutin", branch = "neovide-x11-nt", features=["serde"] }
 gl = "0.14.0"
 swash = "0.1.4"
 clap="2.33.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ dirs = "2"
 rand = "0.7"
 pin-project = "0.4.27"
 futures = "0.3.12"
-glutin = { git = "https://github.com/neovide/glutin", branch = "new-keyboard-all", features=["serde"] }
-winit = { git = "https://github.com/neovide/winit", branch = "new-keyboard-all" }
+glutin = { path = "/home/serg/src/glutin/glutin", features=["serde"] }
+winit = { path = "/home/serg/src/winit/" }
 gl = "0.14.0"
 swash = "0.1.4"
 clap="2.33.3"

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -9,6 +9,7 @@ use glutin::{
     keyboard::{Key, Key::Dead},
     platform::modifier_supplement::KeyEventExtModifierSupplement,
 };
+use log::info;
 
 enum InputEvent {
     KeyEvent(KeyEvent),
@@ -76,6 +77,7 @@ impl KeyboardManager {
                 self.ctrl = modifiers.control_key();
                 self.alt = modifiers.alt_key();
                 self.logo = modifiers.super_key();
+                info!("mods: {:?}", modifiers,);
             }
             Event::MainEventsCleared => {
                 // If the window wasn't just focused.
@@ -88,6 +90,10 @@ impl KeyboardManager {
                                 // And a key was pressed
                                 if key_event.state == ElementState::Pressed {
                                     if let Some(keybinding) = self.maybe_get_keybinding(key_event) {
+                                        info!(
+                                            "{} shift: {}, ctrl: {}, alt: {}, logo: {}",
+                                            keybinding, self.shift, self.ctrl, self.alt, self.logo
+                                        );
                                         EVENT_AGGREGATOR.send(UiCommand::Serial(
                                             SerialCommand::Keyboard(keybinding),
                                         ));


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

----

This should fix following issues:

- https://github.com/neovide/neovide/issues/951
- https://github.com/neovide/neovide/issues/1142
- https://github.com/neovide/neovide/issues/942

And, i think, most linux keyboard-related issues on x11.
----

Instead of merging new fixes into `new-keyboard-all`, i created `neovide-x11-nt` for both glutin and neovide, based on this: https://github.com/maroider/winit/pull/6

@Kethku if you remember what else was merged into `new-keyboard-all`, i could check if we still need it, and merge into those new branches.

But, it builds, it works, and i've used it without problems for a day.

My main concern here is not to break something on MacOS/Windows.