### PR TITLE
Make x11 WM_CLASS property's instance part configurable

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -22,6 +22,7 @@ pub struct CmdLineSettings {
     pub neovim_bin: Option<String>,
     pub wayland_app_id: String,
     pub x11_wm_class: String,
+    pub x11_wm_class_instance: String,
     // Disable open multiple files as tabs
     pub no_tabs: bool,
 }
@@ -46,6 +47,7 @@ impl Default for CmdLineSettings {
             // Command-line arguments with environment variable fallback
             neovim_bin: None,
             wayland_app_id: String::new(),
+            x11_wm_class_instance: String::new(),
             x11_wm_class: String::new(),
             // Disable open multiple files as tabs
             no_tabs: false,
@@ -146,10 +148,16 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
                 .help("Specify an App ID for Wayland"),
         )
         .arg(
+            Arg::new("x11_wm_class_instance")
+                .long("x11-wm-class-instance")
+                .takes_value(true)
+                .help("Specify the instance part of the X11 WM_CLASS property"),
+        )
+        .arg(
             Arg::new("x11_wm_class")
                 .long("x11-wm-class")
                 .takes_value(true)
-                .help("Specify an X11 WM class"),
+                .help("Specify the class part of the X11 WM_CLASS property"),
         );
 
     let matches = clapp.get_matches_from(args);
@@ -217,6 +225,11 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
             .value_of("wayland_app_id")
             .map(|v| v.to_owned())
             .or_else(|| std::env::var("NEOVIDE_APP_ID").ok())
+            .unwrap_or_else(|| "neovide".to_owned()),
+        x11_wm_class_instance: matches
+            .value_of("x11_wm_class_instance")
+            .map(|v| v.to_owned())
+            .or_else(|| std::env::var("NEOVIDE_X11_WM_CLASS_INSTANCE").ok())
             .unwrap_or_else(|| "neovide".to_owned()),
         x11_wm_class: matches
             .value_of("x11_wm_class")

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -335,7 +335,7 @@ pub fn create_window() {
     #[cfg(target_os = "linux")]
     let winit_window_builder = winit_window_builder
         .with_app_id(cmd_line_settings.wayland_app_id)
-        .with_class("neovide".to_string(), cmd_line_settings.x11_wm_class);
+        .with_class(cmd_line_settings.x11_wm_class_instance, cmd_line_settings.x11_wm_class);
 
     let windowed_context = ContextBuilder::new()
         .with_pixel_format(24, 8)

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -335,7 +335,10 @@ pub fn create_window() {
     #[cfg(target_os = "linux")]
     let winit_window_builder = winit_window_builder
         .with_app_id(cmd_line_settings.wayland_app_id)
-        .with_class(cmd_line_settings.x11_wm_class_instance, cmd_line_settings.x11_wm_class);
+        .with_class(
+            cmd_line_settings.x11_wm_class_instance,
+            cmd_line_settings.x11_wm_class,
+        );
 
     let windowed_context = ContextBuilder::new()
         .with_pixel_format(24, 8)

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -104,6 +104,7 @@ containing trace events which may help debug an issue.
 
 ```sh
 --wayland-app-id <wayland_app_id> or an environment variable called NEOVIDE_APP_ID
+--x11-wm-class-instance <x11_wm_class_instance> or an environment variable called NEOVIDE_WM_CLASS_INSTANCE
 --x11-wm-class <x11_wm_class> or an environment variable called NEOVIDE_WM_CLASS
 ```
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

Adds support for configuring the **instance** part of the x11 `WM_CLASS` property.

I basically just copied the code for the `x11-wm-class` config option and changed the name (`x11-wm-class-instance`). So, this will allow configuration via the command line or an environment variable.

### Why?

Previously, https://github.com/neovide/neovide/pull/834 added support for explicitly setting the **class** part of the x11 `WM_CLASS` property. The **instance** part was hardcoded to be `neovide`. But, as of the [icccm specs for this property](https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#wm_class_property):
> Resources that are specified by instance name override any resources that are specified by class name

This means that systems which adhere to this spec will not consider the custom **class** part, and instead always use the **instance** part, ie `neovide`. 

For example with gnome-shell we can see this particular effect in the mapping of `window -> .desktop file`. Gnome first tries to find a desktop entry named after the **instance** part of the `WM_CLASS` property, and only if that fails tries the **class** part (sources [here](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/9be136adc09fe16da17bbac2354cea9c6b4a3e3f/src/shell-window-tracker.c#L418) and [here](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/9be136adc09fe16da17bbac2354cea9c6b4a3e3f/src/shell-window-tracker.c#L210) in case someone is interested). This behavior can be observed when creating a custom `.desktop` file which launches Neovide and then pinning this desktop entry to the Gnome dash (comparable to the quick access icons in the Windows task-bar). Normally, you would expect that clicking the entry would open the existing window if the application already runs. But instead a *new* window appears. My understanding of this behavior is that Gnome associated the existing window automatically to the `neovide.desktop` entry via the **instance** part of the window's `WM_CLASS` property, which causes it to assume that the custom desktop entry is currently *not* running.  Explicitly passing `x11-wm-class` does not help here, because **instance** is checked first. But, if we allow the **instance** part to be renamed it can be set manually to be the same as the name of the `.desktop` file, which resolves this problem.

Note that this is my particular use case, but I expect other desktop environments to behave similar. In any case, I see no downside of making this bit configurable, I just wanted to give a concrete example of how it could be useful. 

### How to test?

If you are on Linux, and you are using x11, you can test this pretty easily with the command `xprop | grep WM_CLASS`. This will allow you to select a window with the mouse and then give you the value for its `WM_CLASS` property.

For example, launching Neovide without any arguments:
`> WM_CLASS(STRING) = "neovide", "neovide"`
Launching Neovide with `-x11-wm-class` set to `custom-class`:
`> WM_CLASS(STRING) = "neovide", "custom-class"`
And launching Neovide with `-x11-wm-class-instance` additionally set to `custom-instance`:
`> WM_CLASS(STRING) = "custom-instance", "custom-class"`

### Backwards compatibility considerations

I implemented this configuration options as an additional command line argument, rather then reusing the already existing one, to preserve backwards compatibility. Still, I think making **instance** and **class** configurable via only one option would be cleaner, it reduces the overall number of cmd arguments and it just makes more sense considering that `WM_CLASS` is also just one property. At the same time, I do not think it is worth breaking backwards compatibility just for this feature.

Another option would be to introduce a new configuration option which allows setting both **instance** and **class**, and possible also the Wayland ID (see for example [how Alacritty does this](https://www.mankier.com/1/alacritty#--class)). The existing options could be marked as deprecated and later removed. I did not implement this right now, because I am questioning if this is even worth the effort (I am referring to the effort of deprecating and then removing the already existing options, implementing this new one is not a big task at all).

Please let me know if you would rather accept this PR as is, or if I should instead implement this new "all-in-one" option.