### PR TITLE
ci(workflows): run build/test for outside pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,16 @@
 name: Build-and-Test
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build-windows:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Nightly Toolchain
         uses: actions-rs/toolchain@v1
@@ -58,7 +61,7 @@ jobs:
         run: |
           cargo build --release
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: neovide-windows
           path: ./target/release/neovide.exe
@@ -67,7 +70,7 @@ jobs:
     runs-on: macos-11
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Nightly Toolchain
         uses: actions-rs/toolchain@v1
@@ -149,7 +152,7 @@ jobs:
           hdiutil create Neovide-uncompressed.dmg -volname "Neovide" -srcfolder target/release/bundle/osx
           hdiutil convert Neovide-uncompressed.dmg -format UDZO -o Neovide.dmg
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: Neovide.dmg
           path: ./Neovide.dmg
@@ -158,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Nightly Toolchain
         uses: actions-rs/toolchain@v1
@@ -206,8 +209,7 @@ jobs:
         run: |
           tar czvf ./target/release/neovide.tar.gz ./target/release/neovide
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: neovide-linux.tar.gz
           path: ./target/release/neovide.tar.gz
-

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install clippy and runstfmt
         run: rustup component add clippy rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: snapcore/action-build@v1
         env:
           SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY: 6G
         id: snapcraft
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: snapcore/action-build@v1
         env:
           SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY: 6G
         id: snapcraft
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}


### PR DESCRIPTION
Run build/test for non-collaborator pull requests. I think it might be useful since there aren't a lot of pull requests and first-time contributors (or all outside contributors if set in repository options) would still require approval to run. Just a suggestion - feel free to close this pr if this is not intended behavior.

Also bumps GitHub actions to latest versions.

## What kind of change does this PR introduce?

CI

## Did this PR introduce a breaking change? 

No
