### PR TITLE
Prevent wsl console window shown

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -54,7 +54,10 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
         result.args(["$SHELL", "-lc"]);
         result.arg(format!("{} {}", command, args.join(" ")));
         #[cfg(windows)]
-        std::os::windows::process::CommandExt::creation_flags(&mut result, 0x0800_0000);
+        std::os::windows::process::CommandExt::creation_flags(
+            &mut result,
+            winapi::um::winbase::CREATE_NO_WINDOW,
+        );
 
         Some(result)
     } else if cfg!(target_os = "macos") {

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -53,6 +53,8 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> Option<StdComm
         let mut result = StdCommand::new("wsl");
         result.args(["$SHELL", "-lc"]);
         result.arg(format!("{} {}", command, args.join(" ")));
+        #[cfg(windows)]
+        std::os::windows::process::CommandExt::creation_flags(&mut result, 0x0800_0000);
 
         Some(result)
     } else if cfg!(target_os = "macos") {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

This PR prevents an additional console window from appearing when starting in `--wsl` mode.

## Did this PR introduce a breaking change? 
- No
