### PR TITLE
use nvim-rs release version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,8 @@ dependencies = [
 [[package]]
 name = "nvim-rs"
 version = "0.5.0"
-source = "git+https://github.com/KillTheMule/nvim-rs?branch=master#d701c2790dcb2579f8f4d7003ba30e2100a7d25b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e98dcbd3b0ece3cf2b76ebc1e33e6511777ea7322884f4b7150cbc253afa37e"
 dependencies = [
  "async-trait",
  "futures 0.3.25",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ lazy_static = "1.4.0"
 log = "0.4.16"
 lru = "0.7.5"
 neovide-derive = { path = "neovide-derive" }
-nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = ["use_tokio"] }
+nvim-rs = { version = "0.5.0", features = ["use_tokio"] }
 parking_lot = "0.12.0"
 pin-project = "1.0.10"
 rand = "0.8.5"


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Prophylaxis. It updates the source from which the `nvim-rs` dependency is pulled from to the official version. 
### Why?
- All necessary functionalities have made their way into the release version.
Using the release version results in a simpler and safer dependency update procedure. It's also a step closer to releasing neovide on crates.io, since no git repo dependencies are allowed.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
