### PR TITLE
fix(cargo.toml): rm debug symbols in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ version = "0.52.0"
 lto = true
 incremental = true
 strip = true
+opt-level = "z"  # Optimize for size.
 
 [package.metadata.bundle]
 name = "Neovide"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ version = "0.52.0"
 [profile.release]
 lto = true
 incremental = true
+strip = true
 
 [package.metadata.bundle]
 name = "Neovide"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ version = "0.52.0"
 lto = true
 incremental = true
 strip = true
-opt-level = "z"  # Optimize for size.
 
 [package.metadata.bundle]
 name = "Neovide"


### PR DESCRIPTION
Helps further slimming of the binary. 

Info:
1. https://doc.rust-lang.org/cargo/reference/profiles.html#strip
2. https://github.com/johnthagen/min-sized-rust#optimize-for-size

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No
