### PR TITLE
[Feature] Support mouse hover (emit mouse move event)

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -181,9 +181,12 @@ impl MouseManager {
                     position: self.drag_position.into(),
                     modifier_string: keyboard_manager.format_modifier_string(true),
                 }));
-            } else if has_moved {
+            } else {
                 // otherwise, update the window_id_under_mouse to match the one selected
                 self.window_details_under_mouse = Some(relevant_window_details.clone());
+            }
+            if has_moved {
+                // Send a mouse move command
                 EVENT_AGGREGATOR.send(UiCommand::Serial(SerialCommand::MouseButton {
                     button: "move".into(),
                     action: "dummy".into(), // this is ignored by nvim

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -189,7 +189,7 @@ impl MouseManager {
                 // Send a mouse move command
                 EVENT_AGGREGATOR.send(UiCommand::Serial(SerialCommand::MouseButton {
                     button: "move".into(),
-                    action: "dummy".into(), // this is ignored by nvim
+                    action: "".into(), // this is ignored by nvim
                     grid_id: relevant_window_details.id,
                     position: self.relative_position.into(),
                     modifier_string: keyboard_manager.format_modifier_string(true),

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -181,7 +181,7 @@ impl MouseManager {
                     position: self.drag_position.into(),
                     modifier_string: keyboard_manager.format_modifier_string(true),
                 }));
-            } else {
+            } else if has_moved {
                 // otherwise, update the window_id_under_mouse to match the one selected
                 self.window_details_under_mouse = Some(relevant_window_details.clone());
                 EVENT_AGGREGATOR.send(UiCommand::Serial(SerialCommand::MouseButton {

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -184,6 +184,13 @@ impl MouseManager {
             } else {
                 // otherwise, update the window_id_under_mouse to match the one selected
                 self.window_details_under_mouse = Some(relevant_window_details.clone());
+                EVENT_AGGREGATOR.send(UiCommand::Serial(SerialCommand::MouseButton {
+                    button: "move".into(),
+                    action: "dummy".into(), // this is ignored by nvim
+                    grid_id: relevant_window_details.id,
+                    position: self.relative_position.into(),
+                    modifier_string: keyboard_manager.format_modifier_string(true),
+                }))
             }
 
             self.has_moved = self.dragging.is_some() && (self.has_moved || has_moved);


### PR DESCRIPTION
Calls [nvim_input_mouse()](https://neovim.io/doc/user/api.html#nvim_input_mouse()) with `button = "move"`.
Currently, it always emits the events, but IMO it should not emit the events if ["mousemoveevent" option](https://neovim.io/doc/user/options.html#'mousemoveevent') is not enabled. How should we achieve this behavior?

- [x] Emit the event
- [ ] Do not emit the event when "mousemoveevent" option is disabled
- [ ] Rerender if mouse moved even if not dragged (ignore `self.dragging.is_some()` if "mousemoveevent" option is enabled)

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- Yes, emits new event
