### PR TITLE
ci: strip linux artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,7 @@ jobs:
       - name: Archive Linux artifact
         run: |
           cd ./target/release/
+          strip neovide
           tar czvf neovide.tar.gz neovide
 
       - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Stripping the binary is drastically reducing it's size! Thus saves a lot of space for the user! Closes #1041 



```
kar@earth:~/Downloads$ du -sh neovide
95M	neovide
kar@earth:~/Downloads$ strip neovide
kar@earth:~/Downloads$ du -sh neovide
19M	neovide
```

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No
