### PR TITLE
Encapsulate glutin

### DIFF
--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -4,8 +4,8 @@ use std::{
     str::FromStr,
 };
 
-use glutin::dpi::PhysicalSize;
 use serde::{Deserialize, Serialize};
+use winit::dpi::PhysicalSize;
 
 use crate::settings;
 

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -3,8 +3,8 @@ mod cursor_vfx;
 
 use std::collections::HashMap;
 
-use glutin::event::{Event, WindowEvent};
 use skia_safe::{op, Canvas, Paint, Path, Point};
+use winit::event::{Event, WindowEvent};
 
 use crate::{
     bridge::EditorMode,

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use glutin::dpi::PhysicalSize;
 use log::trace;
 use skia_safe::{
     colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, Point, Rect, HSV,
 };
+use winit::dpi::PhysicalSize;
 
 use crate::{
     dimensions::Dimensions,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -2,6 +2,7 @@ pub mod animation_utils;
 pub mod cursor_renderer;
 pub mod fonts;
 pub mod grid_renderer;
+mod opengl;
 pub mod profiler;
 mod rendered_window;
 
@@ -30,6 +31,8 @@ pub use grid_renderer::GridRenderer;
 pub use rendered_window::{
     LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails, WindowPadding,
 };
+
+pub use opengl::{build_context, Context};
 
 #[derive(SettingGroup, Clone)]
 pub struct RendererSettings {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -12,10 +12,10 @@ use std::{
     sync::Arc,
 };
 
-use glutin::event::Event;
 use log::error;
 use skia_safe::Canvas;
 use tokio::sync::mpsc::UnboundedReceiver;
+use winit::event::Event;
 
 use crate::{
     bridge::EditorMode,
@@ -32,7 +32,7 @@ pub use rendered_window::{
     LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails, WindowPadding,
 };
 
-pub use opengl::{build_context, Context};
+pub use opengl::{build_context, Context as WindowedContext};
 
 #[derive(SettingGroup, Clone)]
 pub struct RendererSettings {

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -1,0 +1,40 @@
+use crate::cmd_line::CmdLineSettings;
+
+use glutin::{ContextBuilder, GlProfile, PossiblyCurrent, WindowedContext};
+
+use winit::{event_loop::EventLoop, window::WindowBuilder};
+
+pub type Context = WindowedContext<glutin::PossiblyCurrent>;
+
+pub fn build_context<TE>(
+    cmd_line_settings: &CmdLineSettings,
+    winit_window_builder: WindowBuilder,
+    event_loop: &EventLoop<TE>,
+) -> WindowedContext<PossiblyCurrent> {
+    let builder = ContextBuilder::new()
+        .with_pixel_format(24, 8)
+        .with_stencil_buffer(8)
+        .with_gl_profile(GlProfile::Core)
+        .with_srgb(cmd_line_settings.srgb)
+        .with_vsync(cmd_line_settings.vsync);
+
+    let ctx = match builder
+        .clone()
+        .build_windowed(winit_window_builder.clone(), event_loop)
+    {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            // haven't found any sane way to actually match on the pattern rabbithole CreationError
+            // provides, so here goes nothing
+            if err.to_string().contains("vsync") {
+                builder
+                    .with_vsync(false)
+                    .build_windowed(winit_window_builder, event_loop)
+                    .unwrap()
+            } else {
+                panic!("{}", err);
+            }
+        }
+    };
+    unsafe { ctx.make_current().unwrap() }
+}

--- a/src/settings/window_geometry.rs
+++ b/src/settings/window_geometry.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use glutin::dpi::PhysicalPosition;
 use serde::{Deserialize, Serialize};
+use winit::dpi::PhysicalPosition;
 
 use crate::{dimensions::Dimensions, settings::SETTINGS, window::WindowSettings};
 

--- a/src/window/draw_background.rs
+++ b/src/window/draw_background.rs
@@ -1,13 +1,12 @@
-use crate::{settings::SETTINGS, window::WindowSettings};
-use glutin::{PossiblyCurrent, WindowedContext};
+use crate::{renderer::WindowedContext, settings::SETTINGS, window::WindowSettings};
 
 use cocoa::appkit::{NSColor, NSWindow};
 use cocoa::base::{id, nil};
 use csscolorparser::Color;
-use glutin::platform::macos::WindowExtMacOS;
 use objc::{rc::autoreleasepool, runtime::YES};
+use winit::platform::macos::WindowExtMacOS;
 
-pub fn draw_background(window: &WindowedContext<PossiblyCurrent>) {
+pub fn draw_background(window: &WindowedContext) {
     if let Ok(color) = &SETTINGS
         .get::<WindowSettings>()
         .background_color

--- a/src/window/draw_background.rs
+++ b/src/window/draw_background.rs
@@ -1,12 +1,12 @@
-use crate::{renderer::WindowedContext, settings::SETTINGS, window::WindowSettings};
+use crate::{settings::SETTINGS, window::WindowSettings};
 
 use cocoa::appkit::{NSColor, NSWindow};
 use cocoa::base::{id, nil};
 use csscolorparser::Color;
 use objc::{rc::autoreleasepool, runtime::YES};
-use winit::platform::macos::WindowExtMacOS;
+use winit::{platform::macos::WindowExtMacOS, window::Window};
 
-pub fn draw_background(window: &WindowedContext) {
+pub fn draw_background(window: &Window) {
     if let Ok(color) = &SETTINGS
         .get::<WindowSettings>()
         .background_color
@@ -14,7 +14,7 @@ pub fn draw_background(window: &WindowedContext) {
     {
         autoreleasepool(|| unsafe {
             let [red, green, blue, alpha] = color.to_array();
-            let ns_window: id = window.window().ns_window() as id;
+            let ns_window: id = window.ns_window() as id;
             let ns_background = NSColor::colorWithSRGBRed_green_blue_alpha_(
                 nil,
                 red.into(),

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -4,7 +4,7 @@ use crate::{
     settings::SETTINGS,
     window::KeyboardSettings,
 };
-use glutin::{
+use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     keyboard::{Key, Key::Dead},
     platform::modifier_supplement::KeyEventExtModifierSupplement,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -146,7 +146,7 @@ impl WinitWindowWrapper {
             &event,
             &self.keyboard_manager,
             &self.renderer,
-            &self.windowed_context,
+            self.windowed_context.window(),
         );
         self.renderer.handle_event(&event);
         match event {
@@ -491,7 +491,7 @@ pub fn create_window() {
             }
             previous_frame_start = frame_start;
             #[cfg(target_os = "macos")]
-            draw_background(&window_wrapper.windowed_context);
+            draw_background(window_wrapper.windowed_context.window());
         }
 
         *control_flow = ControlFlow::WaitUntil(previous_frame_start + frame_duration)

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     redraw_scheduler::REDRAW_SCHEDULER,
     renderer::Renderer,
     renderer::WindowPadding,
-    renderer::{build_context, Context},
+    renderer::{build_context, WindowedContext},
     running_tracker::*,
     settings::{
         load_last_window_settings, save_window_geometry, PersistentWindowSettings, SETTINGS,
@@ -62,7 +62,7 @@ pub enum WindowCommand {
 }
 
 pub struct WinitWindowWrapper {
-    windowed_context: Context,
+    windowed_context: WindowedContext,
     skia_renderer: SkiaRenderer,
     renderer: Renderer,
     keyboard_manager: KeyboardManager,

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -4,21 +4,19 @@ use std::{
     time::{Duration, Instant},
 };
 
-use glutin::{
-    self,
+use skia_safe::Rect;
+use winit::{
     dpi::PhysicalPosition,
     event::{
         DeviceId, ElementState, Event, MouseButton, MouseScrollDelta, Touch, TouchPhase,
         WindowEvent,
     },
-    PossiblyCurrent, WindowedContext,
 };
-use skia_safe::Rect;
 
 use crate::{
     bridge::{SerialCommand, UiCommand},
     event_aggregator::EVENT_AGGREGATOR,
-    renderer::{Renderer, WindowDrawDetails},
+    renderer::{Renderer, WindowDrawDetails, WindowedContext},
     settings::SETTINGS,
     window::keyboard_manager::KeyboardManager,
     window::WindowSettings,
@@ -109,7 +107,7 @@ impl MouseManager {
         y: i32,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext<PossiblyCurrent>,
+        windowed_context: &WindowedContext,
     ) {
         let size = windowed_context.window().inner_size();
         if x < 0 || x as u32 >= size.width || y < 0 || y as u32 >= size.height {
@@ -313,7 +311,7 @@ impl MouseManager {
         &mut self,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext<PossiblyCurrent>,
+        windowed_context: &WindowedContext,
         finger_id: (DeviceId, u64),
         location: PhysicalPosition<f32>,
         phase: &TouchPhase,
@@ -416,7 +414,7 @@ impl MouseManager {
         event: &Event<()>,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext<PossiblyCurrent>,
+        windowed_context: &WindowedContext,
     ) {
         match event {
             Event::WindowEvent {

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -11,12 +11,13 @@ use winit::{
         DeviceId, ElementState, Event, MouseButton, MouseScrollDelta, Touch, TouchPhase,
         WindowEvent,
     },
+    window::Window,
 };
 
 use crate::{
     bridge::{SerialCommand, UiCommand},
     event_aggregator::EVENT_AGGREGATOR,
-    renderer::{Renderer, WindowDrawDetails, WindowedContext},
+    renderer::{Renderer, WindowDrawDetails},
     settings::SETTINGS,
     window::keyboard_manager::KeyboardManager,
     window::WindowSettings,
@@ -107,9 +108,9 @@ impl MouseManager {
         y: i32,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext,
+        window: &Window,
     ) {
-        let size = windowed_context.window().inner_size();
+        let size = window.inner_size();
         if x < 0 || x as u32 >= size.width || y < 0 || y as u32 >= size.height {
             return;
         }
@@ -311,7 +312,7 @@ impl MouseManager {
         &mut self,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext,
+        window: &Window,
         finger_id: (DeviceId, u64),
         location: PhysicalPosition<f32>,
         phase: &TouchPhase,
@@ -360,7 +361,7 @@ impl MouseManager {
                             location.y.round() as i32,
                             keyboard_manager,
                             renderer,
-                            windowed_context,
+                            window,
                         );
                     }
                     // the double check might seem useless, but the if branch above might set
@@ -383,7 +384,7 @@ impl MouseManager {
                         location.y.round() as i32,
                         keyboard_manager,
                         renderer,
-                        windowed_context,
+                        window,
                     );
                     self.handle_pointer_transition(&MouseButton::Left, true, keyboard_manager);
                 }
@@ -399,7 +400,7 @@ impl MouseManager {
                             trace.start.y.round() as i32,
                             keyboard_manager,
                             renderer,
-                            windowed_context,
+                            window,
                         );
                         self.handle_pointer_transition(&MouseButton::Left, true, keyboard_manager);
                         self.handle_pointer_transition(&MouseButton::Left, false, keyboard_manager);
@@ -414,7 +415,7 @@ impl MouseManager {
         event: &Event<()>,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
-        windowed_context: &WindowedContext,
+        window: &Window,
     ) {
         match event {
             Event::WindowEvent {
@@ -426,10 +427,10 @@ impl MouseManager {
                     position.y as i32,
                     keyboard_manager,
                     renderer,
-                    windowed_context,
+                    window,
                 );
                 if self.mouse_hidden {
-                    windowed_context.window().set_cursor_visible(true);
+                    window.set_cursor_visible(true);
                     self.mouse_hidden = false;
                 }
             }
@@ -466,7 +467,7 @@ impl MouseManager {
             } => self.handle_touch(
                 keyboard_manager,
                 renderer,
-                windowed_context,
+                window,
                 (*device_id, *id),
                 location.cast(),
                 phase,
@@ -489,7 +490,7 @@ impl MouseManager {
                 if key_event.state == ElementState::Pressed {
                     let window_settings = SETTINGS.get::<WindowSettings>();
                     if window_settings.hide_mouse_when_typing && !self.mouse_hidden {
-                        windowed_context.window().set_cursor_visible(false);
+                        window.set_cursor_visible(false);
                         self.mouse_hidden = true;
                     }
                 }

--- a/src/window/renderer.rs
+++ b/src/window/renderer.rs
@@ -1,13 +1,12 @@
 use std::convert::TryInto;
 
 use crate::redraw_scheduler::REDRAW_SCHEDULER;
+use crate::renderer::WindowedContext;
 use gl::types::*;
 use skia_safe::{
     gpu::{gl::FramebufferInfo, BackendRenderTarget, DirectContext, SurfaceOrigin},
     Canvas, ColorType, Surface,
 };
-
-type WindowedContext = glutin::ContextWrapper<glutin::PossiblyCurrent, glutin::window::Window>;
 
 fn create_surface(
     windowed_context: &WindowedContext,


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Refactor

This moves the Glutin context creation to it's own file. It also passes the winit window around rather than the whole context, so that the code mostly becomes dependent on winit rather than glutin. 

The only direct reference to glutin is in the new `opengl.rs` file, but the context is still used outside of that, so some of the code is still dependent on it at an interface level.

This is done mostly to make it easier to review my upcoming render changes. But it should also be quite easy to switch over to not use a forked version of Glutin anymore. The new Glutin versions, no longer depend on winit, so we can use our own version of it. Instead we could directly do something similar as the Glutin winit module https://github.com/rust-windowing/glutin/tree/master/glutin-winit/src

## Did this PR introduce a breaking change? 
- No
