### PR TITLE
Disable srgb on Linux and macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,8 +1541,10 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "rmpv",
+ "scoped-env",
  "serde",
  "serde_json",
+ "serial_test",
  "shlex",
  "skia-safe",
  "swash",
@@ -2245,6 +2260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-env"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86338a78d9058ae1bb70bf4ec558e9c51c611b443a356f7d041d29bb6c1c026"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2316,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures 0.3.28",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ xdg = "2.4.1"
 
 [dev-dependencies]
 mockall = "0.11.0"
+scoped-env = "2.1.0"
+serial_test = "2.0.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser", "wincon"] }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -4,6 +4,11 @@ use crate::{dimensions::Dimensions, frame::Frame, settings::*};
 
 use clap::{builder::FalseyValueParser, ArgAction, Parser};
 
+#[cfg(target_os = "windows")]
+const SRGB_DEFAULT: &str = "1";
+#[cfg(not(target_os = "windows"))]
+const SRGB_DEFAULT: &str = "0";
+
 #[derive(Clone, Debug, Parser)]
 #[command(version, about, long_about = None)]
 pub struct CmdLineSettings {
@@ -71,12 +76,12 @@ pub struct CmdLineSettings {
     pub no_tabs: bool,
 
     /// Request sRGB when initializing the window, may help with GPUs with weird pixel
-    /// formats [DEFAULT]
-    #[arg(long = "srgb", env = "NEOVIDE_SRGB", action = ArgAction::SetTrue, default_value = "1", value_parser = FalseyValueParser::new())]
+    /// formats. Default on Windows.
+    #[arg(long = "srgb", env = "NEOVIDE_SRGB", action = ArgAction::SetTrue, default_value = SRGB_DEFAULT, value_parser = FalseyValueParser::new())]
     pub srgb: bool,
 
     /// Do not request sRGB when initializing the window, may help with GPUs with weird pixel
-    /// formats
+    /// formats. Default on Linux and macOs.
     #[arg(long = "nosrgb", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
     pub _nosrgb: bool,
 
@@ -333,7 +338,11 @@ mod tests {
         let args: Vec<String> = vec!["neovide"].iter().map(|s| s.to_string()).collect();
 
         handle_command_line_arguments(args).expect("Could not parse arguments");
-        assert_eq!(SETTINGS.get::<CmdLineSettings>().srgb, true);
+        #[cfg(target_os = "windows")]
+        let default_value = true;
+        #[cfg(not(target_os = "windows"))]
+        let default_value = false;
+        assert_eq!(SETTINGS.get::<CmdLineSettings>().srgb, default_value);
     }
 
     #[test]

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -132,26 +132,19 @@ pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use std::env::set_var;
-    use std::sync::Mutex;
-
-    use lazy_static::lazy_static;
+    use scoped_env::ScopedEnv;
 
     use super::*;
-
-    // Use a mutex to ensure that the settings are initialized and accessed in series
-    lazy_static! {
-        static ref ACCESSING_SETTINGS: Mutex<bool> = Mutex::new(false);
-    }
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_neovim_passthrough() {
         let args: Vec<String> = vec!["neovide", "--notabs", "--", "--clean"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
@@ -160,13 +153,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_files_to_open() {
         let args: Vec<String> = vec!["neovide", "./foo.txt", "--notabs", "./bar.md"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
@@ -175,6 +168,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_files_to_open_with_passthrough() {
         let args: Vec<String> = vec![
             "neovide",
@@ -188,7 +182,6 @@ mod tests {
         .map(|s| s.to_string())
         .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
@@ -197,13 +190,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_files_to_open_with_flag() {
         let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md", "--geometry=42x24"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
@@ -220,13 +213,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_geometry() {
         let args: Vec<String> = vec!["neovide", "--geometry=42x24"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().geometry,
@@ -238,13 +231,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_size() {
         let args: Vec<String> = vec!["neovide", "--size=420x240"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().size,
@@ -256,47 +249,47 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_log_to_file() {
         let args: Vec<String> = vec!["neovide", "--log"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert!(SETTINGS.get::<CmdLineSettings>().log_to_file);
     }
 
     #[test]
+    #[serial]
     fn test_frameless_flag() {
         let args: Vec<String> = vec!["neovide", "--frame=full"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(SETTINGS.get::<CmdLineSettings>().frame, Frame::Full);
     }
 
     #[test]
+    #[serial]
     fn test_frameless_environment_variable() {
         let args: Vec<String> = vec!["neovide"].iter().map(|s| s.to_string()).collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
-        set_var("NEOVIDE_FRAME", "none");
+        let _env = ScopedEnv::set("NEOVIDE_FRAME", "none");
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(SETTINGS.get::<CmdLineSettings>().frame, Frame::None);
     }
 
     #[test]
+    #[serial]
     fn test_neovim_bin_arg() {
         let args: Vec<String> = vec!["neovide", "--neovim-bin", "foo"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_bin,
@@ -305,11 +298,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_neovim_bin_environment_variable() {
         let args: Vec<String> = vec!["neovide"].iter().map(|s| s.to_string()).collect();
 
-        let _accessing_settings = ACCESSING_SETTINGS.lock().unwrap();
-        set_var("NEOVIM_BIN", "foo");
+        let _env = ScopedEnv::set("NEOVIM_BIN", "foo");
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_bin,

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -83,7 +83,7 @@ pub struct CmdLineSettings {
     /// Do not request sRGB when initializing the window, may help with GPUs with weird pixel
     /// formats. Default on Linux and macOs.
     #[arg(long = "nosrgb", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
-    pub _nosrgb: bool,
+    _nosrgb: bool,
 
     /// Request VSync on the window [DEFAULT]
     #[arg(long = "vsync", env = "NEOVIDE_VSYNC", action = ArgAction::SetTrue, default_value = "1", value_parser = FalseyValueParser::new())]
@@ -91,7 +91,7 @@ pub struct CmdLineSettings {
 
     /// Do not try to request VSync on the window
     #[arg(long = "novsync", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
-    pub _novsync: bool,
+    _novsync: bool,
 
     /// Which NeoVim binary to invoke headlessly instead of `nvim` found on $PATH
     #[arg(long = "neovim-bin", env = "NEOVIM_BIN")]

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -98,13 +98,15 @@ leaking it, be "blocking" and have the shell directly as parent process.
 Instead of skipping some frames in order to match `g:neovide_refresh_rate`, render every possible
 one.
 
-### No sRGB
+### sRGB
 
 ```sh
---nosrgb or $NEOVIDE_NO_SRGB
+--nosrgb, --srgb or $NEOVIDE_SRGB=0|1
 ```
 
-Don't request sRGB on the window. Swapping sometimes fixes startup issues.
+Request sRGB on the window. Swapping sometimes fixes startup issues. Defaults
+to enabled. The command line parameter takes priority over the environment
+variable.
 
 ### No Tabs
 
@@ -122,12 +124,14 @@ or not.
 ## No VSync
 
 ```sh
---novsync
+--novsync, --vsync or $NEOVIDE_VSYNC=0|1
 ```
 
 **Available since 0.10.2.**
 
-By default, Neovide requests to use VSync on the created window. This option disables this behavior.
+By default, Neovide requests to use VSync on the created window. This
+`--novsync` disables this behavior. The command line parameter takes priority
+over the environment variable.
 
 ### Neovim Server
 

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -104,9 +104,12 @@ one.
 --nosrgb, --srgb or $NEOVIDE_SRGB=0|1
 ```
 
-Request sRGB on the window. Swapping sometimes fixes startup issues. Defaults
-to enabled. The command line parameter takes priority over the environment
-variable.
+Request sRGB support on the window. Neovide does not actually render with sRGB,
+but it's still enabled by default on Windows to work around
+[neovim/neovim/issues/907](https://github.com/neovim/neovim/issues/907). Other
+platforms should not need it, but if you encounter either startup crashes or
+wrong colors, you can try to swap the option. The command line parameter takes
+priority over the environment variable.
 
 ### No Tabs
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?

This disables srgb on Linux and macOs to fix issues with wrong colors being rendered on Wayland with Nvidia. 

It's still enabled on Windows by default  to work around https://github.com/neovide/neovide/issues/907. 

Note that the actual rendering is always non-srgb due to the options we pass to Skia. Enabling srgb only enables the support, so it should really not be needed. 

Disabling it fixes a bug on Wayland with Nvidia cards where the colours are rendered wrong. 

This also adds the full pair of parameters `--srgb`, `--nosrgb`, `--vsync` `--novsync`. So that you always can override what's set in the environment variables. The implementation is not the best due to missing support in clap, see https://github.com/clap-rs/clap/issues/3146 and https://github.com/clap-rs/clap/issues/815

Finally it fixes the environment variables, they have now been renamed to NEOVIDE_VSYNC and NEOVIDE_SRGB,
and now work as they should. Previously `NEOVIDE_NO_SRGB=1` enabled SRGB, so the environment variable value was actually inverted. Note the same fix is included in https://github.com/neovide/neovide/pull/1119 @LoipesMas 

And I almost forgot, it also improves the way the cmd_line tests are run serially and isolates the environment variable setting to affect only one test.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._

Yes, `NEOVIDE_NO_SRGB=0` is now `NEOVIDE_SRGB=0` and
`NEOVIDE_NO_VSYNC=0` is now `NEOVIDE_VSYNC=1`. 

Srgb is disabled by default on Linux and macOS, previously it was enabled, so it could cause regressions.

NOTE: I have only tested this on X11 and Wayland with KDE Plasma 5.27.5 and Nvidia drivers 525.116.04-1. Wayland did not work properly with this configuration before these changes. Windows should be unchanged, but I haven't tested it, and I don't own a macOS machine.
