### PR TITLE
Changed default for use_logo to true for MacOS

### DIFF
--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -31,9 +31,19 @@ impl Default for WindowSettings {
     }
 }
 
-#[derive(Clone, Default, SettingGroup)]
+#[derive(Clone, SettingGroup)]
 #[setting_prefix = "input"]
 pub struct KeyboardSettings {
     pub use_logo: bool,
     pub macos_alt_is_meta: bool,
+}
+
+impl Default for KeyboardSettings {
+    fn default() -> Self {
+        if cfg!(target_os = "macos") {
+            Self { use_logo: true, macos_alt_is_meta: false }
+        } else {
+            Self { use_logo: false, macos_alt_is_meta: false }
+        }
+    }
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -40,10 +40,9 @@ pub struct KeyboardSettings {
 
 impl Default for KeyboardSettings {
     fn default() -> Self {
-        if cfg!(target_os = "macos") {
-            Self { use_logo: true, macos_alt_is_meta: false }
-        } else {
-            Self { use_logo: false, macos_alt_is_meta: false }
+        Self {
+            use_logo: cfg!(target_os = "macos"),
+            macos_alt_is_meta: false,
         }
     }
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -109,6 +109,7 @@ Setting `g:neovide_input_use_logo` to a boolean value will change how logo key (
 [command key](https://en.wikipedia.org/wiki/Command_key) or
 [windows key](https://en.wikipedia.org/wiki/Windows_key)) is handled, allowing all key combinations
 containing logo to be forwarded to neovim.
+On MacOS, this defaults to `true` (so that e.g. `cmd+v` works for pasting with respective setup of `init.vim`), and to `false` for other platforms (that typically use e.g. `ctrl+v` for pasting).
 
 #### macOS Alt is Meta
 


### PR DESCRIPTION
Changes the default for use_logo for MacOS to avoid confusion with new users. 

See https://github.com/neovide/neovide/issues/1263
