### PR TITLE
Implement blend options for grid

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -461,7 +461,7 @@ fn parse_option_set(option_set_arguments: Vec<Value>) -> Result<RedrawEvent> {
             "guifontset" => GuiOption::GuiFontSet(parse_string(value)?),
             "guifontwide" => GuiOption::GuiFontWide(parse_string(value)?),
             "linespace" => GuiOption::LineSpace(parse_u64(value)?),
-            "pumblend" => GuiOption::Pumblend(parse_i64(value)?.clamp(0, 100) as u64),
+            "pumblend" => GuiOption::Pumblend(parse_u64(value)?),
             "showtabline" => GuiOption::ShowTabLine(parse_u64(value)?),
             "termguicolors" => GuiOption::TermGuiColors(parse_bool(value)?),
             _ => GuiOption::Unknown(name, value),
@@ -534,9 +534,7 @@ fn parse_style(style_map: Value) -> Result<Style> {
                 }
                 ("underline", Value::Boolean(underline)) => style.underline = underline,
                 ("undercurl", Value::Boolean(undercurl)) => style.undercurl = undercurl,
-                ("blend", Value::Integer(blend)) => {
-                    style.blend = blend.as_i64().unwrap().clamp(0, 100) as u8
-                }
+                ("blend", Value::Integer(blend)) => style.blend = blend.as_u64().unwrap() as u8,
                 _ => debug!("Ignored style attribute: {}", name),
             }
         } else {

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -461,7 +461,7 @@ fn parse_option_set(option_set_arguments: Vec<Value>) -> Result<RedrawEvent> {
             "guifontset" => GuiOption::GuiFontSet(parse_string(value)?),
             "guifontwide" => GuiOption::GuiFontWide(parse_string(value)?),
             "linespace" => GuiOption::LineSpace(parse_u64(value)?),
-            "pumblend" => GuiOption::Pumblend(parse_u64(value)?),
+            "pumblend" => GuiOption::Pumblend(parse_i64(value)?.clamp(0, 100) as u64),
             "showtabline" => GuiOption::ShowTabLine(parse_u64(value)?),
             "termguicolors" => GuiOption::TermGuiColors(parse_bool(value)?),
             _ => GuiOption::Unknown(name, value),
@@ -534,7 +534,9 @@ fn parse_style(style_map: Value) -> Result<Style> {
                 }
                 ("underline", Value::Boolean(underline)) => style.underline = underline,
                 ("undercurl", Value::Boolean(undercurl)) => style.undercurl = undercurl,
-                ("blend", Value::Integer(blend)) => style.blend = blend.as_u64().unwrap() as u8,
+                ("blend", Value::Integer(blend)) => {
+                    style.blend = blend.as_i64().unwrap().clamp(0, 100) as u8
+                }
                 _ => debug!("Ignored style attribute: {}", name),
             }
         } else {

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -108,7 +108,7 @@ impl GridRenderer {
 
         if is_floating {
             self.paint
-                .set_alpha((255.0 * ((100 - style.blend) as f32 / 100.0)) as u8);
+               .set_alpha((255.0 * ((100 - style.blend) as f32 / 100.0)) as u8);
         } else if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON
             // Only make background color transparent
             && self.paint.color() == self.get_default_background()

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -106,9 +106,10 @@ impl GridRenderer {
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
 
+        println!("blend: {:?}", style.blend);
         if is_floating {
             self.paint
-                .set_alpha((255.0 * SETTINGS.get::<RendererSettings>().floating_opacity) as u8);
+               .set_alpha((255.0 * ((100 - style.blend) as f32 / 100.0)) as u8 /*SETTINGS.get::<RendererSettings>().floating_opacity) as u8*/);
         } else if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON
             // Only make background color transparent
             && self.paint.color() == self.get_default_background()

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -106,10 +106,9 @@ impl GridRenderer {
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
 
-        println!("blend: {:?}", style.blend);
         if is_floating {
             self.paint
-               .set_alpha((255.0 * ((100 - style.blend) as f32 / 100.0)) as u8 /*SETTINGS.get::<RendererSettings>().floating_opacity) as u8*/);
+               .set_alpha((255.0 * ((100 - style.blend) as f32 / 100.0)) as u8);
         } else if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON
             // Only make background color transparent
             && self.paint.color() == self.get_default_background()

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -108,7 +108,7 @@ impl GridRenderer {
 
         if is_floating {
             self.paint
-               .set_alpha((255.0 * ((100 - style.blend) as f32 / 100.0)) as u8);
+                .set_alpha((255.0 * ((100 - style.blend) as f32 / 100.0)) as u8);
         } else if (SETTINGS.get::<WindowSettings>().transparency - 1.0).abs() > f32::EPSILON
             // Only make background color transparent
             && self.paint.color() == self.get_default_background()


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Ish, removes the effect of `g:neovide_floating_opacity` at least for the grid renderer

This implements usage of the `blend` option in the style in `grid_renderer`. It _seems_ to match up with `winblend` and obey local vs global options but actually testing it is proving to be quite difficult, and I don't fully understand how the drawing actually works (`RenderedWindow::draw` doesn't seem to actually do anything with its opacity for example).

So far it seems to work correctly for `nnn` in picker mode, but telescope is acting weird: when neovim is doing the drawing it kind of works in that the search box respects the transparency but nothing else does, in multigrid mode it just seems to ignore it completely.

I'm making this a draft because I am not confident that this actually works properly yet. My main concerns are:
- what is `RenderedWindow::draw` doing with its alpha, changing it doesn't seem to have any effect
- I don't really understand how the blend option is getting updated or how it syncs, so I'm not sure if it actually covers everything

Edit: OK I may have done a dumb, telescope has its own config setting for winblend :woman_facepalming: setting that works, and as far as I can tell it stays local to the window