### PR TITLE
Introduce scale_factor option

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -81,10 +81,14 @@ pub struct Renderer {
 
     pub batched_draw_command_receiver: UnboundedReceiver<Vec<DrawCommand>>,
     profiler: profiler::Profiler,
+    os_scale_factor: f64,
+    user_scale_factor: f64,
 }
 
 impl Renderer {
-    pub fn new(scale_factor: f64) -> Self {
+    pub fn new(os_scale_factor: f64) -> Self {
+        let user_scale_factor = SETTINGS.get::<WindowSettings>().scale_factor.into();
+        let scale_factor = user_scale_factor * os_scale_factor;
         let cursor_renderer = CursorRenderer::new();
         let grid_renderer = GridRenderer::new(scale_factor);
         let current_mode = EditorMode::Unknown(String::from(""));
@@ -103,6 +107,8 @@ impl Renderer {
             window_regions,
             batched_draw_command_receiver,
             profiler,
+            os_scale_factor,
+            user_scale_factor,
         }
     }
 
@@ -141,6 +147,14 @@ impl Renderer {
         root_canvas.clear(default_background.with_a((255.0 * transparency) as u8));
         root_canvas.save();
         root_canvas.reset_matrix();
+
+        let user_scale_factor = SETTINGS.get::<WindowSettings>().scale_factor.into();
+        if user_scale_factor != self.user_scale_factor {
+            self.user_scale_factor = user_scale_factor;
+            self.grid_renderer
+                .handle_scale_factor_update(self.os_scale_factor * self.user_scale_factor);
+            font_changed = true;
+        }
 
         if let Some(root_window) = self.rendered_windows.get(&1) {
             let clip_rect = root_window.pixel_region(font_dimensions);
@@ -194,6 +208,11 @@ impl Renderer {
         root_canvas.restore();
 
         font_changed
+    }
+
+    pub fn handle_os_scale_factor_change(&mut self, os_scale_factor: f64) {
+        self.os_scale_factor = os_scale_factor;
+        self.grid_renderer.handle_scale_factor_update(self.os_scale_factor * self.user_scale_factor);
     }
 
     fn handle_draw_command(&mut self, root_canvas: &mut Canvas, draw_command: DrawCommand) {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -212,7 +212,8 @@ impl Renderer {
 
     pub fn handle_os_scale_factor_change(&mut self, os_scale_factor: f64) {
         self.os_scale_factor = os_scale_factor;
-        self.grid_renderer.handle_scale_factor_update(self.os_scale_factor * self.user_scale_factor);
+        self.grid_renderer
+            .handle_scale_factor_update(self.os_scale_factor * self.user_scale_factor);
     }
 
     fn handle_draw_command(&mut self, root_canvas: &mut Canvas, draw_command: DrawCommand) {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -261,9 +261,7 @@ impl GlutinWindowWrapper {
     }
 
     fn handle_scale_factor_update(&mut self, scale_factor: f64) {
-        self.renderer
-            .grid_renderer
-            .handle_scale_factor_update(scale_factor);
+        self.renderer.handle_os_scale_factor_change(scale_factor);
         EVENT_AGGREGATOR.send(EditorCommand::RedrawScreen);
     }
 

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -6,6 +6,7 @@ pub struct WindowSettings {
     pub refresh_rate_idle: u64,
     pub no_idle: bool,
     pub transparency: f32,
+    pub scale_factor: f32,
     pub fullscreen: bool,
     pub iso_layout: bool,
     pub remember_window_size: bool,
@@ -21,6 +22,7 @@ impl Default for WindowSettings {
     fn default() -> Self {
         Self {
             transparency: 1.0,
+            scale_factor: 1.0,
             fullscreen: false,
             iso_layout: false,
             refresh_rate: 60,


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

I tried to implement the scaling proposed in #1301. I decided to use an additional factor to the os_scale_factor.

Example for using the new scale_factor with key bindings:
```
let g:neovide_scale_factor=1.0
function! ChangeScaleFactor(delta)
    let g:neovide_scale_factor = g:neovide_scale_factor * a:delta
endfunction
nnoremap <expr><C-=> ChangeScaleFactor(1.25)
nnoremap <expr><C--> ChangeScaleFactor(1/1.25)
```