### PR TITLE
Fix default window geometry to use the last saved value (broken in #1583)

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -24,7 +24,7 @@ pub struct CmdLineSettings {
     pub neovim_args: Vec<String>,
 
     /// The geometry of the window
-    #[arg(long, default_value_t = DEFAULT_WINDOW_GEOMETRY)]
+    #[arg(long, default_value_t = last_window_geometry())]
     pub geometry: Dimensions,
 
     /// If to enable logging to a file in the current directory
@@ -41,7 +41,7 @@ pub struct CmdLineSettings {
 
     /// Which window decorations to use (do note that the window might not be resizable
     /// if this is "none")
-    #[arg(long, env = "NEOVIDE_FRAME", default_value_t = Frame::default())]
+    #[arg(long, env = "NEOVIDE_FRAME", default_value_t) ]
     pub frame: Frame,
 
     /// Maximize the window on startup (not equivalent to fullscreen)

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -41,7 +41,7 @@ pub struct CmdLineSettings {
 
     /// Which window decorations to use (do note that the window might not be resizable
     /// if this is "none")
-    #[arg(long, env = "NEOVIDE_FRAME", default_value_t) ]
+    #[arg(long, env = "NEOVIDE_FRAME", default_value_t)]
     pub frame: Frame,
 
     /// Maximize the window on startup (not equivalent to fullscreen)

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -16,10 +16,16 @@ pub struct Dimensions {
     pub height: u64,
 }
 
+impl Default for Dimensions {
+    fn default() -> Self {
+        settings::DEFAULT_WINDOW_GEOMETRY
+    }
+}
+
 impl FromStr for Dimensions {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        settings::parse_window_geometry(Some(s.to_string()))
+        settings::parse_window_geometry(s)
     }
 }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -14,7 +14,7 @@ use std::{
 use crate::{bridge::TxWrapper, error_handling::ResultPanicExplanation};
 pub use from_value::ParseFromValue;
 pub use window_geometry::{
-    load_last_window_settings, parse_window_geometry, save_window_geometry,
+    last_window_geometry, load_last_window_settings, parse_window_geometry, save_window_geometry,
     PersistentWindowSettings, DEFAULT_WINDOW_GEOMETRY,
 };
 


### PR DESCRIPTION
#1583 caused the last saved window size to no longer be read or used at startup. The `parse_window_geometry()` function is now only used by the parser for the `Dimensions` struct, which is only used if `--geometry` is passed. If that's the case, though, it'll simply use the parsed command line option instead of using the last saved size.

This PR refactors the `parse_window_geometry()` function into two separate pieces--
1. A new function `last_window_geometry()` has been added that attempts to use the last saved window geometry but falls back to the default. This function is used as the default value expression for the `geometry` command line argument/setting.
2. `parse_window_geometry()` now _only_ parses a command line geometry value (like `100x50`). The diff for this looks worse than it actually is. It's now simply the previous map function that was being applied to the input if present, unchanged.

This also adds a `Default` trait implementation for `Dimensions` which returns the default window geometry.

## What kind of change does this PR introduce?
- Fix
- Refactor

## Did this PR introduce a breaking change? 
- No
