### PR TITLE
Fix #1475

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -170,7 +170,7 @@ impl KeyboardManager {
         let special = special || self.ctrl || use_alt(self.alt) || self.logo;
 
         let open = or_empty(special, "<");
-        let modifiers = self.format_modifier_string(use_shift);
+        let modifiers = self.format_modifier_string(special || use_shift);
         let close = or_empty(special, ">");
 
         open.to_owned() + &modifiers + text + close


### PR DESCRIPTION
Before, CTRL+SHIFT keystrokes registered as like so:

CTRL+SHIFT+p = \<C-P> instead of \<C-S-p> or \<C-S-P>
CTRL+SHIFT+x = \<C-X> instead of \<C-S-x> or \<C-S-X>
...

So different keymaps couldn't be assigned to CTRL+x and CTRL+SHIFT+x
because nvim assumes it is the same mapping.

Now, CTRL+SHIFT+x is interpreted as \<C-S-X>, so different mappings can
be assigned to CTRL+x and CTRL+SHIFT+x.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Maybe, I don't know
