### PR TITLE
Use grid_scroll event for smooth scrolling

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -223,14 +223,6 @@ pub enum RedrawEvent {
         scrolled: bool,
         separator_character: String,
     },
-    WindowViewport {
-        grid: u64,
-        top_line: f64,
-        bottom_line: f64,
-        current_line: f64,
-        current_column: f64,
-        line_count: Option<f64>,
-    },
     CommandLineShow {
         content: StyledContent,
         position: u64,
@@ -679,26 +671,6 @@ fn parse_msg_set_pos(msg_set_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
     })
 }
 
-fn parse_win_viewport(win_viewport_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let ([grid, _window, top_line, bottom_line, current_line, current_column], [line_count]) =
-        extract_values_with_optional(win_viewport_arguments)?;
-
-    let line_count = if let Some(line_count) = line_count {
-        Some(parse_f64(line_count)?)
-    } else {
-        None
-    };
-
-    Ok(RedrawEvent::WindowViewport {
-        grid: parse_u64(grid)?,
-        top_line: parse_f64(top_line)?,
-        bottom_line: parse_f64(bottom_line)?,
-        current_line: parse_f64(current_line)?,
-        current_column: parse_f64(current_column)?,
-        line_count,
-    })
-}
-
 fn parse_styled_content(line: Value) -> Result<StyledContent> {
     parse_array(line)?
         .into_iter()
@@ -853,7 +825,6 @@ pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
             "win_hide" => Some(parse_win_hide(event_parameters)?),
             "win_close" => Some(parse_win_close(event_parameters)?),
             "msg_set_pos" => Some(parse_msg_set_pos(event_parameters)?),
-            "win_viewport" => Some(parse_win_viewport(event_parameters)?),
             "cmdline_show" => Some(parse_cmdline_show(event_parameters)?),
             "cmdline_pos" => Some(parse_cmdline_pos(event_parameters)?),
             "cmdline_special_char" => Some(parse_cmdline_special_char(event_parameters)?),

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -210,12 +210,6 @@ impl Editor {
                 RedrawEvent::MessageSetPosition { grid, row, .. } => {
                     self.set_message_position(grid, row)
                 }
-                RedrawEvent::WindowViewport {
-                    grid,
-                    top_line,
-                    bottom_line,
-                    ..
-                } => self.send_updated_viewport(grid, top_line, bottom_line),
                 _ => {}
             },
             EditorCommand::RedrawScreen => self.redraw_screen(),
@@ -426,14 +420,6 @@ impl Editor {
                 .ok();
 
             self.redraw_screen();
-        }
-    }
-
-    fn send_updated_viewport(&mut self, grid: u64, top_line: f64, bottom_line: f64) {
-        if let Some(window) = self.windows.get_mut(&grid) {
-            window.update_viewport(top_line, bottom_line);
-        } else {
-            trace!("viewport event received before window initialized");
         }
     }
 

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -313,13 +313,6 @@ impl Window {
     pub fn close(&self) {
         self.send_command(WindowDrawCommand::Close);
     }
-
-    pub fn update_viewport(&self, top_line: f64, bottom_line: f64) {
-        self.send_command(WindowDrawCommand::Viewport {
-            top_line,
-            bottom_line,
-        });
-    }
 }
 
 #[cfg(test)]

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -256,8 +256,8 @@ impl CursorRenderer {
 
         if let Some(window) = windows.get(&self.cursor.parent_window_id) {
             let grid_x = cursor_grid_x as f32 + window.grid_current_position.x;
-            let mut grid_y = cursor_grid_y as f32 + window.grid_current_position.y
-                - (window.current_scroll - window.current_surface.top_line as f32);
+            let mut grid_y =
+                cursor_grid_y as f32 + window.grid_current_position.y - window.current_scroll;
 
             // Prevent the cursor from targeting a position outside its current window. Since only
             // the vertical direction is effected by scrolling, we only have to clamp the vertical

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -186,12 +186,7 @@ impl RenderedWindow {
                 self.scroll_t = (self.scroll_t + dt / settings.scroll_animation_length).min(1.0);
             }
 
-            self.current_scroll = ease(
-                ease_out_expo,
-                self.start_scroll,
-                0.0,
-                self.scroll_t,
-            );
+            self.current_scroll = ease(ease_out_expo, self.start_scroll, 0.0, self.scroll_t);
         }
 
         animating


### PR DESCRIPTION
This removes usage of the `win_viewport` event, which was previously used for smooth scrolling. It replaces its usage with the `grid_scroll` event which is better fit to trigger smooth scrolling behavior, as
1. `win_viewport` contains positional information in terms of buffer lines, but these do not always relate 1:1 to drawn lines e.g. when using folds
2. `win_viewport` is triggered in cases where there is no actual scrolling happening e.g. when jumping around in files while doing substitution. This sometimes causes jumpy behavior.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fixes #1334.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
