### PR TITLE
Fixes window position not being remembered on multi-monitor

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -402,11 +402,10 @@ pub fn create_window() {
             let monitor_width = monitor_size.width as i32;
             let monitor_height = monitor_size.height as i32;
 
-            let window_position = if previous_position.is_none() || maximized {
-                window.outer_position().ok()?
-            } else {
-                previous_position.unwrap()
-            };
+            let window_position = previous_position
+                .filter(|_| !maximized)
+                .or_else(|| window.outer_position().ok())?;
+
             let window_size = window.outer_size();
             let window_width = window_size.width as i32;
             let window_height = window_size.height as i32;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -402,7 +402,11 @@ pub fn create_window() {
             let monitor_width = monitor_size.width as i32;
             let monitor_height = monitor_size.height as i32;
 
-            let window_position = window.outer_position().ok()?;
+            let window_position = if previous_position.is_none() || maximized {
+                window.outer_position().ok()?
+            } else {
+                previous_position.unwrap()
+            };
             let window_size = window.outer_size();
             let window_width = window_size.width as i32;
             let window_height = window_size.height as i32;


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

### The bug
With two monitors and the secondary monitor on the left of the main monitor, neovide would always be positioned on the top left instead of the previous position.

### The cause
On `src/window/mod.rs` line 405, `window.outer_position().ok()?` will always return `PhysicalPosition { x: 0, y: 0 }`. I assume this is because window hasn't been positioned at this point. This led to neovide believing window isn't visible on the current monitor and hence repositioned it to the top left of the current monitor.

### The solution
Use `previous_position` when possible. This fixed the bug.

### My system
I'm using KDE with KWin so this might be a KWin specific problem. But this PR shouldn't break anything as it always falls back to `window.outer_position().ok()?` if `previous_position` can't be used.