### PR TITLE
Fixup Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ I've got more ideas for simple unobtrusive improvements. More to come.
 
 Configuration is done almost completely via global neovide variables in your vim config and can be manipulated live at runtime. Details can be found [here](https://github.com/neovide/neovide/wiki/Configuration).
 
+Note: Neovide requires that a font be set in `init.vim` otherwise errors might be encountered.
+See [#527](https://github.com/neovide/neovide/issues/527)
+
 ## Install
 
 **Note**: Building instructions are somewhat limited at the moment. All the libraries I use are cross platform and should have
@@ -198,9 +201,6 @@ nvim PKGBUILD
 makepkg -si
 ```
 
-Note: Neovide requires that a font be set in `init.vim` otherwise errors might be encountered.
-See [#527](https://github.com/neovide/neovide/issues/527)
-
 ##### With non-default branch
 
 ```sh
@@ -211,6 +211,7 @@ sed "$REGEX" PKGBUILD
 makepkg -si
 ```
 #### With Snap
+
 Neovide is also available in the Snap Store. You can install it
 using the command below.
 
@@ -221,6 +222,7 @@ snap install neovide
 
 
 #### From source
+
 1. Install necessary dependencies (adjust for your preferred package manager)
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -174,42 +174,16 @@ $ scoop install neovide
 
 #### Arch Linux
 
-There is an [AUR package for neovide](https://aur.archlinux.org/packages/neovide-git/).
-
-##### With Paru (or your preferred AUR helper)
+Stable releases are [packaged in the community repository](https://archlinux.org/packages/community/x86_64/neovide).
 
 ```sh
-paru -S neovide-git
+pacman -S neovide
 ```
 
-##### Without helper
+To run a development version you can build from [the VCS package in the AUR](https://aur.archlinux.org/packages/neovide-git).
+This can be built and installed using an AUR helper or [by hand in the usual way](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
+To build from a non-default branch you can edit the PKGBUILD and add `#branch-name` to the end of the source URL.
 
-```sh
-git clone https://aur.archlinux.org/neovide-git.git
-cd neovide-git
-makepkg -si
-```
-
-To install a non-default branch:
-
-```sh
-git clone https://aur.archlinux.org/neovide-git.git
-cd neovide-git
-nvim PKGBUILD
-:%s/l}/l}#branch=branch-name-here/
-:wq
-makepkg -si
-```
-
-##### With non-default branch
-
-```sh
-git clone https://aur.archlinux.org/neovide-git.git
-cd neovide-git
-REGEX=$(printf 's/{url}/&\#branch=%s/g' '<YOUR-BRANCH-HERE>')
-sed "$REGEX" PKGBUILD
-makepkg -si
-```
 #### With Snap
 
 Neovide is also available in the Snap Store. You can install it


### PR DESCRIPTION
Arch Linux has official packages now, these new instructions reflect that.

Also there was duplicated/conflicting instructions for building from the AUR. I really think it's better to scrap all that and let the Arch Wiki help people build packages if they don't know how to already, upstream project README's aren't a good home for detailed instructions on how to use a distro.
