### PR TITLE
Revert "Only escape commandline arguments on macOS (#1633)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rand = "0.8.5"
 rmpv = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
+shlex = "1.1.0"
 swash = "0.1.4"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7.1", features = ["compat"] }
@@ -67,7 +68,6 @@ version = "0.52.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"
 objc = "0.2.7"
-shlex = "1.1.0"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
This reverts commit 12b3cee9cce3eb8d20c87709808a5c2ba80f878f.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, #1633's original issue is back again
