### PR TITLE
Fix opening from Finder in macOS

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -59,10 +59,10 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
         let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
         let mut result = StdCommand::new(shell);
 
-        result.arg("-c");
         if env::var_os("TERM").is_none() {
             result.arg("-l");
         }
+        result.arg("-c");
         result.arg(format!("{} {}", command, args.join(" ")));
 
         Some(result)
@@ -121,10 +121,10 @@ fn nvim_cmd_impl(bin: &str, args: &[String]) -> TokioCommand {
         .map(|arg| shlex::quote(arg))
         .collect::<Vec<_>>()
         .join(" ");
-    cmd.arg("-c");
     if env::var_os("TERM").is_none() {
         cmd.arg("-l");
     }
+    cmd.arg("-c");
     cmd.arg(&format!("{} {}", bin, args_str));
     cmd
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
A fix for a bug introduced in #1758 where opening Neovide from Finder (i.e. directly running the .app) when using the fish shell as your $SHELL fails. Running `neovide` from a terminal works fine.

Previously (in 0.10.3), Neovide would always run `$SHELL -lc "which nvim"` on macOS to find the `nvim` binary. After #1758, it now runs `$SHELL -c -l "which nvim"` only if the TERM environment variable is not set. `bash` and `sh` do not care about the order of the `-c` and `-l` flags, but `fish` does (I haven't tested other shells). This fix simply reorders those flags, fixing the issue.

## Did this PR introduce a breaking change? 
No

