### PR TITLE
Document the `os.execute()` invalid message upstream bug

### DIFF
--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -9,6 +9,11 @@
   - whether you can reproduce this by running from the latest git main commit.
     This can be done by running from source or just grabbing the binary from the [`Actions` tab on
     GitHub](https://github.com/neovide/neovide/actions/workflows/build.yml).
+    
+  - if you're calling the `os.execute()` lua function in your startup configuration, due to an
+    [upstream neovim bug](https://github.com/neovide/neovide/issues/1376#issuecomment-1170849510).
+    As of neovim v0.8.2, this crash still occurs; try using
+    [`io.popen()`](http://www.lua.org/manual/5.1/manual.html#pdf-io.popen) instead.
 
 - Neovide requires that a font be set in `init.vim` otherwise errors might be encountered. This can
   be fixed by adding `set guifont=Your\ Font\ Name:h15` in init.vim file. Reference issue


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Documentation

## Did this PR introduce a breaking change? 
- No

This PR documents #1376, an upstream neovim bug that's been known for almost half an year.