### PR TITLE
Render block cursor as an outline when window is not focused

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -430,13 +430,12 @@ impl CursorRenderer {
         subtract.line_to(self.corners[3].current_position + offsets[3]);
         subtract.close();
 
-        match op(&rectangle, &subtract, skia_safe::PathOp::Difference) {
-            Some(path) => {
-                canvas.draw_path(&path, &paint);
-                path
-            }
-            // TODO: How to handle the failure case?
-            None => self.draw_rectangle(canvas, paint),
-        }
+        // We have two "rectangles"; create an outline path by subtracting the smaller rectangle
+        // from the larger one. This can fail in which case we return a full "rectangle".
+        // TODO: Is this the best way to handle the failure case? Would unwrap be ok?
+        let path = op(&rectangle, &subtract, skia_safe::PathOp::Difference).unwrap_or(rectangle);
+
+        canvas.draw_path(&path, &paint);
+        path
     }
 }

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -31,6 +31,13 @@ pub struct CursorSettings {
     animate_in_insert_mode: bool,
     animate_command_line: bool,
     trail_size: f32,
+
+    /// Specify cursor outline width in ems. You probably want this to be a positive value less
+    /// than 0.5. If the value is <=0 then the cursor will be invisible. This setting takes effect
+    /// when the editor window is unfocused, at which time a block cursor will be rendered as an
+    /// outline instead of as a full rectangle.
+    unfocused_outline_width: f32,
+
     vfx_mode: cursor_vfx::VfxMode,
     vfx_opacity: f32,
     vfx_particle_lifetime: f32,
@@ -49,6 +56,7 @@ impl Default for CursorSettings {
             animate_in_insert_mode: true,
             animate_command_line: true,
             trail_size: 0.7,
+            unfocused_outline_width: 1.0 / 8.0,
             vfx_mode: cursor_vfx::VfxMode::Disabled,
             vfx_opacity: 200.0,
             vfx_particle_lifetime: 1.2,
@@ -299,10 +307,6 @@ impl CursorRenderer {
         )
             .into();
 
-        // The width for the outline of a block cursor should be the same as the width of
-        // a vertical cursor.
-        let outline_width = cursor_dimensions.x * DEFAULT_CELL_PERCENTAGE * 2.0;
-
         let in_insert_mode = matches!(current_mode, EditorMode::Insert);
 
         let changed_to_from_cmdline = !matches!(self.previous_editor_mode, EditorMode::CmdLine)
@@ -371,6 +375,7 @@ impl CursorRenderer {
         let path = if self.window_has_focus || self.cursor.shape != CursorShape::Block {
             self.draw_rectangle(canvas, &paint)
         } else {
+            let outline_width = settings.unfocused_outline_width * grid_renderer.em_size;
             self.draw_rectangular_outline(canvas, &paint, outline_width)
         };
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -16,6 +16,7 @@ pub struct GridRenderer {
     pub shaper: CachingShaper,
     pub paint: Paint,
     pub default_style: Arc<Style>,
+    pub em_size: f32,
     pub font_dimensions: Dimensions,
     pub scale_factor: f64,
     pub is_ready: bool,
@@ -31,12 +32,14 @@ impl GridRenderer {
             Some(colors::BLACK),
             Some(colors::GREY),
         )));
+        let em_size = shaper.current_size();
         let font_dimensions: Dimensions = shaper.font_base_dimensions().into();
 
         GridRenderer {
             shaper,
             paint,
             default_style,
+            em_size,
             font_dimensions,
             scale_factor,
             is_ready: false,
@@ -68,6 +71,7 @@ impl GridRenderer {
     }
 
     fn update_font_dimensions(&mut self) {
+        self.em_size = self.shaper.current_size();
         self.font_dimensions = self.shaper.font_base_dimensions().into();
         self.is_ready = true;
         trace!("Updated font dimensions: {:?}", self.font_dimensions,);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -11,6 +11,7 @@ use std::{
     sync::Arc,
 };
 
+use glutin::event::Event;
 use log::error;
 use skia_safe::Canvas;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -97,6 +98,10 @@ impl Renderer {
             batched_draw_command_receiver,
             profiler,
         }
+    }
+
+    pub fn handle_event(&mut self, event: &Event<()>) {
+        self.cursor_renderer.handle_event(event);
     }
 
     pub fn font_names(&self) -> Vec<String> {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -139,6 +139,7 @@ impl GlutinWindowWrapper {
             &self.renderer,
             &self.windowed_context,
         );
+        self.renderer.handle_event(&event);
         match event {
             Event::LoopDestroyed => {
                 self.handle_quit();


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature


## Did this PR introduce a breaking change? 
- No

Hi! I'm really enjoying Neovide! This PR changes the way the cursor is rendered when the editor window is unfocused. If the cursor shape is set to block, then when the window loses focus the cursor will be drawn as an outline. This provides a visual cue that can be easier to notice than other cues like highlighted window borders or title bar because the user tends to focus on the cursor. After using Neovide for a bit I have realized that I rely on the cursor rendering cue - I've been typing into the wrong window much more often recently.

There are still some tweaks that could be made. I have not added tests yet, and I think the outline is a little too thick. I would appreciate any feedback, and I will try to make updates accordingly.

Fixes #1253 