### PR TITLE
Fix mac startup issues

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -71,7 +71,9 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
     }
 }
 
+#[cfg(target_os = "windows")]
 fn platform_exists(bin: &str) -> bool {
+    // exists command is only on windows
     if let Some(mut exists_command) = create_platform_shell_command("exists", &["-x", bin]) {
         if let Ok(output) = exists_command.output() {
             output.status.success()
@@ -80,8 +82,13 @@ fn platform_exists(bin: &str) -> bool {
             std::process::exit(1);
         }
     } else {
-        Path::new(&bin).exists()
+        None
     }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn platform_exists(bin: &str) -> bool {
+    Path::new(&bin).exists()
 }
 
 fn platform_which(bin: &str) -> Option<String> {
@@ -107,7 +114,7 @@ fn platform_which(bin: &str) -> Option<String> {
 
 #[cfg(target_os = "macos")]
 fn nvim_cmd_impl(bin: &str, args: &[String]) -> TokioCommand {
-    let shell = env::var("SHELL").unwrap();
+    let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
     let mut cmd = TokioCommand::new(shell);
     let args_str = args
         .iter()


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

On mac, the `--neovim-bin` and `$NEOVIM_BIN` settings were getting ignored and it was always falling back to `which nvim`. In digging in, I found a few bugs. 

1. The `platform_exists()` function was shelling out to an `exists` command to see if the provided vim could be found. But the `exists` command only exists on Windows. For Mac, calling `Path::new(&bin).exists()` is the better choice than shelling. And as a side note, if a login shell has slow rc files, it impacts startup times for neovide so avoiding that is a bonus.
2. Second, while testing I was using a minimal shell with hardly any environment variables and that was causing crashes. Elsewhere when getting the `$SHELL` var there was a fallback, but in the `nvim_cmd_impl()` function there was just a bare unwrap that was bombing out. So I added the same fallback that is used elsewhere.

Changes are pretty minor bug fixes tested on Mac. The code paths should be effectively unchanged for Linux and Windows, I believe.