### PR TITLE
Add neovide_confirm_quit option to confirm before quitting

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -127,7 +127,9 @@ impl ParallelCommand {
     async fn execute(self, nvim: &Neovim<TxWrapper>) {
         match self {
             ParallelCommand::Quit => {
-                nvim.command("qa!").await.ok();
+                nvim.command("if exists('g:neovide_confirm_quit') && g:neovide_confirm_quit == 1 | confirm qa | else | qa! | endif")
+                    .await
+                    .ok();
             }
             ParallelCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -127,7 +127,7 @@ impl ParallelCommand {
     async fn execute(self, nvim: &Neovim<TxWrapper>) {
         match self {
             ParallelCommand::Quit => {
-                nvim.command("if exists('g:neovide_confirm_quit') && g:neovide_confirm_quit == 1 | confirm qa | else | qa! | endif")
+                nvim.command("if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif")
                     .await
                     .ok();
             }

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -127,9 +127,11 @@ impl ParallelCommand {
     async fn execute(self, nvim: &Neovim<TxWrapper>) {
         match self {
             ParallelCommand::Quit => {
-                nvim.command("if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif")
-                    .await
-                    .ok();
+                nvim.command(
+                    "if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif",
+                )
+                .await
+                .ok();
             }
             ParallelCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)


### PR DESCRIPTION
![Screenshot from 2022-03-16 19-45-05](https://user-images.githubusercontent.com/287339/158726320-f9755d0e-090c-43ca-8fc3-49d9a52f2c90.png)

This adds a new option, `g:neovide_confirm_quit` (default: `0`), which, when set to `1` or `v:true`, will execute `confirm qa` instead of `qa!` when the window is closed.

Mostly fixes #874, by reducing the potential to lose work. It does not pop up a nice dialog box, of course. This is pretty much the way that nvim-qt does things.

Tested on Linux.

Please let me know if there's a more elegant way to query the option than putting it in an inline script.

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No, the option is disabled by default.