### PR TITLE
Fix update loop

### DIFF
--- a/src/editor/cursor.rs
+++ b/src/editor/cursor.rs
@@ -84,7 +84,7 @@ impl Cursor {
         return self
             .style
             .as_ref()
-            .map(|s| (255 as f32 * ((100 - s.blend) as f32 / (100.0 as f32))) as u8)
+            .map(|s| (255_f32 * ((100 - s.blend) as f32 / (100.0_f32))) as u8)
             .unwrap_or(255);
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -83,7 +83,7 @@ impl Editor {
                 }
                 RedrawEvent::ModeInfoSet { cursor_modes } => {
                     self.mode_list = cursor_modes;
-                    if let Some(current_mode_i) = self.current_mode_index.clone() {
+                    if let Some(current_mode_i) = self.current_mode_index {
                         if let Some(current_mode) = self.mode_list.get(current_mode_i as usize) {
                             self.cursor.change_mode(current_mode, &self.defined_styles)
                         }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -119,7 +119,7 @@ impl Editor {
                     trace!("Image flushed");
                     self.send_cursor_info();
                     self.draw_command_batcher.send_batch();
-                    REDRAW_SCHEDULER.queue_next_frame();
+                    REDRAW_SCHEDULER.redraw();
                 }
                 RedrawEvent::DefaultColorsSet { colors } => {
                     self.draw_command_batcher
@@ -127,7 +127,7 @@ impl Editor {
                         .ok();
                     self.redraw_screen();
                     self.draw_command_batcher.send_batch();
-                    REDRAW_SCHEDULER.queue_next_frame();
+                    REDRAW_SCHEDULER.redraw();
                 }
                 RedrawEvent::HighlightAttributesDefine { id, style } => {
                     self.defined_styles.insert(id, Arc::new(style));

--- a/src/redraw_scheduler.rs
+++ b/src/redraw_scheduler.rs
@@ -6,8 +6,8 @@ use std::{
         mpsc::{channel, Sender},
         Arc,
     },
-    time::Instant,
     thread,
+    time::Instant,
 };
 
 use glutin::window::Window;
@@ -54,7 +54,9 @@ impl RedrawScheduler {
                 }
 
                 if let Some(Reverse(next_scheduled_instant)) = scheduled_instants.peek() {
-                    if let Ok(new_schedule) = schedule_receiver.recv_timeout(*next_scheduled_instant - Instant::now()) {
+                    if let Ok(new_schedule) =
+                        schedule_receiver.recv_timeout(*next_scheduled_instant - Instant::now())
+                    {
                         scheduled_instants.push(Reverse(new_schedule));
                     }
                 } else if let Ok(new_schedule) = schedule_receiver.recv() {
@@ -73,9 +75,7 @@ impl RedrawScheduler {
             if let Some(sender) = sender_option.as_ref() {
                 sender.send(redraw_at).unwrap();
             } else {
-                let sender = {
-                    self.schedule_sender.lock().clone()
-                };
+                let sender = { self.schedule_sender.lock().clone() };
 
                 let mut empty_sender_option = RwLockUpgradableReadGuard::upgrade(sender_option);
                 sender.send(redraw_at).unwrap();
@@ -98,7 +98,8 @@ impl RedrawScheduler {
     pub fn should_draw_again(&self) -> bool {
         let remaining_frames = self.frame_buffer.load(Ordering::Relaxed);
         if remaining_frames > 0 {
-            self.frame_buffer.store(remaining_frames - 1, Ordering::Relaxed);
+            self.frame_buffer
+                .store(remaining_frames - 1, Ordering::Relaxed);
             true
         } else {
             false

--- a/src/renderer/cursor_renderer/blink.rs
+++ b/src/renderer/cursor_renderer/blink.rs
@@ -70,7 +70,7 @@ impl BlinkStatus {
         .map(|delay| self.last_transition + Duration::from_millis(delay));
 
         if let Some(scheduled_frame) = scheduled_frame {
-            REDRAW_SCHEDULER.schedule(scheduled_frame);
+            REDRAW_SCHEDULER.schedule_redraw(scheduled_frame);
         }
 
         match self.state {

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -336,7 +336,7 @@ impl CursorRenderer {
         }
 
         if animating {
-            REDRAW_SCHEDULER.queue_next_frame();
+            REDRAW_SCHEDULER.redraw();
         } else {
             self.previous_editor_mode = current_mode.clone();
         }

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -242,7 +242,7 @@ impl RenderedWindow {
         dt: f32,
     ) -> WindowDrawDetails {
         if self.update(settings, dt) {
-            REDRAW_SCHEDULER.queue_next_frame();
+            REDRAW_SCHEDULER.redraw();
         }
 
         let pixel_region = self.pixel_region(font_dimensions);

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -5,7 +5,7 @@ mod settings;
 
 use std::{
     sync::Arc,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use glutin::{
@@ -13,8 +13,8 @@ use glutin::{
     dpi::PhysicalSize,
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::{self, Window, Fullscreen, Icon},
-    ContextBuilder, GlProfile, RawContext, PossiblyCurrent,
+    window::{self, Fullscreen, Icon, Window},
+    ContextBuilder, GlProfile, PossiblyCurrent, RawContext,
 };
 use log::trace;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -79,7 +79,8 @@ impl GlutinWindowWrapper {
             self.window.set_fullscreen(None);
         } else {
             let handle = self.window.current_monitor();
-            self.window.set_fullscreen(Some(Fullscreen::Borderless(handle)));
+            self.window
+                .set_fullscreen(Some(Fullscreen::Borderless(handle)));
         }
 
         self.fullscreen = !self.fullscreen;
@@ -179,9 +180,7 @@ impl GlutinWindowWrapper {
                     self.handle_focus_lost();
                 }
             }
-            Event::RedrawRequested(..) | Event::WindowEvent { .. } => {
-                REDRAW_SCHEDULER.redraw()
-            }
+            Event::RedrawRequested(..) | Event::WindowEvent { .. } => REDRAW_SCHEDULER.redraw(),
             _ => {}
         }
     }
@@ -327,13 +326,12 @@ pub fn create_window() {
         .with_srgb(cmd_line_settings.srgb)
         .build_windowed(winit_window_builder, &event_loop)
         .unwrap();
-    let (gl_context, window) = unsafe { 
-        windowed_context.make_current().unwrap().split()
-    };
+    let (gl_context, window) = unsafe { windowed_context.make_current().unwrap().split() };
     let window = Arc::new(window);
     REDRAW_SCHEDULER.register_window(window.clone());
 
-    let max_monitor_frame_rate = window.available_monitors()
+    let max_monitor_frame_rate = window
+        .available_monitors()
         .flat_map(|monitor| monitor.video_modes())
         .map(|mode| mode.refresh_rate())
         .max()
@@ -410,14 +408,17 @@ pub fn create_window() {
         window_wrapper.handle_event(&e);
 
         if let Event::MainEventsCleared = e {
-            let frame_time = frame_start.duration_since(previous_frame_start).as_secs_f32();
+            let frame_time = frame_start
+                .duration_since(previous_frame_start)
+                .as_secs_f32();
             let configured_refresh_rate = SETTINGS.get::<WindowSettings>().refresh_rate;
 
             let refresh_rate = if configured_refresh_rate != 0 {
                 configured_refresh_rate
             } else {
                 max_monitor_frame_rate
-            } as f32 * 1.1;
+            } as f32
+                * 1.1;
             // Set the rendered refresh rate to 1.1 * the configured rate.
             // This is to avoid being too close to the frame length which would cause skipped
             // frames.

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -3,10 +3,7 @@ mod mouse_manager;
 mod renderer;
 mod settings;
 
-use std::{
-    sync::Arc,
-    time::Instant,
-};
+use std::{sync::Arc, time::Instant};
 
 use glutin::{
     self,

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -11,7 +11,7 @@ use glutin::{
         DeviceId, ElementState, Event, MouseButton, MouseScrollDelta, Touch, TouchPhase,
         WindowEvent,
     },
-    PossiblyCurrent, WindowedContext,
+    window::Window,
 };
 use skia_safe::Rect;
 
@@ -109,9 +109,9 @@ impl MouseManager {
         y: i32,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext<PossiblyCurrent>,
+        window: &Window,
     ) {
-        let size = windowed_context.window().inner_size();
+        let size = window.inner_size();
         if x < 0 || x as u32 >= size.width || y < 0 || y as u32 >= size.height {
             return;
         }
@@ -313,7 +313,7 @@ impl MouseManager {
         &mut self,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext<PossiblyCurrent>,
+        window: &Window,
         finger_id: (DeviceId, u64),
         location: PhysicalPosition<f32>,
         phase: &TouchPhase,
@@ -362,7 +362,7 @@ impl MouseManager {
                             location.y.round() as i32,
                             keyboard_manager,
                             renderer,
-                            windowed_context,
+                            window,
                         );
                     }
                     // the double check might seem useless, but the if branch above might set
@@ -385,7 +385,7 @@ impl MouseManager {
                         location.y.round() as i32,
                         keyboard_manager,
                         renderer,
-                        windowed_context,
+                        window,
                     );
                     self.handle_pointer_transition(&MouseButton::Left, true, keyboard_manager);
                 }
@@ -401,7 +401,7 @@ impl MouseManager {
                             trace.start.y.round() as i32,
                             keyboard_manager,
                             renderer,
-                            windowed_context,
+                            window,
                         );
                         self.handle_pointer_transition(&MouseButton::Left, true, keyboard_manager);
                         self.handle_pointer_transition(&MouseButton::Left, false, keyboard_manager);
@@ -416,7 +416,7 @@ impl MouseManager {
         event: &Event<()>,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext<PossiblyCurrent>,
+        window: &Window,
     ) {
         match event {
             Event::WindowEvent {
@@ -428,10 +428,10 @@ impl MouseManager {
                     position.y as i32,
                     keyboard_manager,
                     renderer,
-                    windowed_context,
+                    window,
                 );
                 if self.mouse_hidden {
-                    windowed_context.window().set_cursor_visible(true);
+                    window.set_cursor_visible(true);
                     self.mouse_hidden = false;
                 }
             }
@@ -468,7 +468,7 @@ impl MouseManager {
             } => self.handle_touch(
                 keyboard_manager,
                 renderer,
-                windowed_context,
+                window,
                 (*device_id, *id),
                 location.cast(),
                 phase,
@@ -491,7 +491,7 @@ impl MouseManager {
                 if key_event.state == ElementState::Pressed {
                     let window_settings = SETTINGS.get::<WindowSettings>();
                     if window_settings.hide_mouse_when_typing && !self.mouse_hidden {
-                        windowed_context.window().set_cursor_visible(false);
+                        window.set_cursor_visible(false);
                         self.mouse_hidden = true;
                     }
                 }

--- a/src/window/renderer.rs
+++ b/src/window/renderer.rs
@@ -1,13 +1,10 @@
 use std::convert::TryInto;
 
 use gl::types::*;
+use glutin::{window::Window, PossiblyCurrent, RawContext};
 use skia_safe::{
     gpu::{gl::FramebufferInfo, BackendRenderTarget, DirectContext, SurfaceOrigin},
     Canvas, ColorType, Surface,
-};
-use glutin::{
-    window::Window,
-    RawContext, PossiblyCurrent,
 };
 
 fn create_surface(
@@ -88,6 +85,11 @@ impl SkiaRenderer {
     }
 
     pub fn resize(&mut self, gl_context: &RawContext<PossiblyCurrent>, window: &Window) {
-        self.surface = create_surface(gl_context, window, &mut self.skia_context, self.framebuffer_info);
+        self.surface = create_surface(
+            gl_context,
+            window,
+            &mut self.skia_context,
+            self.framebuffer_info,
+        );
     }
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -20,7 +20,7 @@ impl Default for WindowSettings {
             transparency: 1.0,
             fullscreen: false,
             iso_layout: false,
-            refresh_rate: 60,
+            refresh_rate: 0,
             no_idle: SETTINGS.get::<CmdLineSettings>().no_idle,
             remember_window_size: true,
             remember_window_position: true,


### PR DESCRIPTION
Addresses low framerate caused by faulty usage of winit event loop.

This PR changes the redraw scheduler to take a reference to the window object. This lets the scheduler queue a redraw when the app is waiting. I also changed the scheduler to keep track of a running buffer of frames.

So now whenever a frame is queued, the render loop switches to poll mode for 100 frames. Once those frames run out, the system swaps to wait mode where it stops the event loop until another frame is queued or some window event occurs. This lets us render as fast as possible when animations are playing, but stop rendering when nothing has changed on the screen in order to save processing power and battery.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change?
- Yes

The default configured refresh rate is now set to 0. This falls back to the recorded refresh rate from connected monitors observed on startup. This way the system automatically renders as fast as the fastest monitor by default, but is still configurable if the user desires.
