### PR TITLE
GA cargo test fail fix for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,20 +20,20 @@ jobs:
       - name: Install Utilities
         run: |
           cargo install cargo2junit
-
       - uses: Swatinem/rust-cache@v1
 
       - name: Check Formatting
         run: |
           cargo fmt --all -- --check
-
       - name: Install Neovim
         run: |
           choco install -y neovim
+      - name: Add Neovim to PATH
+        run: echo "C:\tools\neovim\nvim-win64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Test
         env:
-          NEOVIM_BIN: "C:/tools/neovim/Neovim/bin/nvim.exe"
+          NEOVIM_BIN: "C:/tools/neovim/nvim-win64/bin/nvim.exe"
           RUST_BACKTRACE: full
         run: |
           # Pay attention not to break BUILD stage of a test,
@@ -47,7 +47,6 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
           # Oh, it still does not fail on Windows. ¯\_(ツ)_/¯
           cat results.json | cargo2junit > results.xml
-
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v1
         if: always()
@@ -57,7 +56,6 @@ jobs:
       - name: Build Release
         run: |
           cargo build --release
-
       - uses: actions/upload-artifact@v2
         with:
           name: neovide-windows


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix
Tests failing on Windows #1375

## Did this PR introduce a breaking change? 
- No

this occurred due to choco installing nvim in different location and not adding env path correctly.
Because of that, this test (test_read_initial_values ) failed.
since we are using std::process:exit(1), program exits in middle when it's not able to find nvim exec. 
Thats why when this particular test failed no useful error msg or info shown. maybe future refactoring!!

![image](https://user-images.githubusercontent.com/21097695/176590694-c5cc983b-8914-4f7a-82ea-2e78a3158275.png)
