### PR TITLE
Fix: Neovide.app not working in Finder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ snap install neovide
 
 ## Troubleshooting
 - Neovide requires that a font be set in `init.vim` otherwise errors might be encountered. This can be fixed by adding `set guifont=Your\ Font\ Name:h15` in init.vim file. Reference issue [#527](https://github.com/neovide/neovide/issues/527).
+- If you installed `neovim` via Apple Silicon (M1)-based `brew`, you have to add the `brew prefix` to `$PATH` to run `Neovide.app` in GUI. Please see the [homebrew documentation](https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities). Reference issue [#1242](https://github.com/neovide/neovide/pull/1242)
 
 ### Linux-specific
 - If you recieve errors complaining about DRI3 settings, please reference issue [#44](https://github.com/neovide/neovide/issues/44#issuecomment-578618052).

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -58,6 +58,8 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
     } else if cfg!(target_os = "macos") {
         let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
         let mut result = StdCommand::new(&shell);
+        result.env("PATH", "/opt/homebrew/bin");
+
         result.args(&["-lc"]);
         result.arg(format!("{} {}", command, args.join(" ")));
 

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -56,8 +56,10 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
 
         Some(result)
     } else if cfg!(target_os = "macos") {
-        let mut result = StdCommand::new(command);
-        result.args(args);
+        let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let mut result = StdCommand::new(&shell);
+        result.args(&["-lc"]);
+        result.arg(format!("{} {}", command, args.join(" ")));
 
         Some(result)
     } else {

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -58,7 +58,6 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
     } else if cfg!(target_os = "macos") {
         let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
         let mut result = StdCommand::new(&shell);
-        result.env("PATH", "/opt/homebrew/bin");
 
         result.args(&["-lc"]);
         result.arg(format!("{} {}", command, args.join(" ")));


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

This PR resolve #1240 

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

The content in #1217 is getting long, so I'm making this PR with a new alternative.
I hadn't thought of this PR (#1072), so currently `Neovide.app` cannot be run through Finder on macOS.

~~However, this still leaves some problems.~~

~~For example, if neovim is installed through `brew`, it will not run (in Finder) because `nvim` does not exist in the `PATH` variable (default installation path is `/opt/homebrew/bin/`).~~

~~But one thing I'm concerned about is that hardcoding the settings of a 3rd party app has maintenance issues later on.
So, if there is a better way, please give feedback.~~

EDIT: Thank you, everyone. I removed direct hardcoding of brew to `PATH` and added a way to solve this problem instead.
