### PR TITLE
Fall back to key without modifiers

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -140,7 +140,10 @@ impl KeyboardManager {
             }
         } else {
             let key_text = if self.prev_dead_key.is_none() {
-                key_event.text
+                key_event.text.or_else(|| match key_event.key_without_modifiers() {
+                    Key::Character(ch) => Some(ch),
+                    _ => None,
+                })
             } else {
                 key_event.text_with_all_modifiers()
             };

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -140,10 +140,12 @@ impl KeyboardManager {
             }
         } else {
             let key_text = if self.prev_dead_key.is_none() {
-                key_event.text.or_else(|| match key_event.key_without_modifiers() {
-                    Key::Character(ch) => Some(ch),
-                    _ => None,
-                })
+                key_event
+                    .text
+                    .or_else(|| match key_event.key_without_modifiers() {
+                        Key::Character(ch) => Some(ch),
+                        _ => None,
+                    })
             } else {
                 key_event.text_with_all_modifiers()
             };


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 

This PR makes it so that more key presses received by neovide will make it to neovim. I am not sure whether this change has effects other than fixing #1646.