### PR TITLE
Refine workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,7 @@ defaults:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Run rustfmt
-        run: cargo fmt --all --check
-
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
+    uses: ./.github/workflows/lint-app.yml
 
   test:
     needs: lint
@@ -77,16 +68,21 @@ jobs:
           cargo nextest run --profile ci
 
       - if: runner.os != 'Linux'
-        name: Publish test results for Windows and macOS
+        name: Publish test results for ${{ runner.os }}
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:
           junit_files: target/nextest/ci/results.xml
+          check_name: test results (${{ matrix.os }})
+          comment_title: Test Results
+          comment_mode: off
 
       - if: runner.os == 'Linux'
         name: Publish test results for Linux
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           junit_files: target/nextest/ci/results.xml
+          check_name: test results (${{ matrix.os }})
+          comment_title: Test Results
 
   build-deploy:
     needs: test
@@ -99,8 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cargo cache
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -203,7 +198,7 @@ jobs:
           name: ${{ env.ARTIFACT }}
           path: target/release/${{ env.ARTIFACT }}
 
-      - if: runner.os != 'macOS'
+      - if: env.ARTIFACT2
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT2 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         os: [windows-latest, macOS-11, ubuntu-latest]
         toolchain: [stable, nightly]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:
           junit_files: target/nextest/ci/results.xml
-          check_name: test results (${{ matrix.os }})
+          check_name: test results (${{ matrix.os }}, ${{ matrix.toolchain }})
           comment_title: Test Results
           comment_mode: off
 
@@ -81,7 +81,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           junit_files: target/nextest/ci/results.xml
-          check_name: test results (${{ matrix.os }})
+          check_name: test results (${{ matrix.os }}, ${{ matrix.toolchain }})
           comment_title: Test Results
 
   build-deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,23 +66,29 @@ jobs:
           RUST_BACKTRACE: full
         run: |
           cargo nextest run --profile ci
+          mv target/nextest/ci/results.xml target/nextest/ci/results-${{ matrix.os }}.xml
 
-      - if: runner.os != 'Linux'
-        name: Publish test results for ${{ runner.os }}
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          junit_files: target/nextest/ci/results.xml
-          check_name: test results (${{ matrix.os }}, ${{ matrix.toolchain }})
-          comment_title: Test Results
-          comment_mode: off
+      - name: Prepare test results
+        run: |
+          mkdir -p test-results
+          mv target/nextest/ci/results-*.xml test-results/
 
-      - if: runner.os == 'Linux'
-        name: Publish test results for Linux
-        uses: EnricoMi/publish-unit-test-result-action@v2
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
         with:
-          junit_files: target/nextest/ci/results.xml
-          check_name: test results (${{ matrix.os }}, ${{ matrix.toolchain }})
-          comment_title: Test Results
+          name: test-results
+          path: |
+            test-results
+
+  event-upload:
+    needs: test
+    name: Upload Test Event
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: test-event
+          path: ${{ github.event_path }}
 
   build-deploy:
     needs: test
@@ -187,7 +193,7 @@ jobs:
               --icon-file=../../assets/neovide.svg \
               --output=appimage
 
-            find . -type f -name 'Neovide_(nvim)-*.AppImage' -exec mv {} neovide.AppImage \;
+            mv Neovide_\(nvim\)-*.AppImage neovide.AppImage
 
             echo "ARTIFACT=neovide-linux-x86_64.tar.gz" >> $GITHUB_ENV
             echo "ARTIFACT2=neovide.AppImage" >> $GITHUB_ENV

--- a/.github/workflows/lint-app.yml
+++ b/.github/workflows/lint-app.yml
@@ -5,8 +5,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_call:
@@ -28,6 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: giraffate/clippy-action@v1
         with:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -4,16 +4,14 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "website/**"
-      - ".vscode/**"
-      - "**.md"
+  workflow_run:
+    workflows: [Build and Test]
+    types: [completed]
 
 jobs:
   snap:
     runs-on: ubuntu-20.04
+    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,41 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: [Build and Test]
+    types: [completed]
+permissions: {}
+
+jobs:
+  Publish:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download and extract artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p artifacts && cd artifacts
+
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+          gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/test-event/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Codestyle
- Refactor

## Did this PR introduce a breaking change? 
- No

This PR contains refinements and enhancements that can be made to my recent workflow-related commits. It's things I noted down while doing DevOps work on similar GitHub actions afterwards.

result: https://github.com/tobealive/neovide/actions/runs/4275873794

### Changes

- Use cache prior to clippy, as this step is sped up as well if there is a cache hit (~4min vs 30s).
- Call reusable linting workflow instead of re-authoring the linting steps in the build action. This was already intended in the original renovation, which is why `workflow_call` was added as part of the `on` block.
- Update the artifact upload condition -> Check if there is a second artifact; instead of assuming there is none on macOS and others have one.
- Update test result publishing
  - Publishing on Mac was unbearably slow due to the Python setup (should take seconds, but took ~5 min). Adding a Python setup action would improve this, but I went with abstracting the test result publishing into a workflow. This is even faster.
  - It also groups the platform results and fixes adding test results as PR comments for forks. Until now, it only worked for internal but not for PRs from forks. [e.g. PR](https://github.com/tobealive/neovide/pull/3)
- Require a successful build test to start the snap workflow
  

<br>
(Since the `Upload Test Event` and `Test Results` jobs are workflow names and will be used in the job overview on the left side of the build workflow, naming is not fully uniform. I didn't want to be too german about it and didn't update the names for the whole workflow. Please leave a word if it's preferred. I'll quickly add this small commit.)