### PR TITLE
Only escape commandline arguments on macOS take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ rand = "0.8.5"
 rmpv = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
-shlex = "1.1.0"
 swash = "0.1.4"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7.1", features = ["compat"] }
@@ -68,6 +67,7 @@ version = "0.52.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"
 objc = "0.2.7"
+shlex = "1.1.0"
 
 [profile.release]
 lto = true

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -51,7 +51,7 @@ fn build_nvim_cmd() -> TokioCommand {
 fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdCommand> {
     if cfg!(target_os = "windows") && SETTINGS.get::<CmdLineSettings>().wsl {
         let mut result = StdCommand::new("wsl");
-        result.args(&["$SHELL", "-lc"]);
+        result.args(["$SHELL", "-lc"]);
         result.arg(format!("{} {}", command, args.join(" ")));
 
         Some(result)
@@ -59,7 +59,7 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
         let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
         let mut result = StdCommand::new(&shell);
 
-        result.args(&["-lc"]);
+        result.args(["-lc"]);
         result.arg(format!("{} {}", command, args.join(" ")));
 
         Some(result)
@@ -102,23 +102,34 @@ fn platform_which(bin: &str) -> Option<String> {
     }
 }
 
-fn build_nvim_cmd_with_args(bin: &str) -> TokioCommand {
-    let mut args = vec!["--embed".to_string()];
-    args.extend(SETTINGS.get::<CmdLineSettings>().neovim_args);
-    let args_str = args.join(" ");
+#[cfg(target_os = "macos")]
+fn nvim_cmd_impl(bin: &str, args: &[String]) -> TokioCommand {
+    let shell = env::var("SHELL").unwrap();
+    let mut cmd = TokioCommand::new(shell);
+    let args_str = args
+        .iter()
+        .map(|arg| shlex::quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    cmd.args(&["-lc", &format!("{} {}", bin, args_str)]);
+    cmd
+}
 
+#[cfg(not(target_os = "macos"))]
+fn nvim_cmd_impl(bin: &str, args: &[String]) -> TokioCommand {
     if cfg!(target_os = "windows") && SETTINGS.get::<CmdLineSettings>().wsl {
         let mut cmd = TokioCommand::new("wsl");
-        cmd.args(&["$SHELL", "-lc", &format!("{} {}", bin, args_str)]);
-        cmd
-    } else if cfg!(target_os = "macos") {
-        let shell = env::var("SHELL").unwrap();
-        let mut cmd = TokioCommand::new(shell);
-        cmd.args(&["-lc", &format!("{} {}", bin, args_str)]);
+        cmd.args(&["$SHELL", "-lc", &format!("{} {}", bin, args.join(" "))]);
         cmd
     } else {
         let mut cmd = TokioCommand::new(bin);
         cmd.args(args);
         cmd
     }
+}
+
+fn build_nvim_cmd_with_args(bin: &str) -> TokioCommand {
+    let mut args = vec!["--embed".to_string()];
+    args.extend(SETTINGS.get::<CmdLineSettings>().neovim_args);
+    nvim_cmd_impl(bin, &args)
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -12,7 +12,7 @@ pub struct CmdLineSettings {
         num_args = ..,
         action = ArgAction::Append,
     )]
-    pub files_to_open: Vec<String>, // Can't be a PathBuf since shlex can't operate on bytes
+    pub files_to_open: Vec<String>,
 
     /// Arguments to pass down to NeoVim without interpreting them
     #[arg(
@@ -116,17 +116,11 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
     // The neovim_args in cmdline are unprocessed, actually add options to it
     let maybe_tab_flag = (!cmdline.no_tabs).then(|| "-p".to_string());
 
-    let neovim_args = maybe_tab_flag
+    cmdline.neovim_args = maybe_tab_flag
         .into_iter()
         .chain(mem::take(&mut cmdline.files_to_open))
-        .chain(cmdline.neovim_args);
-    cmdline.neovim_args = if cfg!(windows) {
-        neovim_args.collect()
-    } else {
-        neovim_args
-            .map(|arg| shlex::quote(&arg).into_owned())
-            .collect()
-    };
+        .chain(cmdline.neovim_args)
+        .collect();
 
     SETTINGS.set::<CmdLineSettings>(&cmdline);
     Ok(())


### PR DESCRIPTION
Fixed the signature of the macos version