### PR TITLE
Fix Lua instructions in Background Colour

### DIFF
--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -131,7 +131,7 @@ Lua:
 ```lua
 -- Helper function for transparency formatting
 local alpha = function()
-  return string.format("%x", math.floor(255 * vim.g.neovide_transparency_point or 0.8))
+  return string.format("%x", math.floor(255 * vim.g.transparency or 0.8))
 end
 -- g:neovide_transparency should be 0 if you want to unify transparency of content and title bar.
 vim.g.neovide_transparency = 0.0


### PR DESCRIPTION
The previous version says to use `vim.g.neovide_transparency_point` which gives an error. To match with the VimScript version, this should be `vim.g.transparency` instead (which does work).

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Documentation

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
