### PR TITLE
Add profiling support through Tracy Profiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "tracy-client-sys",
  "unicode-segmentation",
  "which",
  "winapi",
@@ -2689,6 +2690,15 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcbdba03a3cfc5f757469fd5b6d795fc461484c97e47e94b0fc7db93261d9c5"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = ["neovide-derive"]
 [features]
 default = []
 embed-fonts = []
+profiling = ["dep:tracy-client-sys"]
+gpu_profiling = ["profiling"]
 
 [dependencies]
 async-trait = "0.1.53"
@@ -45,6 +47,7 @@ swash = "0.1.8"
 time = "0.3.9"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
+tracy-client-sys = { version = "0.19.0", optional = true }
 unicode-segmentation = "1.9.0"
 which = "4.2.5"
 winit = { git = "https://github.com/neovide/winit", branch = "new-keyboard-all" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,11 @@ lto = true
 incremental = true
 strip = true
 
+[profile.profiling]
+inherits = "release"
+strip = false
+debug = true
+
 [package.metadata.bundle]
 name = "Neovide"
 identifier = "com.neovide.neovide"

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod editor;
 mod error_handling;
 mod event_aggregator;
 mod frame;
+mod profiling;
 mod redraw_scheduler;
 mod renderer;
 mod running_tracker;
@@ -56,6 +57,8 @@ pub use event_aggregator::*;
 pub use running_tracker::*;
 #[cfg(target_os = "windows")]
 pub use windows_utils::*;
+
+pub use profiling::startup_profiler;
 
 const BACKTRACES_FILE: &str = "neovide_backtraces.log";
 const REQUEST_MESSAGE: &str = "This is a bug and we would love for it to be reported to https://github.com/neovide/neovide/issues";
@@ -138,6 +141,8 @@ fn protected_main() {
     //   another frame next frame, or if it can safely skip drawing to save battery and cpu power.
     //   Multiple other parts of the app "queue_next_frame" function to ensure animations continue
     //   properly or updates to the graphics are pushed to the screen.
+
+    startup_profiler();
 
     #[cfg(target_os = "windows")]
     windows_attach_to_console();

--- a/src/profiling/mod.rs
+++ b/src/profiling/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(not(feature = "profiling"))]
+mod profiling_disabled;
+#[cfg(feature = "profiling")]
+mod profiling_enabled;
+
+#[cfg(not(feature = "profiling"))]
+pub use profiling_disabled::*;
+#[cfg(feature = "profiling")]
+pub use profiling_enabled::*;

--- a/src/profiling/profiling_disabled.rs
+++ b/src/profiling/profiling_disabled.rs
@@ -1,0 +1,23 @@
+#[inline(always)]
+pub fn startup_profiler() {}
+
+#[inline(always)]
+pub fn emit_frame_mark() {}
+
+#[inline(always)]
+pub fn tracy_create_gpu_context(_name: &str) {}
+
+#[inline(always)]
+pub fn tracy_gpu_collect() {}
+
+macro_rules! tracy_zone {
+    ($name: expr, $color: expr) => {};
+    ($name: expr) => {};
+}
+macro_rules! tracy_gpu_zone {
+    ($name: expr, $color: expr) => {};
+    ($name: expr) => {};
+}
+
+pub(crate) use tracy_gpu_zone;
+pub(crate) use tracy_zone;

--- a/src/profiling/profiling_enabled.rs
+++ b/src/profiling/profiling_enabled.rs
@@ -1,0 +1,309 @@
+use std::{
+    cell::RefCell,
+    ffi::CString,
+    mem,
+    ptr::null,
+    sync::atomic::{AtomicU8, Ordering},
+};
+
+use tracy_client_sys::{
+    ___tracy_c_zone_context, ___tracy_connected, ___tracy_emit_frame_mark,
+    ___tracy_emit_gpu_context_name, ___tracy_emit_gpu_new_context, ___tracy_emit_gpu_time_serial,
+    ___tracy_emit_gpu_zone_begin_serial, ___tracy_emit_gpu_zone_end_serial,
+    ___tracy_emit_zone_begin, ___tracy_emit_zone_end, ___tracy_gpu_context_name_data,
+    ___tracy_gpu_new_context_data, ___tracy_gpu_time_data, ___tracy_gpu_zone_begin_data,
+    ___tracy_gpu_zone_end_data, ___tracy_source_location_data, ___tracy_startup_profiler,
+};
+
+use gl::{
+    GenQueries, GetInteger64v, GetQueryObjectiv, GetQueryObjectui64v, QueryCounter, QUERY_RESULT,
+    QUERY_RESULT_AVAILABLE, TIMESTAMP,
+};
+
+pub struct _LocationData {
+    pub data: ___tracy_source_location_data,
+}
+
+unsafe impl Send for _LocationData {}
+unsafe impl Sync for _LocationData {}
+
+#[allow(unconditional_panic)]
+const fn illegal_null_in_string() {
+    [][0]
+}
+
+#[doc(hidden)]
+pub const fn validate_cstr_contents(bytes: &[u8]) {
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\0' {
+            illegal_null_in_string();
+        }
+        i += 1;
+    }
+}
+
+macro_rules! cstr {
+    ( $s:literal ) => {{
+        $crate::profiling::validate_cstr_contents($s.as_bytes());
+        unsafe { std::mem::transmute::<_, &std::ffi::CStr>(concat!($s, "\0")) }
+    }};
+}
+
+macro_rules! file_cstr {
+    ( ) => {{
+        unsafe { std::mem::transmute::<_, &std::ffi::CStr>(concat!(std::file!(), "\0")) }
+    }};
+}
+
+pub const fn _create_location_data(
+    name: &std::ffi::CStr,
+    function: &std::ffi::CStr,
+    file: &std::ffi::CStr,
+    line: u32,
+    color: u32,
+) -> _LocationData {
+    _LocationData {
+        data: ___tracy_source_location_data {
+            name: name.as_ptr(),
+            function: function.as_ptr(),
+            file: file.as_ptr(),
+            line,
+            color,
+        },
+    }
+}
+
+#[allow(dead_code)]
+fn is_connected() -> bool {
+    unsafe { ___tracy_connected() > 0 }
+}
+
+#[cfg(feature = "gpu_profiling")]
+fn gpu_enabled() -> bool {
+    is_connected()
+}
+
+#[cfg(not(feature = "gpu_profiling"))]
+fn gpu_enabled() -> bool {
+    false
+}
+
+pub struct _Zone {
+    context: ___tracy_c_zone_context,
+    gpu: bool,
+}
+
+impl _Zone {
+    pub fn new(loc_data: &___tracy_source_location_data, gpu: bool) -> Self {
+        let context = unsafe { ___tracy_emit_zone_begin(loc_data, 1) };
+        let gpu = gpu && gpu_enabled();
+        if gpu {
+            let (context, query, glquery) = GPUCTX.with(|ctx| {
+                let mut ctx = ctx.borrow_mut();
+                let query = ctx.next_query_id();
+                (ctx.id, query, ctx.query[query])
+            });
+
+            let gpu_data = ___tracy_gpu_zone_begin_data {
+                srcloc: (loc_data as *const ___tracy_source_location_data) as u64,
+                queryId: query as u16,
+                context,
+            };
+            unsafe {
+                QueryCounter(glquery, TIMESTAMP);
+                ___tracy_emit_gpu_zone_begin_serial(gpu_data);
+            }
+        }
+        _Zone { context, gpu }
+    }
+}
+
+impl Drop for _Zone {
+    fn drop(&mut self) {
+        if self.gpu && gpu_enabled() {
+            let (context, query, glquery) = GPUCTX.with(|ctx| {
+                let mut ctx = ctx.borrow_mut();
+                let query = ctx.next_query_id();
+                (ctx.id, query, ctx.query[query])
+            });
+            let gpu_data = ___tracy_gpu_zone_end_data {
+                queryId: query as u16,
+                context,
+            };
+            unsafe {
+                QueryCounter(glquery, TIMESTAMP);
+                ___tracy_emit_gpu_zone_end_serial(gpu_data);
+            }
+        }
+        unsafe {
+            ___tracy_emit_zone_end(self.context);
+        }
+    }
+}
+
+static CONTEXT_ID: AtomicU8 = AtomicU8::new(0);
+
+struct GpuCtx {
+    id: u8,
+    query: [u32; 64 * 1024],
+    head: usize,
+    tail: usize,
+}
+
+impl GpuCtx {
+    fn next_query_id(&mut self) -> usize {
+        let query = self.head;
+        self.head = (self.head + 1) % self.query.len();
+        assert!(self.head != self.tail);
+        query
+    }
+}
+
+thread_local! {
+    static GPUCTX: RefCell<GpuCtx> = RefCell::new(GpuCtx {
+        id: CONTEXT_ID.fetch_add(1, Ordering::Relaxed),
+        query: unsafe {mem::MaybeUninit::zeroed().assume_init()},
+        head: 0,
+        tail: 0,
+    });
+}
+
+pub fn startup_profiler() {
+    unsafe {
+        ___tracy_startup_profiler();
+    }
+}
+
+#[inline(always)]
+pub fn emit_frame_mark() {
+    unsafe {
+        ___tracy_emit_frame_mark(null());
+    }
+}
+
+pub fn tracy_create_gpu_context(name: &str) {
+    // Don't change order, only add new entries at the end, this is also used on trace dumps!
+    #[allow(dead_code)]
+    enum GpuContextType {
+        Invalid,
+        OpenGl,
+        Vulkan,
+        OpenCL,
+        Direct3D12,
+        Direct3D11,
+    }
+
+    let id = GPUCTX.with(|ctx| {
+        let mut ctx = ctx.borrow_mut();
+        unsafe {
+            GenQueries(ctx.query.len() as i32, ctx.query.as_mut_ptr());
+        }
+
+        ctx.id
+    });
+
+    let mut timestamp: i64 = 0;
+    unsafe {
+        GetInteger64v(TIMESTAMP, &mut timestamp);
+    }
+
+    let ctxt_data = ___tracy_gpu_new_context_data {
+        gpuTime: timestamp,
+        period: 1.0,
+        context: id,
+        flags: 0,
+        type_: GpuContextType::OpenGl as u8,
+    };
+    let namestring = CString::new(name).unwrap();
+    let name_data = ___tracy_gpu_context_name_data {
+        context: id,
+        name: namestring.as_ptr(),
+        len: name.len() as u16,
+    };
+    unsafe {
+        ___tracy_emit_gpu_new_context(ctxt_data);
+        ___tracy_emit_gpu_context_name(name_data);
+    }
+}
+
+pub fn tracy_gpu_collect() {
+    tracy_zone!("collect gpu info");
+    if !gpu_enabled() {
+        return;
+    }
+
+    GPUCTX.with(|ctx| {
+        let mut ctx = ctx.borrow_mut();
+
+        while ctx.tail != ctx.head {
+            let mut available: i32 = 0;
+            unsafe {
+                GetQueryObjectiv(ctx.query[ctx.tail], QUERY_RESULT_AVAILABLE, &mut available);
+            }
+            if available <= 0 {
+                break;
+            }
+
+            let mut time: u64 = 0;
+            unsafe {
+                GetQueryObjectui64v(ctx.query[ctx.tail], QUERY_RESULT, &mut time);
+            }
+            let time_data = ___tracy_gpu_time_data {
+                gpuTime: time as i64,
+                queryId: ctx.tail as u16,
+                context: ctx.id,
+            };
+            unsafe {
+                ___tracy_emit_gpu_time_serial(time_data);
+            }
+            ctx.tail = (ctx.tail + 1) % ctx.query.len();
+        }
+    });
+}
+
+#[macro_export]
+macro_rules! location_data {
+    ($name: expr, $color: expr) => {{
+        static LOC: $crate::profiling::_LocationData = $crate::profiling::_create_location_data(
+            $crate::profiling::cstr!($name),
+            // There does not seem to be any way of getting a c string to the current
+            // function until this is implemented
+            // https://github.com/rust-lang/rust/issues/63084
+            // So use Unknown for now
+            $crate::profiling::cstr!("Unknown"),
+            $crate::profiling::file_cstr!(),
+            std::line!(),
+            $color,
+        );
+        &LOC.data
+    }};
+}
+
+#[macro_export]
+macro_rules! tracy_zone {
+    ($name: expr, $color: expr) => {
+        let _tracy_zone =
+            $crate::profiling::_Zone::new($crate::profiling::location_data!($name, $color), false);
+    };
+    ($name: expr) => {
+        $crate::profiling::tracy_zone!($name, 0)
+    };
+}
+
+#[macro_export]
+macro_rules! tracy_gpu_zone {
+    ($name: expr, $color: expr) => {
+        let _tracy_zone =
+            $crate::profiling::_Zone::new($crate::profiling::location_data!($name, $color), true);
+    };
+    ($name: expr) => {
+        $crate::profiling::tracy_gpu_zone!($name, 0)
+    };
+}
+
+pub(crate) use cstr;
+pub(crate) use file_cstr;
+pub(crate) use location_data;
+pub(crate) use tracy_gpu_zone;
+pub(crate) use tracy_zone;

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -9,6 +9,7 @@ use winit::event::{Event, WindowEvent};
 use crate::{
     bridge::EditorMode,
     editor::{Cursor, CursorShape},
+    profiling::tracy_zone,
     redraw_scheduler::REDRAW_SCHEDULER,
     renderer::animation_utils::*,
     renderer::{GridRenderer, RenderedWindow},
@@ -278,6 +279,7 @@ impl CursorRenderer {
         canvas: &mut Canvas,
         dt: f32,
     ) {
+        tracy_zone!("cursor_draw");
         let render = self.blink_status.update_status(&self.cursor);
         let settings = SETTINGS.get::<CursorSettings>();
 

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -16,6 +16,7 @@ use swash::{
 };
 use unicode_segmentation::UnicodeSegmentation;
 
+use crate::profiling::tracy_zone;
 use crate::renderer::fonts::{font_loader::*, font_options::*};
 
 #[derive(new, Clone, Hash, PartialEq, Eq, Debug)]
@@ -392,6 +393,7 @@ impl CachingShaper {
     }
 
     pub fn shape_cached(&mut self, text: String, bold: bool, italic: bool) -> &Vec<TextBlob> {
+        tracy_zone!("shape_cached");
         let key = ShapeKey::new(text.clone(), bold, italic);
 
         if !self.blob_cache.contains(&key) {

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -9,6 +9,7 @@ use winit::dpi::PhysicalSize;
 use crate::{
     dimensions::Dimensions,
     editor::{Colors, Style, UnderlineStyle},
+    profiling::tracy_zone,
     renderer::{CachingShaper, RendererSettings},
     settings::*,
     window::WindowSettings,
@@ -103,6 +104,7 @@ impl GridRenderer {
         style: &Option<Arc<Style>>,
         is_floating: bool,
     ) {
+        tracy_zone!("draw_background");
         self.paint.set_blend_mode(BlendMode::Src);
 
         let region = self.compute_text_region(grid_position, cell_width);
@@ -137,6 +139,7 @@ impl GridRenderer {
         cell_width: u64,
         style: &Option<Arc<Style>>,
     ) {
+        tracy_zone!("draw_foreground");
         let (x, y) = grid_position * self.font_dimensions;
         let width = cell_width * self.font_dimensions.width;
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     bridge::EditorMode,
     editor::{Cursor, Style},
     event_aggregator::EVENT_AGGREGATOR,
+    profiling::tracy_zone,
     settings::*,
     WindowSettings,
 };
@@ -143,6 +144,7 @@ impl Renderer {
     /// `bool` indicating whether or not font was changed during this frame.
     #[allow(clippy::needless_collect)]
     pub fn draw_frame(&mut self, root_canvas: &mut Canvas, dt: f32) -> bool {
+        tracy_zone!("renderer_draw_frame");
         let mut draw_commands = Vec::new();
         while let Ok(draw_command) = self.batched_draw_command_receiver.try_recv() {
             draw_commands.extend(draw_command);

--- a/src/renderer/profiler.rs
+++ b/src/renderer/profiler.rs
@@ -4,7 +4,10 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::renderer::{fonts::font_loader::*, RendererSettings};
+use crate::{
+    profiling::tracy_zone,
+    renderer::{fonts::font_loader::*, RendererSettings},
+};
 use skia_safe::{Canvas, Color, Paint, Point, Rect, Size};
 
 const FRAMETIMES_COUNT: usize = 48;
@@ -32,6 +35,7 @@ impl Profiler {
     }
 
     pub fn draw(&mut self, root_canvas: &mut Canvas, dt: f32) {
+        tracy_zone!("profiler_draw");
         if !SETTINGS.get::<RendererSettings>().profiler {
             return;
         }

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -11,6 +11,7 @@ use skia_safe::{
 use crate::{
     dimensions::Dimensions,
     editor::Style,
+    profiling::tracy_zone,
     redraw_scheduler::REDRAW_SCHEDULER,
     renderer::{animation_utils::*, GridRenderer, RendererSettings},
 };
@@ -356,6 +357,7 @@ impl RenderedWindow {
                 grid_size,
                 floating_order,
             } => {
+                tracy_zone!("position_cmd", 0);
                 let Dimensions {
                     width: font_width,
                     height: font_height,
@@ -413,6 +415,7 @@ impl RenderedWindow {
                 }
             }
             WindowDrawCommand::DrawLine(line_fragments) => {
+                tracy_zone!("draw_line_cmd", 0);
                 let canvas = self.current_surface.surface.canvas();
 
                 canvas.save();
@@ -455,6 +458,7 @@ impl RenderedWindow {
                 rows,
                 cols,
             } => {
+                tracy_zone!("scroll_cmd", 0);
                 let Dimensions {
                     width: font_width,
                     height: font_height,
@@ -488,6 +492,7 @@ impl RenderedWindow {
                 canvas.restore();
             }
             WindowDrawCommand::Clear => {
+                tracy_zone!("clear_cmd", 0);
                 self.current_surface.surface = build_window_surface_with_grid_size(
                     self.current_surface.surface.canvas(),
                     grid_renderer,
@@ -497,6 +502,7 @@ impl RenderedWindow {
                 self.snapshots.clear();
             }
             WindowDrawCommand::Show => {
+                tracy_zone!("show_cmd", 0);
                 if self.hidden {
                     self.hidden = false;
                     self.position_t = 2.0; // We don't want to animate since the window is becoming visible,
@@ -504,8 +510,12 @@ impl RenderedWindow {
                     self.grid_start_position = self.grid_destination;
                 }
             }
-            WindowDrawCommand::Hide => self.hidden = true,
+            WindowDrawCommand::Hide => {
+                tracy_zone!("hide_cmd", 0);
+                self.hidden = true;
+            }
             WindowDrawCommand::Viewport { scroll_delta, .. } => {
+                tracy_zone!("viewport_cmd", 0);
                 if scroll_delta.abs() > f64::EPSILON {
                     let new_snapshot = self.current_surface.snapshot();
                     self.snapshots.push_back(new_snapshot);

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -38,7 +38,9 @@ use crate::{
     editor::EditorCommand,
     event_aggregator::EVENT_AGGREGATOR,
     frame::Frame,
-    profiling::{emit_frame_mark, tracy_gpu_collect, tracy_gpu_zone},
+    profiling::{
+        emit_frame_mark, tracy_create_gpu_context, tracy_gpu_collect, tracy_gpu_zone, tracy_zone,
+    },
     redraw_scheduler::REDRAW_SCHEDULER,
     renderer::Renderer,
     renderer::WindowPadding,
@@ -102,6 +104,7 @@ impl WinitWindowWrapper {
 
     #[allow(clippy::needless_collect)]
     pub fn handle_window_commands(&mut self) {
+        tracy_zone!("handle_window_commands", 0);
         while let Ok(window_command) = self.window_command_receiver.try_recv() {
             match window_command {
                 WindowCommand::TitleChanged(new_title) => self.handle_title_changed(new_title),
@@ -143,6 +146,7 @@ impl WinitWindowWrapper {
     }
 
     pub fn handle_event(&mut self, event: Event<()>) {
+        tracy_zone!("handle_event", 0);
         self.keyboard_manager.handle_event(&event);
         self.mouse_manager.handle_event(
             &event,
@@ -195,6 +199,7 @@ impl WinitWindowWrapper {
     }
 
     pub fn draw_frame(&mut self, dt: f32) {
+        tracy_zone!("draw_frame");
         let window = self.windowed_context.window();
 
         let window_settings = SETTINGS.get::<WindowSettings>();
@@ -462,6 +467,8 @@ pub fn create_window() {
         saved_grid_size: None,
         window_command_receiver,
     };
+
+    tracy_create_gpu_context("main_render_context");
 
     let mut previous_frame_start = Instant::now();
 


### PR DESCRIPTION
This add profiling support through the [Tracy Profiler](https://github.com/wolfpld/tracy)

To use the profiler you can use the `profiling` or `gpu_profiling` feature, for example

`cargo run --features gpu_profiling`, just remember to launch Tracy first and wait for the connection. It's also helpful to add `--noidle` to better stress the system, and in some cases to disable vsync with `--novsync`

I have also added a few profiling events, that covers most of the basic frame loop. 

Below is a sample, with my screen refresh rate set to 60, matching the default 60 FPS that Neovide tries to maintain. On the surface it looks good, all frames are close to 16.66 ms. But if you look closely it's constantly missing the vsync (over 17ms), followed by a shorter frame to catch up. This will be fixed later, I just have to do some final cleanup for that pull request. Also note that there's almost no load on my system, when it's showing a static screen, you have to zoom in to see something else than `swap_buffers`, which is just a wait.

![Screenshot_20230305_020932](https://user-images.githubusercontent.com/9946255/222934631-c6876db8-0de3-4297-a70a-db9c5d23f320.png)

This pull request also adds a `--profiling` build profile, which is basically release with debug symbols. This helps a bit with the sampling profiler part of tracy, but I haven't really used that. I did use the profiler of Visual Studio though, which works properly if you use this build profile.

To run that you can do for example
`cargo run --profile profiling --features profiling -- --noidle`

NOTE: I decided to write my own integration, rather than the one provided by the `tracy-client` library, that one copies some strings, allocates and has extra overhead. I also wanted everything to get completely optimized out when the profiling is disabled.

Regarding the enabling of the  GPU profiling, for OpenGL, and this integration there's not much overhead, but I also have a Direct3D implementation, and for that there's some extra overhead, mostly because I can't modify Skia, so that's why it's good to be able to disable it, when you don't need the GPU part.

The Direct3D implementation will come in a later pull request, where I enable Direct3D support for Windows, that was required to get butter smooth frame rates there. The OpenGL support for Windows, especially in Windowed mode is sadly lacking, and it would just drop frames, for now apparent reason randomly, sometimes for almost 100ms.
