### PR TITLE
Allow use of fonts containing `_` in the name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "gl",
  "glutin",
  "image",
+ "itertools",
  "lazy_static",
  "log",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3.21"
 gl = "0.14.0"
 glutin = { git = "https://github.com/neovide/glutin", branch = "new-keyboard-all", features = ["serde"] }
 image = { version = "0.24.1", default-features = false, features = ["ico"] }
+itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.16"
 lru = "0.7.5"

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -27,7 +27,7 @@ impl FontOptions {
             let parsed_font_list: Vec<String> = parts
                 .split(',')
                 .filter(|fallback| !fallback.is_empty())
-                .map(|fallback| parse_font_name(fallback))
+                .map(parse_font_name)
                 .collect();
 
             if !parsed_font_list.is_empty() {

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -97,10 +97,9 @@ impl PartialEq for FontOptions {
     }
 }
 
-fn parse_font_name(font_name: impl Into<String>) -> String {
-    let font_name: String = font_name.into();
-
+fn parse_font_name(font_name: impl AsRef<str>) -> String {
     let parsed_font_name = font_name
+        .as_ref()
         .chars()
         .batching(|iter| {
             let ch = iter.next();

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -115,8 +115,6 @@ fn parse_font_name(font_name: impl Into<String>) -> String {
         }
     }
 
-    println!("{}", parsed_font_name);
-
     parsed_font_name
 }
 

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -27,7 +27,7 @@ impl FontOptions {
             let parsed_font_list: Vec<String> = parts
                 .split(',')
                 .filter(|fallback| !fallback.is_empty())
-                .map(|fallback| fallback.replace('_', " "))
+                .map(|fallback| fallback.to_string())
                 .collect();
 
             if !parsed_font_list.is_empty() {


### PR DESCRIPTION
The documentation encourages the use of `\` to escape spaces, and there's no way to escape `_` (underline), in the current main branch, it's not possible to load fonts containing it in the name. 

## What kind of change does this PR introduce?
- Fix


## Did this PR introduce a breaking change? 
- No
