### PR TITLE
Fix failing formatting test

### DIFF
--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -6,7 +6,7 @@ use crate::clipboard;
 
 pub fn get_clipboard_contents(format: Option<&str>) -> Result<Value, Box<dyn Error + Send + Sync>> {
     let clipboard_raw = clipboard::get_contents()?.replace('\r', "");
-    let is_line_paste = clipboard_raw.ends_with('\n'); 
+    let is_line_paste = clipboard_raw.ends_with('\n');
 
     let lines = if let Some("dos") = format {
         // Add \r to lines if current file format is dos.


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?

Removes a formatting error that's causing formatting tests to fail.
(a little EOL white space that slipped through in 3365a638083a4c56885c0aa3ee133c2df81617e1). 

To prevent this in the future, we could consider adding a `rustmt.toml`. This would allow contributors to format-on-save with their rust formatter more easily. Currently, a system-level rustfmt configuration that differs from the defaults will cause formatting changes, so staging/pushing without formatting is facilitated. 

Please let me know if it is appropriate to add a `rustfmt.toml` with default values which would match neovide's current formatting style (an emtpy file would do as well - we could just add something like a `# use defaults` comment).

## Did this PR introduce a breaking change? 

- No

edit: I'm updating the PR title and commit message to match the dominant uppercase convention in the commit history  (sorry for the noise)
