### PR TITLE
Fix parse additional parameter for `win_viewport` event

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -695,8 +695,10 @@ fn parse_msg_set_pos(msg_set_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
 }
 
 fn parse_win_viewport(win_viewport_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let ([grid, _window, top_line, bottom_line, current_line, current_column], [line_count]) =
-        extract_values_with_optional(win_viewport_arguments)?;
+    let (
+        [grid, _window, top_line, bottom_line, current_line, current_column],
+        [line_count, _scroll_delta],
+    ) = extract_values_with_optional(win_viewport_arguments)?;
 
     let line_count = if let Some(line_count) = line_count {
         Some(parse_f64(line_count)?)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix


## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

Fixes #1798
Fixes https://github.com/neovide/neovide/issues/1804

This fixes an index out of bounds panic because neovim nightly added a new argument to the `win_viewport` event. 
Tested with nvim versions nightly `v0.9.0-dev-1230+gd1e0f7454` and stable `v0.8.3`

![image](https://user-images.githubusercontent.com/34637103/225085858-9b91b965-db8d-44db-9f9c-a577a357c5e7.png)

