### PR TITLE
Update faq.md

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -53,8 +53,8 @@ noremap <expr><D-[> ChangeTransparency(-0.01)
 ...aka `nvm use` doesn't work, aka anything configured in `~/.bashrc`/`~/.zshrc`
 is ignored by Neovide.
 
-Neovide doesn't start the embedded neovim instance in a login shell, so your
-shell doesn't read its resource file (`~/.bashrc`/`~/.zshrc`/whatever the
+Neovide doesn't start the embedded neovim instance in an interactive shell, so your
+shell doesn't read part of its startup file (`~/.bashrc`/`~/.zshrc`/whatever the
 equivalent for your shell is). But depending on your shell there are other
 options for doing so, for example for zsh you can just put your relevant content
 into `~/.zprofile` or `~/.zlogin`.


### PR DESCRIPTION
Edit phrasing in FAQ about shell env startup file.

According to zsh official [user guide](https://zsh.sourceforge.io/Guide/zshguide02.html) (section 2.2), `.zprofile` and `.zlogin` are for login shell only (before and after source `.zshrc` separately) while `.zshrc` are for interactive shell. Original statement is kinda confusing imo.

## What kind of change does this PR introduce?
Documentation

## Did this PR introduce a breaking change? 
No
