### PR TITLE
Alternative Alt + character handling for MacOS

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -147,7 +147,7 @@ impl KeyboardManager {
             if let Some(original_key_text) = key_text {
                 let mut key_text = original_key_text;
                 if self.alt {
-                    if let Some(modify) = key_event.text_with_all_modifiers() {
+                    if let Some(modify) = key_event_text(key_event) {
                         key_text = modify;
                     }
                 }
@@ -194,8 +194,24 @@ fn use_alt(alt: bool) -> bool {
 // The option or alt key is used on Macos for character set changes
 // and does not operate the same as other systems.
 #[cfg(target_os = "macos")]
-fn use_alt(_: bool) -> bool {
-    false
+fn use_alt(alt: bool) -> bool {
+    let settings = SETTINGS.get::<KeyboardSettings>();
+    settings.macos_alt_is_meta && alt
+}
+
+#[cfg(not(target_os = "macos"))]
+fn key_event_text(key_event: &KeyEvent) -> Option<&str> {
+    key_event.text_with_all_modifiers()
+}
+
+#[cfg(target_os = "macos")]
+fn key_event_text(key_event: &KeyEvent) -> Option<&str> {
+    let settings = SETTINGS.get::<KeyboardSettings>();
+    if settings.macos_alt_is_meta {
+        key_event.text
+    } else {
+        key_event.text_with_all_modifiers()
+    }
 }
 
 fn or_empty(condition: bool, text: &str) -> &str {

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -35,4 +35,5 @@ impl Default for WindowSettings {
 #[setting_prefix = "input"]
 pub struct KeyboardSettings {
     pub use_logo: bool,
+    pub macos_alt_is_meta: bool,
 }


### PR DESCRIPTION
By default on MacOS pressing a key combination containing an Alt key produces a special character:

    <Alt+s> -> ß
    <Alt+v> -> √
    ...

This is really unfortunate if you want to use those key combinations as shortcuts and usually this case has to be separately handled by the app.

This commit introduces a new configuration flag `neovide_macos_alt_is_meta`. When the flag is set to true then all the
<Alt+key> combinations are treated as shortcuts with no extra character modifications, i.e. pressing `Alt` and `s` indeed emits a `<M-s>` shortcut.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?

Fixes #1046 

## Did this PR introduce a breaking change? 

No, as far as I can tell