### PR TITLE
Clipboard: Read channel id from nvim variable

### DIFF
--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -4,6 +4,38 @@ use rmpv::Value;
 
 use crate::{bridge::TxWrapper, error_handling::ResultPanicExplanation};
 
+const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
+    local function set_clipboard(register)
+        return function(lines, regtype)
+            vim.rpcnotify(
+                vim.g.neovide_channel_id,
+                'neovide.set_clipboard',
+                lines,
+                regtype,
+                register
+            )
+        end
+    end
+
+    local function get_clipboard(register)
+        return function()
+            return vim.rpcrequest(vim.g.neovide_channel_id, 'neovide.get_clipboard', register)
+        end
+    end
+
+    vim.g.clipboard = {
+        name = 'neovide',
+        copy = {
+            ['+'] = set_clipboard('+'),
+            ['*'] = set_clipboard('*'),
+        },
+        paste = {
+            ['+'] = get_clipboard('+'),
+            ['*'] = get_clipboard('*'),
+        },
+        cache_enabled = 0
+    }";
+
 pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<TxWrapper>, neovide_channel: u64) {
     // users can opt-out with
     // vim: `let g:neovide_no_custom_clipboard = v:true`
@@ -18,30 +50,12 @@ pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<TxWrapper>, neovide_ch
         return;
     }
 
-    // don't know how to setup lambdas with Value, so use string as command
-    let custom_clipboard = r#"
-        let g:clipboard = {
-          'name': 'custom',
-          'copy': {
-            '+': {
-              lines,
-              regtype -> rpcnotify(neovide_channel, 'neovide.set_clipboard', lines, regtype, '+')
-            },
-            '*': {
-              lines,
-              regtype -> rpcnotify(neovide_channel, 'neovide.set_clipboard', lines, regtype, '*')
-            },
-          },
-          'paste': {
-            '+': {-> rpcrequest(neovide_channel, 'neovide.get_clipboard', '+')},
-            '*': {-> rpcrequest(neovide_channel, 'neovide.get_clipboard', '*')},
-          },
-          'cache_enabled': 0
-        }
-        "#
-    .replace('\n', "") // make one-liner, because multiline is not accepted (?)
-    .replace("neovide_channel", &neovide_channel.to_string());
-    nvim.command(&custom_clipboard).await.ok();
+    nvim.set_var("neovide_channel_id", Value::from(neovide_channel))
+        .await
+        .ok();
+    nvim.execute_lua(&REGISTER_CLIPBOARD_PROVIDER_LUA, vec![])
+        .await
+        .ok();
 }
 
 pub async fn setup_neovide_specific_state(nvim: &Neovim<TxWrapper>, is_remote: bool) {


### PR DESCRIPTION
[Clipboard providers are only loaded once by Neovim](https://github.com/neovim/neovim/issues/8017), causing the previous code to use an obsolete channel id when reconnecting to a remote nvim instance.

Fixes #1329.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
I hope not.
