### PR TITLE
ci: remove unncessary dirs in linux artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,8 @@ jobs:
 
       - name: Archive Linux artifact
         run: |
-          tar czvf ./target/release/neovide.tar.gz ./target/release/neovide
+          cd ./target/release/
+          tar czvf neovide.tar.gz neovide
 
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
## Problem
The linux archive ships with un-necessary dir's, 
```
kar@earth:~$ tar -tf Downloads/neovide.tar.gz
./target/release/neovide
```
## Solution
This patch removes them & archives just the binary
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
