### PR TITLE
Handle different underlining styles supported by neovim

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::{self, Debug},
 };
 
-use log::{debug};
+use log::debug;
 use rmpv::Value;
 use skia_safe::Color4f;
 
@@ -496,11 +496,21 @@ fn parse_style(style_map: Value) -> Result<Style> {
                 ("blend", Value::Integer(blend)) => style.blend = blend.as_u64().unwrap() as u8,
 
                 // TODO: handle correct precedence?
-                ("underline", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::Underline),
-                ("undercurl", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderCurl),
-                ("underdotted", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderDot),
-                ("underdashed", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderDash),
-                ("underdouble", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderDouble),
+                ("underline", Value::Boolean(true)) => {
+                    style.underline = Some(UnderlineStyle::Underline)
+                }
+                ("undercurl", Value::Boolean(true)) => {
+                    style.underline = Some(UnderlineStyle::UnderCurl)
+                }
+                ("underdotted", Value::Boolean(true)) => {
+                    style.underline = Some(UnderlineStyle::UnderDot)
+                }
+                ("underdashed", Value::Boolean(true)) => {
+                    style.underline = Some(UnderlineStyle::UnderDash)
+                }
+                ("underdouble", Value::Boolean(true)) => {
+                    style.underline = Some(UnderlineStyle::UnderDouble)
+                }
 
                 _ => debug!("Ignored style attribute: {}", name),
             }

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -502,13 +502,13 @@ fn parse_style(style_map: Value) -> Result<Style> {
                 ("undercurl", Value::Boolean(true)) => {
                     style.underline = Some(UnderlineStyle::UnderCurl)
                 }
-                ("underdotted", Value::Boolean(true)) => {
+                ("underdotted" | "underdot", Value::Boolean(true)) => {
                     style.underline = Some(UnderlineStyle::UnderDot)
                 }
-                ("underdashed", Value::Boolean(true)) => {
+                ("underdashed" | "underdash", Value::Boolean(true)) => {
                     style.underline = Some(UnderlineStyle::UnderDash)
                 }
-                ("underdouble", Value::Boolean(true)) => {
+                ("underdouble" | "underlineline", Value::Boolean(true)) => {
                     style.underline = Some(UnderlineStyle::UnderDouble)
                 }
 

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -4,11 +4,11 @@ use std::{
     fmt::{self, Debug},
 };
 
-use log::debug;
+use log::{debug};
 use rmpv::Value;
 use skia_safe::Color4f;
 
-use crate::editor::{Colors, CursorMode, CursorShape, Style};
+use crate::editor::{Colors, CursorMode, CursorShape, Style, UnderlineStyle};
 
 #[derive(Clone, Debug)]
 pub enum ParseError {
@@ -493,9 +493,15 @@ fn parse_style(style_map: Value) -> Result<Style> {
                 ("strikethrough", Value::Boolean(strikethrough)) => {
                     style.strikethrough = strikethrough
                 }
-                ("underline", Value::Boolean(underline)) => style.underline = underline,
-                ("undercurl", Value::Boolean(undercurl)) => style.undercurl = undercurl,
                 ("blend", Value::Integer(blend)) => style.blend = blend.as_u64().unwrap() as u8,
+
+                // TODO: handle correct precedence?
+                ("underline", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::Underline),
+                ("undercurl", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderCurl),
+                ("underdotted", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderDot),
+                ("underdashed", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderDash),
+                ("underdouble", Value::Boolean(true)) => style.underline = Some(UnderlineStyle::UnderDouble),
+
                 _ => debug!("Ignored style attribute: {}", name),
             }
         } else {

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -495,7 +495,6 @@ fn parse_style(style_map: Value) -> Result<Style> {
                 }
                 ("blend", Value::Integer(blend)) => style.blend = blend.as_u64().unwrap() as u8,
 
-                // TODO: handle correct precedence?
                 ("underline", Value::Boolean(true)) => {
                     style.underline = Some(UnderlineStyle::Underline)
                 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 pub use cursor::{Cursor, CursorMode, CursorShape};
 pub use draw_command_batcher::DrawCommandBatcher;
 pub use grid::CharacterGrid;
-pub use style::{Colors, Style};
+pub use style::{Colors, Style, UnderlineStyle};
 pub use window::*;
 
 const MODE_CMDLINE: u64 = 4;

--- a/src/editor/style.rs
+++ b/src/editor/style.rs
@@ -7,6 +7,15 @@ pub struct Colors {
     pub special: Option<Color4f>,
 }
 
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum UnderlineStyle {
+    Underline,
+    UnderDouble,
+    UnderDash,
+    UnderDot,
+    UnderCurl,
+}
+
 #[derive(new, Debug, Clone, PartialEq)]
 pub struct Style {
     pub colors: Colors,
@@ -19,11 +28,9 @@ pub struct Style {
     #[new(default)]
     pub strikethrough: bool,
     #[new(default)]
-    pub underline: bool,
-    #[new(default)]
-    pub undercurl: bool,
-    #[new(default)]
     pub blend: u8,
+    #[new(default)]
+    pub underline: Option<UnderlineStyle>,
 }
 
 impl Style {

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -309,7 +309,7 @@ impl Window {
         self.send_command(WindowDrawCommand::Clear);
         // Draw the lines from the bottom up so that underlines don't get overwritten by the line
         // below.
-        for row in self.grid.height..0 {
+        for row in (0..self.grid.height).rev() {
             self.redraw_line(row);
         }
     }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -225,7 +225,17 @@ impl Window {
                 );
             }
 
+            // Due to the limitations of the current rendering strategy, some underlines get
+            // clipped by the line below. To mitigate that, we redraw the adjacent lines whenever
+            // an individual line is redrawn. Unfortunately, some clipping still happens.
+            // TODO: figure out how to solve this
+            if row < self.grid.height - 1 {
+                self.redraw_line(row + 1);
+            }
             self.redraw_line(row);
+            if row > 0 {
+                self.redraw_line(row - 1);
+            }
         } else {
             warn!("Draw command out of bounds");
         }
@@ -297,7 +307,9 @@ impl Window {
 
     pub fn redraw(&self) {
         self.send_command(WindowDrawCommand::Clear);
-        for row in 0..self.grid.height {
+        // Draw the lines from the bottom up so that underlines don't get overwritten by the line
+        // below.
+        for row in self.grid.height..0 {
             self.redraw_line(row);
         }
     }

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -205,7 +205,9 @@ impl GridRenderer {
         canvas.save();
 
         let mut underline_paint = self.paint.clone();
-        let auto_scaling = SETTINGS.get::<RendererSettings>().underline_automatic_scaling;
+        let auto_scaling = SETTINGS
+            .get::<RendererSettings>()
+            .underline_automatic_scaling;
         // Arbitrary value under which we simply round the line thickness to 1. Anything else
         // results in ugly aliasing artifacts.
         let stroke_width = if self.shaper.current_size() < 15. || auto_scaling == false {

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -235,8 +235,8 @@ impl GridRenderer {
                 canvas.draw_line(p1, p2, &underline_paint);
             }
             UnderlineStyle::UnderCurl => {
-                let p1 = (p1.x, p1.y - 2.);
-                let p2 = (p2.x, p2.y - 2.);
+                let p1 = (p1.x, p1.y - 3. + stroke_width);
+                let p2 = (p2.x, p2.y - 3. + stroke_width);
                 underline_paint
                     .set_path_effect(None)
                     .set_anti_alias(true)
@@ -245,10 +245,11 @@ impl GridRenderer {
                 path.move_to(p1);
                 let mut i = p1.0;
                 let mut sin = -2. * stroke_width;
-                while i <= p2.0 {
+                let increment = self.font_dimensions.width as f32 / 2.;
+                while i < p2.0 {
                     sin *= -1.;
-                    i += 4. * stroke_width;
-                    path.quad_to((i - 2. * stroke_width, p1.1 + sin), (i, p1.1));
+                    i += increment;
+                    path.quad_to((i - (increment / 2.), p1.1 + sin), (i, p1.1));
                 }
                 canvas.draw_path(&path, &underline_paint);
             }

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use glutin::dpi::PhysicalSize;
 use log::trace;
-use skia_safe::{colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Rect, HSV, Path, Point};
+use skia_safe::{
+    colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, Point, Rect, HSV,
+};
 
 use crate::{
     dimensions::Dimensions,
@@ -146,8 +148,14 @@ impl GridRenderer {
 
         if let Some(underline_style) = style.underline {
             let line_position = self.shaper.underline_position();
-            let p1 = (x as f32, (y - line_position + self.font_dimensions.height) as f32);
-            let p2 = ((x + width) as f32, (y - line_position + self.font_dimensions.height) as f32);
+            let p1 = (
+                x as f32,
+                (y - line_position + self.font_dimensions.height) as f32,
+            );
+            let p2 = (
+                (x + width) as f32,
+                (y - line_position + self.font_dimensions.height) as f32,
+            );
 
             self.draw_underline(canvas, &style, underline_style, p1.into(), p2.into())
         }
@@ -186,7 +194,14 @@ impl GridRenderer {
         canvas.restore();
     }
 
-    fn draw_underline(&self, canvas: &mut Canvas, style: &Arc<Style>, underline_style: UnderlineStyle, p1: Point, p2: Point) {
+    fn draw_underline(
+        &self,
+        canvas: &mut Canvas,
+        style: &Arc<Style>,
+        underline_style: UnderlineStyle,
+        p1: Point,
+        p2: Point,
+    ) {
         let mut underline_paint = self.paint.clone();
 
         underline_paint.set_color(style.special(&self.default_style.colors).to_color());
@@ -196,18 +211,19 @@ impl GridRenderer {
             UnderlineStyle::Underline => {
                 underline_paint.set_path_effect(None);
                 canvas.draw_line(p1, p2, &underline_paint);
-            },
+            }
             UnderlineStyle::UnderDouble => {
                 underline_paint.set_path_effect(None);
                 canvas.draw_line(p1, p2, &underline_paint);
                 let p1 = (p1.x, p1.y - 2 as f32);
                 let p2 = (p2.x, p2.y - 2 as f32);
                 canvas.draw_line(p1, p2, &underline_paint);
-            },
+            }
             UnderlineStyle::UnderCurl => {
                 let p1 = (p1.x, p1.y - 2.);
                 let p2 = (p2.x, p2.y - 2.);
-                underline_paint.set_path_effect(None)
+                underline_paint
+                    .set_path_effect(None)
                     .set_anti_alias(true)
                     .set_style(skia_safe::paint::Style::Stroke);
                 let mut path = Path::default();
@@ -220,21 +236,15 @@ impl GridRenderer {
                     path.quad_to((i - 2., p1.1 + sin), (i, p1.1));
                 }
                 canvas.draw_path(&path, &underline_paint);
-            },
+            }
             UnderlineStyle::UnderDash => {
-                underline_paint.set_path_effect(dash_path_effect::new(
-                    &[6.0, 2.0],
-                    0.0,
-                ));
+                underline_paint.set_path_effect(dash_path_effect::new(&[6.0, 2.0], 0.0));
                 canvas.draw_line(p1, p2, &underline_paint);
-            },
+            }
             UnderlineStyle::UnderDot => {
-                underline_paint.set_path_effect(dash_path_effect::new(
-                    &[1.0, 1.0],
-                    0.0,
-                ));
+                underline_paint.set_path_effect(dash_path_effect::new(&[1.0, 1.0], 0.0));
                 canvas.draw_line(p1, p2, &underline_paint);
-            },
+            }
         }
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -39,6 +39,7 @@ pub struct RendererSettings {
     floating_blur_amount_y: f32,
     debug_renderer: bool,
     profiler: bool,
+    underline_automatic_scaling: bool,
 }
 
 impl Default for RendererSettings {
@@ -52,6 +53,7 @@ impl Default for RendererSettings {
             floating_blur_amount_y: 2.0,
             debug_renderer: false,
             profiler: false,
+            underline_automatic_scaling: false,
         }
     }
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -117,7 +117,7 @@ corner.
 #### Underline automatic scaling
 
 ```vim
-let g:neovide_underline_automatic_scaling = v:true
+let g:neovide_underline_automatic_scaling = v:false
 ```
 
 Setting `g:neovide_underline_automatic_scaling` to a boolean value determines whether automatic

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -114,6 +114,19 @@ let g:neovide_profiler = v:false
 Setting this to `v:true` enables the profiler, which shows a frametime graph in the upper left
 corner.
 
+#### Underline automatic scaling
+
+```vim
+let g:neovide_underline_automatic_scaling = v:true
+```
+
+Setting `g:neovide_underline_automatic_scaling` to a boolean value determines whether automatic
+scaling of text underlines (including undercurl, underdash, etc.) is enabled. Noticeable for font
+sizes above 15.
+
+**Note**: This is currently glitchy, and leads to some underlines being clipped by the line of text
+below.
+
 ### Input Settings
 
 #### Use Logo Key


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Feature
- Fixes #764 

## Did this PR introduce a breaking change? 
- No

## Content
This overhauls the drawing of underlines and actually implements the
undercurl that was simulated with underdashes before.

Implemented in this PR:
* underline
![underline](https://user-images.githubusercontent.com/4097716/183495049-370bc6fe-02d0-4dcd-bb04-ff23ca3dd477.png)

* underdouble
![underdouble](https://user-images.githubusercontent.com/4097716/183495203-874e4060-1dc3-4eb2-b01f-00bc3def9043.png)

* underdashed
![underdashed](https://user-images.githubusercontent.com/4097716/183495116-a69e6a11-d28b-4470-8c0a-f0f05dfeb06a.png)

* underdotted
![underdotted](https://user-images.githubusercontent.com/4097716/183495240-9a4ba9c4-8c05-43ed-a771-8af536e7cd6c.png)

* undercurl
![undercurl](https://user-images.githubusercontent.com/4097716/183495149-874ba429-6c31-4c1b-a74c-86f92d264fb7.png)

## Points to note
* Previously the underline thickness was proportional to the stroke width. This led to weird aliasing artifacts when drawing lines (especially dashes and dots) and isn't in line with how most other terminal emulators handle this. With this PR, all the lines are pixel-perfect and 1px thick. If desired, it'll be easy to add a configuration option to make it possible to configure the line thickness, but I don't recommend making it proportional to the text itself.
* The undercurl looks (in my opinion) nice, but I don't really know what I'm doing here. I'm using quadratic interpolation from skia by generating points under the text every time. I haven't noticed any hangups, but I'm sure there's a better optimized way to do this if it becomes an issue.
* I'm not sure if there should be an order of precedence between the different line styles (cf the TODO left in the code for now). I'm inclined to say we leave it like that, as I don't think multiple underline styles can happen at the same time in neovim (don't quote me on this though).
* Maybe the gap between the dots for `underdotted` should be widened? I'm worried it'll look like a thin solid line on high-dpi screens.