### PR TITLE
Fix carriage return in keymapping

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -270,7 +270,7 @@ fn is_special(text: &str) -> Option<(&str, bool)> {
         "\\" => Some(("Bslash", false)),
         "|" => Some(("Bar", false)),
         "\t" => Some(("Tab", true)),
-        "\n" => Some(("CR", true)),
+        "\n" | "\r" => Some(("CR", true)),
         _ => None,
     }
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

According to `:help key-notation`, `<CR>` stands for carriage return, which is `\r`.

```
notation	meaning		    equivalent	decimal value(s)
----------------------------------------------------------------------- ~
<CR>		carriage return		CTRL-M	 13	*carriage-return*
<Return>	same as <CR>				*<Return>*
<Enter>		same as <CR>				*<Enter>*
```

This should fix #992.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._

- No
