### PR TITLE
Add documentation about #1634

### DIFF
--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -24,7 +24,7 @@
 - If you recieve errors complaining about DRI3 settings, please reference issue
   [#44](https://github.com/neovide/neovide/issues/44#issuecomment-578618052).
 
-- If your scroling is very stutter
+- If your scrolling is very stutter
 
     - Add flag `--novsync` before startup as a quickfix.
     - Check if the value of `g:neovide_refresh_rate` and the refresh rate of your monitor are matched.

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -26,12 +26,16 @@
 
 - If your scroling is very stutter
 
-    - Add flag "--novsync" before startup as a quickfix.
+    - Add flag `--novsync` before startup as a quickfix.
     - Check if the value of `g:neovide_refresh_rate` and the refresh rate of your monitor are matched.
 
-    If your `g:neovide_refresh_rate` is correct, then check if you are using dual monitors with mixed refresh rate, say `144` and `60`, if so, that's because [PSA: X11 does support mixed refresh rate monitors!](https://www.reddit.com/r/linux/comments/yaatyo/psa_x11_does_support_mixed_refresh_rate_monitors/) and X11 force it to the lower one, you can set
-    ```
+    If your `g:neovide_refresh_rate` is correct, then check if you are using dual monitors with mixed refresh rate, say `144` and `60`, by checking output of `xrandr` (wayland should support mixed refresh rate out of the box), if so,that's because X11 does not support mixed refresh rate well and that's not a problem of Neovide. You can find solutions for your setups [here](https://www.reddit.com/r/linux/comments/yaatyo/psa_x11_does_support_mixed_refresh_rate_monitors/), or just set `g:neovide_refresh_rate` to  the lower value.
+
+    As a minimal example, for a window manager without doing any compositing(like dwm) and NVIDIA GPU,
+
+    ```sh
     export __GL_SYNC_DISPLAY_DEVICE=DP-0
     ```
-    before starting neovide, where `DP-0` is the monitor with high refresh rate.
+
+    before startup should do the trick, where `DP-0` is the monitor with higher refresh rate.
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -23,3 +23,15 @@
 
 - If you recieve errors complaining about DRI3 settings, please reference issue
   [#44](https://github.com/neovide/neovide/issues/44#issuecomment-578618052).
+
+- If your scroling is very stutter
+
+    - Add flag "--novsync" before startup as a quickfix.
+    - Check if the value of `g:neovide_refresh_rate` and the refresh rate of your monitor are matched.
+
+    If your `g:neovide_refresh_rate` is correct, then check if you are using dual monitors with mixed refresh rate, say `144` and `60`, if so, that's because [PSA: X11 does support mixed refresh rate monitors!](https://www.reddit.com/r/linux/comments/yaatyo/psa_x11_does_support_mixed_refresh_rate_monitors/) and X11 force it to the lower one, you can set
+    ```
+    export __GL_SYNC_DISPLAY_DEVICE=DP-0
+    ```
+    before starting neovide, where `DP-0` is the monitor with high refresh rate.
+


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Documentation

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

I investigate it further and found that's may because X11 don't support mixed refresh rate monitors well, and that's the reason in my case, I demonstrate it in [`troubeshotting.md`](https://github.com/fecet/neovide/blob/main/website/docs/troubleshooting.md).

This should work for [#1634](https://github.com/neovide/neovide/issues/1634), and maybe for [#1312](https://github.com/neovide/neovide/issues/1312)
