### PR TITLE
macos: open filepath which contains spaces correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_json",
+ "shlex",
  "skia-safe",
  "swash",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rand = "0.8.5"
 rmpv = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
+shlex = "1.1.0"
 swash = "0.1.4"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7.1", features = ["compat"] }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -170,12 +170,17 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
         neovim_args.push("-p".to_owned());
     }
 
-    neovim_args.extend::<Vec<String>>(
-        files_to_open
-            .iter()
-            .map(|file| file.replace(" ", "\\ "))
-            .collect(),
-    );
+    if cfg!(target_os = "macos") {
+        // escape filepath which contain spaces
+        neovim_args.extend::<Vec<String>>(
+            files_to_open
+                .iter()
+                .map(|file| file.replace(" ", "\\ "))
+                .collect(),
+        );
+    } else {
+        neovim_args.extend::<Vec<String>>(files_to_open);
+    }
 
     /*
      * Integrate Environment Variables as Defaults to the command-line ones.

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -172,11 +172,10 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
 
     if cfg!(target_os = "macos") {
         // escape filepath which contain spaces
-        neovim_args.extend::<Vec<String>>(
+        neovim_args.extend(
             files_to_open
                 .iter()
-                .map(|file| file.replace(" ", "\\ "))
-                .collect(),
+                .map(|file| shlex::quote(file).into_owned()),
         );
     } else {
         neovim_args.extend::<Vec<String>>(files_to_open);

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -170,7 +170,12 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
         neovim_args.push("-p".to_owned());
     }
 
-    neovim_args.extend::<Vec<String>>(files_to_open);
+    neovim_args.extend::<Vec<String>>(
+        files_to_open
+            .iter()
+            .map(|file| file.replace(" ", "\\ "))
+            .collect(),
+    );
 
     /*
      * Integrate Environment Variables as Defaults to the command-line ones.


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix
#1399

## Did this PR introduce a breaking change? 
- No

Currently tested against mac and windows os.

for some reason enclosing singlequotes around filepath doesnt worked as expected as mentioned by aJuvan. so went with escaping space with backslash.
