### PR TITLE
fix: bridge command

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -51,9 +51,8 @@ fn build_nvim_cmd() -> TokioCommand {
 fn create_platform_shell_command(command: &str, args: Vec<&str>) -> Option<StdCommand> {
     if cfg!(target_os = "windows") && SETTINGS.get::<CmdLineSettings>().wsl {
         let mut result = StdCommand::new("wsl");
-        result.args(&["$SHELL", "-lic"]);
-        result.arg(command);
-        result.args(&args);
+        result.args(&["$SHELL", "-lc"]);
+        result.arg(format!("{} {}", command, args.join(" ")));
 
         Some(result)
     } else if cfg!(target_os = "macos") {

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Command as StdCommand, Stdio},
 };
 
-use log::{error, info, warn};
+use log::{debug, error, warn};
 use tokio::process::Command as TokioCommand;
 
 use crate::{cmd_line::CmdLineSettings, settings::*};
@@ -12,7 +12,7 @@ use crate::{cmd_line::CmdLineSettings, settings::*};
 pub fn create_nvim_command() -> TokioCommand {
     let mut cmd = build_nvim_cmd();
 
-    info!("Starting neovim with: {:?}", cmd);
+    debug!("Starting neovim with: {:?}", cmd);
 
     #[cfg(not(debug_assertions))]
     cmd.stderr(Stdio::piped());
@@ -48,7 +48,7 @@ fn build_nvim_cmd() -> TokioCommand {
 }
 
 // Creates a shell command if needed on this platform (wsl or macos)
-fn create_platform_shell_command(command: &str, args: Vec<&str>) -> Option<StdCommand> {
+fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdCommand> {
     if cfg!(target_os = "windows") && SETTINGS.get::<CmdLineSettings>().wsl {
         let mut result = StdCommand::new("wsl");
         result.args(&["$SHELL", "-lc"]);
@@ -57,7 +57,7 @@ fn create_platform_shell_command(command: &str, args: Vec<&str>) -> Option<StdCo
         Some(result)
     } else if cfg!(target_os = "macos") {
         let mut result = StdCommand::new(command);
-        result.args(&args);
+        result.args(args);
 
         Some(result)
     } else {
@@ -66,8 +66,7 @@ fn create_platform_shell_command(command: &str, args: Vec<&str>) -> Option<StdCo
 }
 
 fn platform_exists(bin: &str) -> bool {
-    // if let Some(mut exists_command) = create_platform_shell_command(format!("exists -x {}", bin)) {
-    if let Some(mut exists_command) = create_platform_shell_command("exists", vec!["-x", bin]) {
+    if let Some(mut exists_command) = create_platform_shell_command("exists", &["-x", bin]) {
         if let Ok(output) = exists_command.output() {
             output.status.success()
         } else {
@@ -80,8 +79,8 @@ fn platform_exists(bin: &str) -> bool {
 }
 
 fn platform_which(bin: &str) -> Option<String> {
-    if let Some(mut which_command) = create_platform_shell_command("which", vec![bin]) {
-        info!("Running which command: {:?}", which_command);
+    if let Some(mut which_command) = create_platform_shell_command("which", &[bin]) {
+        debug!("Running which command: {:?}", which_command);
         if let Ok(output) = which_command.output() {
             if output.status.success() {
                 let nvim_path = String::from_utf8(output.stdout).unwrap();


### PR DESCRIPTION
This PR resolves #1175 

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

First of all, I got rid of Interactive (`-i`) options in shell. because, If a banner or similar text is output at the start of the shell, the output buffer of the executed command cannot be retrieved normally.

**Example:**
![화면 캡처 2022-02-16 015645](https://user-images.githubusercontent.com/32578710/154110372-ff0371f7-d6cb-4fb0-beda-53c985b23395.png)

(But, in the case of Windows, the command is executed through `wsl`. It may not be affected by files such as `bashrc`, `zshrc`, `bashenv`, `zshenv`, etc)

And referring to the specification of the `Command` as follows

> * No arguments to the program
> * Inherit the current process’s environment

In macOS, It seems that we do not need to run the command through the shell (with `-c`), but simply execute the run command directly.

This may not be a perfect solution. So, I'd really appreciate it if you could give me feedback.