### PR TITLE
Clean up cmdline handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 3.2.22",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -227,12 +227,39 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -240,6 +267,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1298,7 +1334,7 @@ version = "0.10.1"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
- "clap",
+ "clap 4.0.8",
  "cocoa",
  "copypasta",
  "csscolorparser",
@@ -1775,6 +1811,30 @@ dependencies = [
  "once_cell",
  "thiserror",
  "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ embed-fonts = []
 copypasta = "0.8.1"
 async-trait = "0.1.53"
 cfg-if = "1.0.0"
-clap = { version = "3.1.9", features = ["cargo"] }
+clap = { version = "4.0.8", features = ["cargo", "derive", "env"] }
 csscolorparser = "0.6.2"
 derive-new = "0.5.9"
 dirs = "4.0.0"

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -86,7 +86,7 @@ pub struct CmdLineSettings {
     /// The class part of the X11 WM_CLASS property (X only, useful for setting WM rules)
     #[arg(
         long = "x11-wm-class",
-        env = "NEOVIDE_X11_WM_CLASS",
+        env = "NEOVIDE_WM_CLASS",
         default_value = "neovide"
     )]
     pub x11_wm_class: String,
@@ -94,7 +94,7 @@ pub struct CmdLineSettings {
     /// The instance part of the X11 WM_CLASS property (X only, useful for setting WM rules)
     #[arg(
         long = "x11-wm-class-instance",
-        env = "NEOVIDE_X11_WM_CLASS_INSTANCE",
+        env = "NEOVIDE_WM_CLASS_INSTANCE",
         default_value = "neovide"
     )]
     pub x11_wm_class_instance: String,

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -79,7 +79,7 @@ pub struct CmdLineSettings {
     #[arg(
         long = "wayland_app_id",
         env = "NEOVIDE_APP_ID",
-        default_value_t = String::new(),
+        default_value = "neovide"
     )]
     pub wayland_app_id: String,
 
@@ -87,7 +87,7 @@ pub struct CmdLineSettings {
     #[arg(
         long = "x11-wm-class",
         env = "NEOVIDE_X11_WM_CLASS",
-        default_value_t = String::new(),
+        default_value = "neovide"
     )]
     pub x11_wm_class: String,
 
@@ -95,7 +95,7 @@ pub struct CmdLineSettings {
     #[arg(
         long = "x11-wm-class-instance",
         env = "NEOVIDE_X11_WM_CLASS_INSTANCE",
-        default_value_t = String::new(),
+        default_value = "neovide"
     )]
     pub x11_wm_class_instance: String,
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -1,244 +1,125 @@
+use std::{iter, mem};
+
 use crate::{dimensions::Dimensions, frame::Frame, settings::*};
 
-use clap::{Arg, Command};
+use clap::{ArgAction, Parser};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Parser)]
+#[command(version, about, long_about = None)]
 pub struct CmdLineSettings {
-    // Pass through arguments
+    /// Files to open (plainly appended to NeoVim args)
+    #[arg(
+        num_args = ..,
+        action = ArgAction::Append,
+    )]
+    pub files_to_open: Vec<String>, // TODO(multisn8): I want this to be a PathBuf
+
+    /// Arguments to pass down to NeoVim without interpreting them
+    #[arg(
+        num_args = ..,
+        action = ArgAction::Append,
+        last = true,
+        allow_hyphen_values = true
+    )]
     pub neovim_args: Vec<String>,
-    // Command-line arguments only
+
+    /// The geometry of the window
+    #[arg(long, default_value_t = DEFAULT_WINDOW_GEOMETRY)]
     pub geometry: Dimensions,
+
+    /// If to enable logging to a file in the current directory
+    #[arg(long = "log")]
     pub log_to_file: bool,
-    pub no_fork: bool,
+
+    /// Connect to NeoVim through this remote TCP
+    #[arg(long = "remote-tcp")]
     pub remote_tcp: Option<String>,
+
+    /// Run NeoVim in WSL rather than on the host
+    #[arg(long)]
     pub wsl: bool,
-    // Command-line flags with environment variable fallback
+
+    /// Which window decorations ("frame") to use (do note that the window might not be resizable
+    /// if this is "none")
+    #[arg(long, env = "NEOVIDE_FRAME", default_value_t = Frame::default())]
     pub frame: Frame,
+
+    /// Maximize the window on startup (not equivalent to fullscreen)
+    #[arg(long, env = "NEOVIDE_MAXIMIZED")]
     pub maximized: bool,
+
+    /// Enable the Multigrid extension (enables smooth scrolling and floating blur)
+    #[arg(long = "multigrid", env = "NEOVIDE_MULTIGRID")]
     pub multi_grid: bool,
+
+    /// Instead of spawning a child process and leaking it, be "blocking" and let the shell persist
+    /// as parent process
+    #[arg(long = "nofork")]
+    pub no_fork: bool,
+
+    /// Render every frame, takes more power and CPU time but possibly helps with frame timing
+    /// issues
+    #[arg(long = "noidle", env = "NEOVIDE_NO_IDLE")]
     pub no_idle: bool,
-    pub srgb: bool,
-    // Command-line arguments with environment variable fallback
-    pub neovim_bin: Option<String>,
-    pub wayland_app_id: String,
-    pub x11_wm_class: String,
-    pub x11_wm_class_instance: String,
-    // Disable open multiple files as tabs
+
+    /// Disable opening multiple files supplied in tabs (they're still buffers)
+    #[arg(long = "notabs")]
     pub no_tabs: bool,
+
+    /// Do not request sRGB when initializing the window, may help with GPUs with weird pixel
+    /// formats
+    #[arg(long = "nosrgb", env = "NEOVIDE_NO_SRGB", action = ArgAction::SetFalse)]
+    pub srgb: bool,
+
+    // Command-line arguments with environment variable fallback
+    #[arg(long = "neovim-bin", env = "NEOVIM_BIN")]
+    pub neovim_bin: Option<String>,
+
+    /// The app ID to show to the compositor (Wayland only, useful for setting WM rules)
+    #[arg(
+        long = "wayland_app_id",
+        env = "NEOVIDE_APP_ID",
+        default_value_t = String::new(),
+    )]
+    pub wayland_app_id: String,
+
+    /// The class part of the X11 WM_CLASS property (X only, useful for setting WM rules)
+    #[arg(
+        long = "x11-wm-class",
+        env = "NEOVIDE_X11_WM_CLASS",
+        default_value_t = String::new(),
+    )]
+    pub x11_wm_class: String,
+
+    /// The instance part of the X11 WM_CLASS property (X only, useful for setting WM rules)
+    #[arg(
+        long = "x11-wm-class-instance",
+        env = "NEOVIDE_X11_WM_CLASS_INSTANCE",
+        default_value_t = String::new(),
+    )]
+    pub x11_wm_class_instance: String,
 }
 
 impl Default for CmdLineSettings {
     fn default() -> Self {
-        Self {
-            // Pass through arguments
-            neovim_args: vec![],
-            // Command-line arguments only
-            geometry: DEFAULT_WINDOW_GEOMETRY,
-            log_to_file: false,
-            no_fork: false,
-            remote_tcp: None,
-            wsl: false,
-            // Command-line flags with environment variable fallback
-            frame: Frame::Full,
-            maximized: false,
-            multi_grid: false,
-            no_idle: false,
-            srgb: true,
-            // Command-line arguments with environment variable fallback
-            neovim_bin: None,
-            wayland_app_id: String::new(),
-            x11_wm_class_instance: String::new(),
-            x11_wm_class: String::new(),
-            // Disable open multiple files as tabs
-            no_tabs: false,
-        }
+        Self::parse_from(iter::empty::<String>())
     }
 }
 
 pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
-    let clapp = Command::new("Neovide")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about(crate_description!())
-        // Pass through arguments
-        .arg(
-            Arg::new("files_to_open")
-                .multiple_values(true)
-                .takes_value(true)
-                .help("Files to open"),
-        )
-        .arg(
-            Arg::new("neovim_args")
-                .multiple_values(true)
-                .takes_value(true)
-                .last(true)
-                .help("Specify Arguments to pass down to neovim"),
-        )
-        // Command-line arguments only
-        .arg(
-            Arg::new("geometry")
-                .long("geometry")
-                .takes_value(true)
-                .help("Specify the Geometry of the window"),
-        )
-        .arg(
-            Arg::new("log_to_file")
-                .long("log")
-                .help("Log to a file"),
-        )
-        .arg(
-            Arg::new("nofork")
-                .long("nofork")
-                .help(r#"Instead of spawning a child process and leaking it, be "blocking" and have the shell directly as parent process"#),
-        )
-        .arg(
-            Arg::new("no_tabs")
-                .long("notabs")
-                .help("Disable open multiple files as tabs"),
-        )
-        .arg(
-            Arg::new("remote_tcp")
-                .long("remote-tcp")
-                .takes_value(true)
-                .help("Connect to Remote TCP"),
-        )
-        .arg(
-            Arg::new("wsl")
-                .long("wsl")
-                .help("Run in WSL")
-        )
-        // Command-line flags with environment variable fallback
-        .arg(
-            Arg::new("frame")
-            .long("frame")
-            .takes_value(true)
-            .help("Configure the window frame. NOTE: Window might not be resizable if setting is None.")
-        )
-        .arg(
-            Arg::new("maximized")
-                .long("maximized")
-                .help("Maximize the window"),
-        )
-        .arg(
-            Arg::new("multi_grid")
-                .long("multigrid")
-                .help("Enable Multigrid"),
-        )
-        .arg(
-            Arg::new("noidle")
-                .long("noidle")
-                .help("Render every frame. Takes more power and cpu time but possibly fixes animation issues"),
-        )
-        .arg(
-            Arg::new("nosrgb")
-                .long("nosrgb")
-                .help("Do not use standard color space to initialize the window. Swapping this variable sometimes fixes issues on startup"),
-        )
-        // Command-line arguments with environment variable fallback
-        .arg(
-            Arg::new("neovim_bin")
-                .long("neovim-bin")
-                .takes_value(true)
-                .help("Specify path to neovim"),
-        )
-        .arg(
-            Arg::new("wayland_app_id")
-                .long("wayland-app-id")
-                .takes_value(true)
-                .help("Specify an App ID for Wayland"),
-        )
-        .arg(
-            Arg::new("x11_wm_class_instance")
-                .long("x11-wm-class-instance")
-                .takes_value(true)
-                .help("Specify the instance part of the X11 WM_CLASS property"),
-        )
-        .arg(
-            Arg::new("x11_wm_class")
-                .long("x11-wm-class")
-                .takes_value(true)
-                .help("Specify the class part of the X11 WM_CLASS property"),
-        );
+    let mut cmdline = CmdLineSettings::parse_from(args);
 
-    let matches = clapp.get_matches_from(args);
-    let mut neovim_args: Vec<String> = matches
-        .values_of("neovim_args")
-        .map(|opt| opt.map(|v| v.to_owned()).collect())
-        .unwrap_or_default();
+    // The neovim_args in cmdline are unprocessed, actually add options to it
+    let maybe_tab_flag = (!cmdline.no_tabs).then(|| "-p".to_string());
 
-    let files_to_open: Vec<String> = matches
-        .values_of("files_to_open")
-        .map(|opt| opt.map(String::from).collect())
-        .unwrap_or_default();
+    cmdline.neovim_args = maybe_tab_flag
+        .into_iter()
+        .chain(mem::take(&mut cmdline.files_to_open))
+        .chain(cmdline.neovim_args)
+        .map(|arg| shlex::quote(&arg).into_owned())
+        .collect();
 
-    if files_to_open.len() > 1
-        && !neovim_args.contains(&String::from("-p"))
-        && !matches.is_present("no_tabs")
-    {
-        neovim_args.push("-p".to_owned());
-    }
-
-    if cfg!(target_os = "macos") {
-        // escape filepath which contain spaces
-        neovim_args.extend(
-            files_to_open
-                .iter()
-                .map(|file| shlex::quote(file).into_owned()),
-        );
-    } else {
-        neovim_args.extend::<Vec<String>>(files_to_open);
-    }
-
-    /*
-     * Integrate Environment Variables as Defaults to the command-line ones.
-     *
-     * If the command-line argument is not set, the environment variable is used.
-     */
-    SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
-        // Pass through arguments
-        neovim_args,
-        // Command-line arguments only
-        geometry: parse_window_geometry(matches.value_of("geometry").map(|i| i.to_owned()))?,
-        log_to_file: matches.is_present("log_to_file"),
-        no_fork: matches.is_present("nofork"),
-        remote_tcp: matches.value_of("remote_tcp").map(|i| i.to_owned()),
-        wsl: matches.is_present("wsl"),
-        // Command-line flags with environment variable fallback
-        frame: match matches.value_of("frame") {
-            Some(val) => Frame::from_string(val.to_string()),
-            None => match std::env::var("NEOVIDE_FRAME") {
-                Ok(f) => Frame::from_string(f),
-                Err(_) => Frame::Full,
-            },
-        },
-        maximized: matches.is_present("maximized") || std::env::var("NEOVIDE_MAXIMIZED").is_ok(),
-        multi_grid: matches.is_present("multi_grid") || std::env::var("NEOVIDE_MULTIGRID").is_ok(),
-        no_idle: matches.is_present("noidle") || std::env::var("NEOVIDE_NO_IDLE").is_ok(),
-        // Srgb is enabled by default, so set it to false if nosrgb or NOEVIDE_NO_SRGB is set
-        srgb: !(matches.is_present("nosrgb") || std::env::var("NEOVIDE_NO_SRGB").is_ok()),
-        // Command-line arguments with environment variable fallback
-        neovim_bin: matches
-            .value_of("neovim_bin")
-            .map(|v| v.to_owned())
-            .or_else(|| std::env::var("NEOVIM_BIN").ok()),
-        wayland_app_id: matches
-            .value_of("wayland_app_id")
-            .map(|v| v.to_owned())
-            .or_else(|| std::env::var("NEOVIDE_APP_ID").ok())
-            .unwrap_or_else(|| "neovide".to_owned()),
-        x11_wm_class_instance: matches
-            .value_of("x11_wm_class_instance")
-            .map(|v| v.to_owned())
-            .or_else(|| std::env::var("NEOVIDE_X11_WM_CLASS_INSTANCE").ok())
-            .unwrap_or_else(|| "neovide".to_owned()),
-        x11_wm_class: matches
-            .value_of("x11_wm_class")
-            .map(|v| v.to_owned())
-            .or_else(|| std::env::var("NEOVIDE_X11_WM_CLASS").ok())
-            .unwrap_or_else(|| "neovide".to_owned()),
-        // Disable open multiple files as tabs
-        no_tabs: matches.is_present("no_tabs") || std::env::var("NEOVIDE_NO_TABS").is_ok(),
-    });
+    SETTINGS.set::<CmdLineSettings>(&cmdline);
     Ok(())
 }
 
@@ -258,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_neovim_passthrough() {
-        let args: Vec<String> = vec!["neovide", "--", "--clean"]
+        let args: Vec<String> = vec!["neovide", "--notabs", "--", "--clean"]
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -273,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_files_to_open() {
-        let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md"]
+        let args: Vec<String> = vec!["neovide", "./foo.txt", "--notabs", "./bar.md"]
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -282,7 +163,7 @@ mod tests {
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
-            vec!["-p", "./foo.txt", "./bar.md"]
+            vec!["./foo.txt", "./bar.md"]
         );
     }
 
@@ -304,28 +185,22 @@ mod tests {
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
-            vec!["--clean", "./foo.txt", "./bar.md"]
+            vec!["./foo.txt", "./bar.md", "--clean"]
         );
     }
 
     #[test]
     fn test_files_to_open_with_flag() {
-        let args: Vec<String> = vec![
-            "neovide",
-            "--notabs",
-            "./foo.txt",
-            "./bar.md",
-            "--geometry=42x24",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+        let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md", "--geometry=42x24"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
-            vec!["./foo.txt", "./bar.md"]
+            vec!["-p", "./foo.txt", "./bar.md"]
         );
 
         assert_eq!(

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -12,7 +12,7 @@ pub struct CmdLineSettings {
         num_args = ..,
         action = ArgAction::Append,
     )]
-    pub files_to_open: Vec<String>, // TODO(multisn8): I want this to be a PathBuf
+    pub files_to_open: Vec<String>, // Can't be a PathBuf since shlex can't operate on bytes
 
     /// Arguments to pass down to NeoVim without interpreting them
     #[arg(

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -39,7 +39,7 @@ pub struct CmdLineSettings {
     #[arg(long)]
     pub wsl: bool,
 
-    /// Which window decorations ("frame") to use (do note that the window might not be resizable
+    /// Which window decorations to use (do note that the window might not be resizable
     /// if this is "none")
     #[arg(long, env = "NEOVIDE_FRAME", default_value_t = Frame::default())]
     pub frame: Frame,
@@ -71,7 +71,7 @@ pub struct CmdLineSettings {
     #[arg(long = "nosrgb", env = "NEOVIDE_NO_SRGB", action = ArgAction::SetFalse)]
     pub srgb: bool,
 
-    // Command-line arguments with environment variable fallback
+    /// Which NeoVim binary to invoke headlessly instead of `nvim` found on $PATH
     #[arg(long = "neovim-bin", env = "NEOVIM_BIN")]
     pub neovim_bin: Option<String>,
 

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -1,13 +1,32 @@
-use std::ops::{Div, Mul};
+use std::{
+    fmt::Display,
+    ops::{Div, Mul},
+    str::FromStr,
+};
 
 use glutin::dpi::PhysicalSize;
 use serde::{Deserialize, Serialize};
+
+use crate::settings;
 
 // Maybe this should be independent from serialization?
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Dimensions {
     pub width: u64,
     pub height: u64,
+}
+
+impl FromStr for Dimensions {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        settings::parse_window_geometry(Some(s.to_string()))
+    }
+}
+
+impl Display for Dimensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}x{}", self.width, self.height)
+    }
 }
 
 macro_rules! impl_from_tuple_to_dimensions {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,3 +1,7 @@
+use core::fmt;
+
+use clap::{builder::PossibleValue, ValueEnum};
+
 // Options for the frame decorations
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Frame {
@@ -9,22 +13,46 @@ pub enum Frame {
     None,
 }
 
+impl Frame {
+    fn to_static_str(&self) -> &'static str {
+        match self {
+            Frame::Full => "full",
+
+            #[cfg(target_os = "macos")]
+            Frame::Transparent => "transparent",
+            #[cfg(target_os = "macos")]
+            Frame::Buttonless => "buttonless",
+
+            Frame::None => "none",
+        }
+    }
+}
+
 impl Default for Frame {
     fn default() -> Frame {
         Frame::Full
     }
 }
 
-impl Frame {
-    pub fn from_string(decoration: String) -> Frame {
-        match decoration.to_lowercase().as_str() {
-            "full" => Frame::Full,
-            #[cfg(target_os = "macos")]
-            "transparent" => Frame::Transparent,
-            #[cfg(target_os = "macos")]
-            "buttonless" => Frame::Buttonless,
-            "none" => Frame::None,
-            _ => Frame::Full,
-        }
+impl ValueEnum for Frame {
+    fn value_variants<'a>() -> &'a [Self] {
+        #[cfg(target_os = "macos")]
+        let variants = { &[Self::Full, Self::Transparent, Self::Buttonless, Self::None] };
+        #[cfg(not(target_os = "macos"))]
+        let variants = { &[Self::Full, Self::None] };
+
+        variants
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        let value = self.to_static_str();
+
+        Some(PossibleValue::new(value))
+    }
+}
+
+impl fmt::Display for Frame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_static_str())
     }
 }

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -59,7 +59,7 @@ containing trace events which may help debug an issue.
 ### Maximized
 
 ```sh
---maximized
+--maximized or $NEOVIDE_MAXIMIZED
 ```
 
 Maximize the window on startup, while still having decorations and the status bar of your OS
@@ -92,7 +92,7 @@ leaking it, be "blocking" and have the shell directly as parent process.
 ### No Idle
 
 ```sh
---noidle
+--noidle or $NEOVIDE_NO_IDLE
 ```
 
 Instead of skipping some frames in order to match `g:neovide_refresh_rate`, render every possible
@@ -101,7 +101,7 @@ one.
 ### No sRGB
 
 ```sh
---nosrgb
+--nosrgb or $NEOVIDE_NO_SRGB
 ```
 
 Don't request sRGB on the window. Swapping sometimes fixes startup issues.
@@ -138,7 +138,7 @@ Runs neovim from inside wsl rather than as a normal executable.
 ### Neovim Binary
 
 ```sh
---neovim-bin
+--neovim-bin or $NEOVIM_BIN
 ```
 
 Sets where to find neovim's executable. If unset, neovide will try to find `nvim` on the `PATH`


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

Uses clap 4.0 in order to make adding new arguments way, way cleaner. Would be very happy if someone with a specialized usage of Neovide's CLI could actually test this, the testsuite ran through but that doesn't mean anything.

## What kind of change does this PR introduce?
- Refactor

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No (practically, theoretically arguments passed to NeoVim have been reordered a bit)
