### PR TITLE
Enable confirm quit by default

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -127,7 +127,7 @@ impl ParallelCommand {
     async fn execute(self, nvim: &Neovim<TxWrapper>) {
         match self {
             ParallelCommand::Quit => {
-                nvim.command("confirm qa").await.ok();
+                nvim.command("if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif").await.ok();
             }
             ParallelCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -127,11 +127,7 @@ impl ParallelCommand {
     async fn execute(self, nvim: &Neovim<TxWrapper>) {
         match self {
             ParallelCommand::Quit => {
-                nvim.command(
-                    "if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif",
-                )
-                .await
-                .ok();
+                nvim.command("confirm qa").await.ok();
             }
             ParallelCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -127,7 +127,11 @@ impl ParallelCommand {
     async fn execute(self, nvim: &Neovim<TxWrapper>) {
         match self {
             ParallelCommand::Quit => {
-                nvim.command("if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif").await.ok();
+                nvim.command(
+                    "if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif",
+                )
+                .await
+                .ok();
             }
             ParallelCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -13,6 +13,7 @@ pub struct WindowSettings {
     pub touch_deadzone: f32,
     pub touch_drag_timeout: f32,
     pub background_color: String,
+    pub confirm_quit: bool,
 }
 
 impl Default for WindowSettings {
@@ -29,6 +30,7 @@ impl Default for WindowSettings {
             touch_deadzone: 6.0,
             touch_drag_timeout: 0.17,
             background_color: "".to_string(),
+            confirm_quit: true,
         }
     }
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -95,6 +95,19 @@ Setting `g:neovide_fullscreen` to a boolean value will set whether the app shoul
 screen. This uses the so called "windowed fullscreen" mode that is sometimes used in games which
 want quick window switching.
 
+
+#### Confirm Quit
+
+```vim
+let g:neovide_confirm_quit=v:false
+" or
+let g:neovide_confirm_quit=0
+```
+
+When buffer having unsaved changes, setting `g:neovide_confirm_quit` to a boolean value will confirm quit
+before closing neovide window. Enabled by default.
+
+
 #### Remember Previous Window Size
 
 ```vim

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -95,7 +95,6 @@ Setting `g:neovide_fullscreen` to a boolean value will set whether the app shoul
 screen. This uses the so called "windowed fullscreen" mode that is sometimes used in games which
 want quick window switching.
 
-
 #### Confirm Quit
 
 ```vim
@@ -106,7 +105,6 @@ let g:neovide_confirm_quit=0
 
 If set to `true`, quitting while having unsaved changes will require confirmation.
 Enabled by default.
-
 
 #### Remember Previous Window Size
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -104,8 +104,8 @@ let g:neovide_confirm_quit=v:false
 let g:neovide_confirm_quit=0
 ```
 
-When buffer having unsaved changes, setting `g:neovide_confirm_quit` to a boolean value will confirm quit
-before closing neovide window. Enabled by default.
+If set to `true`, quitting while having unsaved changes will require confirmation.
+Enabled by default.
 
 
 #### Remember Previous Window Size


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Refactor

## Did this PR introduce a breaking change? 
- No

This is the default behaviour in nvim-qt. So enabled it by default.
#1247 - original PR with flag. 