### PR TITLE
small fix for unstable library feature

### DIFF
--- a/src/settings/window_geometry.rs
+++ b/src/settings/window_geometry.rs
@@ -86,14 +86,14 @@ pub fn save_window_geometry(
                 size: {
                     window_settings
                         .remember_window_size
-                        .then_some(grid_size)
+                        .then(|| grid_size)
                         .flatten()
                         .unwrap_or(DEFAULT_WINDOW_GEOMETRY)
                 },
                 position: {
                     window_settings
                         .remember_window_position
-                        .then_some(position)
+                        .then(|| position)
                         .flatten()
                         .unwrap_or_default()
                 },


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- I honestly don't know. but i don't think so.

## Explanation:
I found when i was compiling the v0.9.0 on Windows it says:

```
error[E0658]: use of unstable library feature 'bool_to_option'
  --> src\settings\window_geometry.rs:89:26
   |
89 |                         .then_some(grid_size)
   |                          ^^^^^^^^^
   |
   = note: see issue #80967 <https://github.com/rust-lang/rust/issues/80967> for more information

error[E0658]: use of unstable library feature 'bool_to_option'
  --> src\settings\window_geometry.rs:96:26
   |
96 |                         .then_some(position)
   |                          ^^^^^^^^^
   |
   = note: see issue #80967 <https://github.com/rust-lang/rust/issues/80967> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `neovide` due to 2 previous errors
```
and in the mentioned Github issue there is this message: <https://github.com/rust-lang/rust/issues/80967#issuecomment-759382572>
which states:
"Every use of the `then_some` function can be trivially translated to use `then` instead, by adding `||` in front of the argument"
the following messages state some situations where this fix isn't this easy but in this case i could just change to the `then` function. 
