### PR TITLE
Fix MacOS bundle instructions

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -83,7 +83,7 @@ brew install --cask neovide
 
 8. `cargo bundle --release`
 
-9. Copy `./target/release/bundle/osx/neovide.app` to `~/Applications` and enjoy.
+9. `cp -r ./target/release/bundle/osx/Neovide.app /Applications/Neovide.app` and enjoy.
 
 ## Linux
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A documentation fix. The bundle output needed to be capitalized, and it was pointing to the wrong `Applications` path. I also turned the whole thing into a shell command like the others, but I can change it back if desired.

## Did this PR introduce a breaking change? 

No
