### PR TITLE
Make vsync configurable

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -71,6 +71,10 @@ pub struct CmdLineSettings {
     #[arg(long = "nosrgb", env = "NEOVIDE_NO_SRGB", action = ArgAction::SetFalse)]
     pub srgb: bool,
 
+    /// Do not try to request VSync on the window
+    #[arg(long = "novsync", env = "NEOVIDE_NO_VSYNC", action = ArgAction::SetFalse)]
+    pub vsync: bool,
+
     /// Which NeoVim binary to invoke headlessly instead of `nvim` found on $PATH
     #[arg(long = "neovim-bin", env = "NEOVIM_BIN")]
     pub neovim_bin: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ use cmd_line::CmdLineSettings;
 use editor::start_editor;
 use renderer::{cursor_renderer::CursorSettings, RendererSettings};
 use settings::SETTINGS;
-use window::{create_window, KeyboardSettings, VSync, WindowSettings};
+use window::{create_window, KeyboardSettings, WindowSettings};
 
 pub use channel_utils::*;
 pub use event_aggregator::*;
@@ -142,7 +142,7 @@ fn main() {
 
     start_bridge();
     start_editor();
-    create_window(VSync::Disabled);
+    create_window();
 }
 
 #[cfg(not(test))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ use cmd_line::CmdLineSettings;
 use editor::start_editor;
 use renderer::{cursor_renderer::CursorSettings, RendererSettings};
 use settings::SETTINGS;
-use window::{create_window, KeyboardSettings, WindowSettings};
+use window::{create_window, KeyboardSettings, VSync, WindowSettings};
 
 pub use channel_utils::*;
 pub use event_aggregator::*;
@@ -142,7 +142,7 @@ fn main() {
 
     start_bridge();
     start_editor();
-    create_window();
+    create_window(VSync::Disabled);
 }
 
 #[cfg(not(test))]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -350,11 +350,11 @@ pub fn create_window() {
         .with_pixel_format(24, 8)
         .with_stencil_buffer(8)
         .with_gl_profile(GlProfile::Core)
-        .with_srgb(cmd_line_settings.srgb);
+        .with_srgb(cmd_line_settings.srgb)
+        .with_vsync(cmd_line_settings.vsync);
 
     let windowed_context = match builder
         .clone()
-        .with_vsync(cmd_line_settings.vsync)
         .build_windowed(winit_window_builder.clone(), &event_loop)
     {
         Ok(ctx) => ctx,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -272,7 +272,12 @@ impl GlutinWindowWrapper {
     }
 }
 
-pub fn create_window() {
+pub enum VSync {
+    Enabled,
+    Disabled,
+}
+
+pub fn create_window(vsync: VSync) {
     let icon = {
         let icon = load_from_memory(ICON).expect("Failed to parse icon data");
         let (width, height) = icon.dimensions();
@@ -350,7 +355,10 @@ pub fn create_window() {
         .with_pixel_format(24, 8)
         .with_stencil_buffer(8)
         .with_gl_profile(GlProfile::Core)
-        .with_vsync(false)
+        .with_vsync(match vsync {
+            VSync::Enabled => true,
+            VSync::Disabled => false,
+        })
         .with_srgb(cmd_line_settings.srgb)
         .build_windowed(winit_window_builder, &event_loop)
         .unwrap();

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -272,12 +272,7 @@ impl GlutinWindowWrapper {
     }
 }
 
-pub enum VSync {
-    Enabled,
-    Disabled,
-}
-
-pub fn create_window(vsync: VSync) {
+pub fn create_window() {
     let icon = {
         let icon = load_from_memory(ICON).expect("Failed to parse icon data");
         let (width, height) = icon.dimensions();
@@ -355,10 +350,7 @@ pub fn create_window(vsync: VSync) {
         .with_pixel_format(24, 8)
         .with_stencil_buffer(8)
         .with_gl_profile(GlProfile::Core)
-        .with_vsync(match vsync {
-            VSync::Enabled => true,
-            VSync::Disabled => false,
-        })
+        .with_vsync(cmd_line_settings.vsync)
         .with_srgb(cmd_line_settings.srgb)
         .build_windowed(winit_window_builder, &event_loop)
         .unwrap();

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -121,7 +121,7 @@ or not.
 
 ## No VSync
 
-```
+```sh
 --novsync
 ```
 

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -119,6 +119,14 @@ buffers.
 Note: Even if files are opened in tabs, they're buffers anyways. It's just about them being visible
 or not.
 
+## No VSync
+
+```
+--novsync
+```
+
+By default, Neovide requests to use VSync on the created window. This option disables this behavior.
+
 ### Remote TCP
 
 ```sh


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

Maybe fixes #1248, by allowing the user to turn VSync off if not needed/automatically does so if creation fails. Do not merge until some confirmations on that come in, as I'm again running blind here.

Open questions:

- Should we automatically retry without VSync if window creation fails and the error string contains `vsync`? (maybe we can add spaces around it, though I'm more for the general if we should to so thing)
