### PR TITLE
feat: add support for blend=100

### DIFF
--- a/src/editor/cursor.rs
+++ b/src/editor/cursor.rs
@@ -80,6 +80,13 @@ impl Cursor {
             .unwrap_or_else(|| default_colors.foreground.unwrap())
     }
 
+    pub fn blend_is_hide(&self) -> bool {
+        self.style
+            .as_ref()
+            .map(|s| s.blend == 100)
+            .unwrap_or(false)
+    }
+
     pub fn change_mode(&mut self, cursor_mode: &CursorMode, styles: &HashMap<u64, Arc<Style>>) {
         let CursorMode {
             shape,

--- a/src/editor/cursor.rs
+++ b/src/editor/cursor.rs
@@ -83,7 +83,7 @@ impl Cursor {
     pub fn alpha(&self) -> u8 {
         return self.style
             .as_ref()
-            .map(|s| 255 * (100 - s.blend))
+            .map(|s| (255 as f32 * ((100 - s.blend) as f32 / (100.0 as f32))) as u8)
             .unwrap_or(255)
     }
 

--- a/src/editor/cursor.rs
+++ b/src/editor/cursor.rs
@@ -80,11 +80,11 @@ impl Cursor {
             .unwrap_or_else(|| default_colors.foreground.unwrap())
     }
 
-    pub fn blend_is_hide(&self) -> bool {
-        self.style
+    pub fn alpha(&self) -> u8 {
+        return self.style
             .as_ref()
-            .map(|s| s.blend == 100)
-            .unwrap_or(false)
+            .map(|s| 255 * (100 - s.blend))
+            .unwrap_or(255)
     }
 
     pub fn change_mode(&mut self, cursor_mode: &CursorMode, styles: &HashMap<u64, Arc<Style>>) {

--- a/src/editor/cursor.rs
+++ b/src/editor/cursor.rs
@@ -81,10 +81,11 @@ impl Cursor {
     }
 
     pub fn alpha(&self) -> u8 {
-        return self.style
+        return self
+            .style
             .as_ref()
             .map(|s| (255 as f32 * ((100 - s.blend) as f32 / (100.0 as f32))) as u8)
-            .unwrap_or(255)
+            .unwrap_or(255);
     }
 
     pub fn change_mode(&mut self, cursor_mode: &CursorMode, styles: &HashMap<u64, Arc<Style>>) {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -85,7 +85,7 @@ impl Editor {
                     self.mode_list = cursor_modes;
                     if let Some(curr_mode_i) = self.current_mode_index.clone() {
                         if let Some(curr_mode) = self.mode_list.get(curr_mode_i as usize) {
-                          self.cursor.change_mode(curr_mode, &self.defined_styles)
+                            self.cursor.change_mode(curr_mode, &self.defined_styles)
                         }
                     }
                 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -83,9 +83,9 @@ impl Editor {
                 }
                 RedrawEvent::ModeInfoSet { cursor_modes } => {
                     self.mode_list = cursor_modes;
-                    if let Some(curr_mode_i) = self.current_mode_index.clone() {
-                        if let Some(curr_mode) = self.mode_list.get(curr_mode_i as usize) {
-                            self.cursor.change_mode(curr_mode, &self.defined_styles)
+                    if let Some(current_mode_i) = self.current_mode_index.clone() {
+                        if let Some(current_mode) = self.mode_list.get(current_mode_i as usize) {
+                            self.cursor.change_mode(current_mode, &self.defined_styles)
                         }
                     }
                 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -60,6 +60,7 @@ pub struct Editor {
     pub defined_styles: HashMap<u64, Arc<Style>>,
     pub mode_list: Vec<CursorMode>,
     pub draw_command_batcher: Arc<DrawCommandBatcher>,
+    pub current_mode_index: Option<u64>,
 }
 
 impl Editor {
@@ -70,6 +71,7 @@ impl Editor {
             defined_styles: HashMap::new(),
             mode_list: Vec::new(),
             draw_command_batcher: Arc::new(DrawCommandBatcher::new()),
+            current_mode_index: None,
         }
     }
 
@@ -79,11 +81,21 @@ impl Editor {
                 RedrawEvent::SetTitle { title } => {
                     EVENT_AGGREGATOR.send(WindowCommand::TitleChanged(title));
                 }
-                RedrawEvent::ModeInfoSet { cursor_modes } => self.mode_list = cursor_modes,
+                RedrawEvent::ModeInfoSet { cursor_modes } => {
+                    self.mode_list = cursor_modes;
+                    if let Some(curr_mode_i) = self.current_mode_index.clone() {
+                        if let Some(curr_mode) = self.mode_list.get(curr_mode_i as usize) {
+                          self.cursor.change_mode(curr_mode, &self.defined_styles)
+                        }
+                    }
+                }
                 RedrawEvent::OptionSet { gui_option } => self.set_option(gui_option),
                 RedrawEvent::ModeChange { mode, mode_index } => {
                     if let Some(cursor_mode) = self.mode_list.get(mode_index as usize) {
                         self.cursor.change_mode(cursor_mode, &self.defined_styles);
+                        self.current_mode_index = Some(mode_index)
+                    } else {
+                        self.current_mode_index = None
                     }
                     self.draw_command_batcher
                         .queue(DrawCommand::ModeChanged(mode))

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -340,14 +340,15 @@ impl CursorRenderer {
         } else {
             self.previous_editor_mode = current_mode.clone();
         }
-        if !(self.cursor.enabled && render) || self.cursor.blend_is_hide() {
+        if !(self.cursor.enabled && render) {
             return;
         }
         // Draw Background
         let background_color = self
             .cursor
             .background(&grid_renderer.default_style.colors)
-            .to_color();
+            .to_color()
+            .with_a(self.cursor.alpha());
         paint.set_color(background_color);
 
         // The cursor is made up of four points, so I create a path with each of the four
@@ -366,7 +367,8 @@ impl CursorRenderer {
         let foreground_color = self
             .cursor
             .foreground(&grid_renderer.default_style.colors)
-            .to_color();
+            .to_color()
+            .with_a(self.cursor.alpha());
         paint.set_color(foreground_color);
 
         canvas.save();

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -340,8 +340,7 @@ impl CursorRenderer {
         } else {
             self.previous_editor_mode = current_mode.clone();
         }
-
-        if !(self.cursor.enabled && render) {
+        if !(self.cursor.enabled && render) || self.cursor.blend_is_hide() {
             return;
         }
         // Draw Background


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature


## Did this PR introduce a breaking change? 
- No

This adds support for `blend=100` when drawing the cursor. In terminal mode if blend=100 is in the active highlight group for `guicursor` then it makes the cursor invisible, my personal use-case for this is hiding the cursor in nerdtree and similar.

Note that I'm not sure if there is more to `blend` than just making the cursor invisible if its 100, `:help blend` says something about blend level in floating windows but I think the cursor is special, in any case I've only implemented the cursor bit.