### PR TITLE
Neovide crashes when both x & y blur are set to 0

### DIFF
--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -275,7 +275,7 @@ impl RenderedWindow {
         }
 
         if self.floating_order.is_some() && settings.floating_blur {
-            let blur = blur(
+            if let Some(blur) = blur(
                 (
                     settings.floating_blur_amount_x,
                     settings.floating_blur_amount_y,
@@ -283,13 +283,13 @@ impl RenderedWindow {
                 None,
                 None,
                 None,
-            )
-            .unwrap();
-            let save_layer_rec = SaveLayerRec::default()
-                .backdrop(&blur)
-                .bounds(&pixel_region);
+            ) {
+                let save_layer_rec = SaveLayerRec::default()
+                    .backdrop(&blur)
+                    .bounds(&pixel_region);
 
-            root_canvas.save_layer(&save_layer_rec);
+                root_canvas.save_layer(&save_layer_rec);
+            }
         }
 
         let mut paint = Paint::default();


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix
  - `blur()` return `None` if both x & y blur are 0. I couldn't find any doc on this but I assume this is because a sigma of 0 makes a division by 0 error. Instead of crashing straight away via `unwrap()`, it now simply does nothing (i.e. doesn't blur) if `None` is returned. 
  - Note that interestingly when only one of x or y blur is set to 0, it does not return `None`.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
