### PR TITLE
Preserve PATH when launching from terminal on MacOS

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -51,7 +51,7 @@ fn build_nvim_cmd() -> TokioCommand {
 fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdCommand> {
     if cfg!(target_os = "windows") && SETTINGS.get::<CmdLineSettings>().wsl {
         let mut result = StdCommand::new("wsl");
-        result.args(["$SHELL", "-lc"]);
+        result.args(["$SHELL", "-c"]);
         result.arg(format!("{} {}", command, args.join(" ")));
 
         Some(result)
@@ -59,7 +59,7 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
         let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
         let mut result = StdCommand::new(&shell);
 
-        result.args(["-lc"]);
+        result.args(["-c"]);
         result.arg(format!("{} {}", command, args.join(" ")));
 
         Some(result)
@@ -111,7 +111,7 @@ fn nvim_cmd_impl(bin: &str, args: &[String]) -> TokioCommand {
         .map(|arg| shlex::quote(arg))
         .collect::<Vec<_>>()
         .join(" ");
-    cmd.args(&["-lc", &format!("{} {}", bin, args_str)]);
+    cmd.args(&["-c", &format!("{} {}", bin, args_str)]);
     cmd
 }
 
@@ -119,7 +119,7 @@ fn nvim_cmd_impl(bin: &str, args: &[String]) -> TokioCommand {
 fn nvim_cmd_impl(bin: &str, args: &[String]) -> TokioCommand {
     if cfg!(target_os = "windows") && SETTINGS.get::<CmdLineSettings>().wsl {
         let mut cmd = TokioCommand::new("wsl");
-        cmd.args(&["$SHELL", "-lc", &format!("{} {}", bin, args.join(" "))]);
+        cmd.args(&["$SHELL", "-c", &format!("{} {}", bin, args.join(" "))]);
         cmd
     } else {
         let mut cmd = TokioCommand::new(bin);


### PR DESCRIPTION
**Problem**: When neovide is launched from a terminal on MacOS, the $PATH of the launching environment is not preserved due to use of the `-l /--login` option for shell commands.

This causes problems for me, because when launching neovide from CLI with an activated conda python environment, I would like the PATH be preserved from my terminal session so that the pyright language server starts with the desired python interpreter.

**Solution:** This solution is based on j4qfrost's work from https://github.com/neovide/neovide/pull/309, but it seems like the functionality was lost somewhere along the way :D 

So in this PR, I propose using the `--login` option for launching shells if and only if we are launching not from a terminal.