### PR TITLE
Clipboard commands

### DIFF
--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -29,17 +29,13 @@ pub fn get_clipboard_contents(format: Option<&str>) -> Result<Value, Box<dyn Err
     Ok(Value::from(vec![lines, paste_mode]))
 }
 
-pub fn set_clipboard_contents(arguments: Vec<Value>) -> Result<Value, Box<dyn Error + Send + Sync>> {
-    if arguments.len() != 3 {
-        return Err("expected exactly 3 arguments to set_remote_clipboard".into());
-    }
-
+pub fn set_clipboard_contents(value: &Value) -> Result<Value, Box<dyn Error + Send + Sync>> {
     #[cfg(not(windows))]
     let endline = "\n";
     #[cfg(windows)]
     let endline = "\r\n";
 
-    let lines = arguments[0]
+    let lines = value
         .as_array()
         .map(|arr| {
             arr.iter()

--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -4,7 +4,7 @@ use rmpv::Value;
 
 use copypasta::{ClipboardContext, ClipboardProvider};
 
-pub fn get_remote_clipboard(format: Option<&str>) -> Result<Value, Box<dyn Error + Send + Sync>> {
+pub fn get_clipboard_contents(format: Option<&str>) -> Result<Value, Box<dyn Error + Send + Sync>> {
     let mut clipboard_ctx: ClipboardContext = ClipboardContext::new()?;
     let clipboard_raw = clipboard_ctx.get_contents()?.replace('\r', "");
 
@@ -29,7 +29,7 @@ pub fn get_remote_clipboard(format: Option<&str>) -> Result<Value, Box<dyn Error
     Ok(Value::from(vec![lines, paste_mode]))
 }
 
-pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<Value, Box<dyn Error + Send + Sync>> {
+pub fn set_clipboard_contents(arguments: Vec<Value>) -> Result<Value, Box<dyn Error + Send + Sync>> {
     if arguments.len() != 3 {
         return Err("expected exactly 3 arguments to set_remote_clipboard".into());
     }

--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -29,7 +29,7 @@ pub fn get_remote_clipboard(format: Option<&str>) -> Result<Value, Box<dyn Error
     Ok(Value::from(vec![lines, paste_mode]))
 }
 
-pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<(), Box<dyn Error + Send + Sync>> {
+pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<Value, Box<dyn Error + Send + Sync>> {
     if arguments.len() != 3 {
         return Err("expected exactly 3 arguments to set_remote_clipboard".into());
     }
@@ -52,5 +52,6 @@ pub fn set_remote_clipboard(arguments: Vec<Value>) -> Result<(), Box<dyn Error +
 
     let mut clipboard_ctx: ClipboardContext = ClipboardContext::new()?;
     clipboard_ctx.set_contents(lines)?;
-    Ok(())
+
+    Ok(Value::Nil)
 }

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -31,7 +31,7 @@ impl Handler for NeovimHandler {
     async fn handle_request(
         &self,
         event_name: String,
-        _arguments: Vec<Value>,
+        arguments: Vec<Value>,
         neovim: Neovim<TxWrapper>,
     ) -> Result<Value, Value> {
         trace!("Neovim request: {:?}", &event_name);
@@ -50,6 +50,10 @@ impl Handler for NeovimHandler {
 
                 get_remote_clipboard(endline_type.as_deref())
                     .map_err(|_| Value::from("cannot get remote clipboard content"))
+            }
+            "neovide.set_clipboard" => {
+                set_remote_clipboard(arguments)
+                    .map_err(|_| Value::from("cannot set remote clipboard content"))
             }
             _ => Ok(Value::from("rpcrequest not handled")),
         }
@@ -90,9 +94,6 @@ impl Handler for NeovimHandler {
             #[cfg(windows)]
             "neovide.unregister_right_click" => {
                 EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::UnregisterRightClick));
-            }
-            "neovide.set_clipboard" => {
-                set_remote_clipboard(arguments).ok();
             }
             _ => {}
         }

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -51,10 +51,8 @@ impl Handler for NeovimHandler {
                 get_clipboard_contents(endline_type.as_deref())
                     .map_err(|_| Value::from("cannot get clipboard contents"))
             }
-            "neovide.set_clipboard" => {
-                set_clipboard_contents(arguments)
-                    .map_err(|_| Value::from("cannot set clipboard contents"))
-            }
+            "neovide.set_clipboard" => set_clipboard_contents(&arguments[0])
+                .map_err(|_| Value::from("cannot set clipboard contents")),
             _ => Ok(Value::from("rpcrequest not handled")),
         }
     }

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -3,7 +3,7 @@ use log::trace;
 use nvim_rs::{Handler, Neovim};
 use rmpv::Value;
 
-use crate::bridge::clipboard::{get_remote_clipboard, set_remote_clipboard};
+use crate::bridge::clipboard::{get_clipboard_contents, set_clipboard_contents};
 #[cfg(windows)]
 use crate::bridge::ui_commands::{ParallelCommand, UiCommand};
 use crate::{
@@ -48,12 +48,12 @@ impl Handler for NeovimHandler {
                         s.next().map(String::from)
                     });
 
-                get_remote_clipboard(endline_type.as_deref())
-                    .map_err(|_| Value::from("cannot get remote clipboard content"))
+                get_clipboard_contents(endline_type.as_deref())
+                    .map_err(|_| Value::from("cannot get clipboard contents"))
             }
             "neovide.set_clipboard" => {
-                set_remote_clipboard(arguments)
-                    .map_err(|_| Value::from("cannot set remote clipboard content"))
+                set_clipboard_contents(arguments)
+                    .map_err(|_| Value::from("cannot set clipboard contents"))
             }
             _ => Ok(Value::from("rpcrequest not handled")),
         }

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -7,13 +7,7 @@ use crate::{bridge::TxWrapper, error_handling::ResultPanicExplanation};
 const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
     local function set_clipboard(register)
         return function(lines, regtype)
-            vim.rpcrequest(
-                vim.g.neovide_channel_id,
-                'neovide.set_clipboard',
-                lines,
-                regtype,
-                register
-            )
+            vim.rpcrequest(vim.g.neovide_channel_id, 'neovide.set_clipboard', lines)
         end
     end
 

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -7,7 +7,7 @@ use crate::{bridge::TxWrapper, error_handling::ResultPanicExplanation};
 const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
     local function set_clipboard(register)
         return function(lines, regtype)
-            vim.rpcnotify(
+            vim.rpcrequest(
                 vim.g.neovide_channel_id,
                 'neovide.set_clipboard',
                 lines,

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -1,0 +1,65 @@
+use copypasta::{ClipboardContext, ClipboardProvider};
+
+use log::error;
+
+use std::{error::Error, thread};
+
+use crate::event_aggregator::EVENT_AGGREGATOR;
+
+type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync + 'static>>;
+
+#[derive(Clone, Debug)]
+pub enum ClipboardCommand {
+    SetContents(String),
+}
+
+pub struct Clipboard {
+    context: ClipboardContext,
+}
+
+impl Clipboard {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            context: ClipboardContext::new()?,
+        })
+    }
+
+    pub fn get_contents(&mut self) -> Result<String> {
+        self.context.get_contents()
+    }
+
+    pub fn set_contents(&mut self, lines: String) -> Result<()> {
+        self.context.set_contents(lines)
+    }
+}
+
+struct ClipboardCommandHandler {
+    clipboard: Clipboard,
+}
+
+impl ClipboardCommandHandler {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            clipboard: Clipboard::new()?,
+        })
+    }
+
+    fn handle_command(&mut self, command: ClipboardCommand) -> Result<()> {
+        match command {
+            ClipboardCommand::SetContents(lines) => self.clipboard.set_contents(lines),
+        }
+    }
+}
+
+pub fn start_clipboard_command_handler() {
+    thread::spawn(move || {
+        let mut command_handler = ClipboardCommandHandler::new().unwrap();
+
+        let mut command_receiver = EVENT_AGGREGATOR.register_event::<ClipboardCommand>();
+        while let Some(command) = command_receiver.blocking_recv() {
+            if let Err(e) = command_handler.handle_command(command) {
+                error!("Error in ClipboardCommandHandler: {}", e)
+            }
+        }
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate clap;
 
 mod bridge;
 mod channel_utils;
+mod clipboard;
 mod cmd_line;
 mod dimensions;
 mod editor;
@@ -37,6 +38,7 @@ use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
 use log::trace;
 
 use bridge::start_bridge;
+use clipboard::start_clipboard_command_handler;
 use cmd_line::CmdLineSettings;
 use editor::start_editor;
 use renderer::{cursor_renderer::CursorSettings, RendererSettings};
@@ -140,6 +142,7 @@ fn main() {
     KeyboardSettings::register();
 
     start_bridge();
+    start_clipboard_command_handler();
     start_editor();
     create_window();
 }


### PR DESCRIPTION
Use the event aggregator system to set the clipboard.

The X11 clipboard doesn't work correctly if we set the clipboard directly from the handler responsible for the `neovide.set_clipboard` RPC. I'm not certain why this is, but I presume it has to do with the thread handling the request being rather short-lived. To solve the problem, we delegate this task to the clipboard command handler, which is run by a long-running thread.

## What kind of change does this PR introduce?
- Fix
- Refactor

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- It changes the RPC used for setting the clipboard. Consequently, this functionality won't work for remote sessions that has been attached to older versions of Neovide. Restarting the nvim instance and attaching the new Neovide version will restore the functionality.
