### PR TITLE
Don't run shlex on the cmdline args on Woe

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -116,12 +116,17 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
     // The neovim_args in cmdline are unprocessed, actually add options to it
     let maybe_tab_flag = (!cmdline.no_tabs).then(|| "-p".to_string());
 
-    cmdline.neovim_args = maybe_tab_flag
+    let neovim_args = maybe_tab_flag
         .into_iter()
         .chain(mem::take(&mut cmdline.files_to_open))
-        .chain(cmdline.neovim_args)
-        .map(|arg| shlex::quote(&arg).into_owned())
-        .collect();
+        .chain(cmdline.neovim_args);
+    cmdline.neovim_args = if cfg!(windows) {
+        neovim_args.collect()
+    } else {
+        neovim_args
+            .map(|arg| shlex::quote(&arg).into_owned())
+            .collect()
+    };
 
     SETTINGS.set::<CmdLineSettings>(&cmdline);
     Ok(())


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix #1608

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes
  - Command line args are actually usable now

This might have some serious implications, to be specific with shell injections. So don't merge just yet.