### PR TITLE
Fix `no idle` behaviour

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -69,7 +69,7 @@ pub struct CmdLineSettings {
     /// Render every frame, takes more power and CPU time but possibly helps with frame timing
     /// issues
     #[arg(long = "noidle", env = "NEOVIDE_IDLE", action = ArgAction::SetFalse, value_parser = FalseyValueParser::new())]
-    pub no_idle: bool,
+    pub idle: bool,
 
     /// Disable opening multiple files supplied in tabs (they're still buffers)
     #[arg(long = "notabs")]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -218,7 +218,7 @@ impl WinitWindowWrapper {
             self.skia_renderer.resize(&self.windowed_context);
         }
 
-        if REDRAW_SCHEDULER.should_draw() || SETTINGS.get::<WindowSettings>().no_idle {
+        if REDRAW_SCHEDULER.should_draw() || !SETTINGS.get::<WindowSettings>().idle {
             self.font_changed_last_frame =
                 self.renderer.draw_frame(self.skia_renderer.canvas(), dt);
             self.skia_renderer.gr_context.flush(None);

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -4,7 +4,7 @@ use crate::{cmd_line::CmdLineSettings, settings::*};
 pub struct WindowSettings {
     pub refresh_rate: u64,
     pub refresh_rate_idle: u64,
-    pub no_idle: bool,
+    pub idle: bool,
     pub transparency: f32,
     pub scale_factor: f32,
     pub fullscreen: bool,
@@ -31,7 +31,7 @@ impl Default for WindowSettings {
             iso_layout: false,
             refresh_rate: 60,
             refresh_rate_idle: 5,
-            no_idle: SETTINGS.get::<CmdLineSettings>().no_idle,
+            idle: SETTINGS.get::<CmdLineSettings>().idle,
             remember_window_size: true,
             remember_window_position: true,
             hide_mouse_when_typing: false,

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -95,8 +95,11 @@ leaking it, be "blocking" and have the shell directly as parent process.
 --noidle or $NEOVIDE_IDLE=0|1
 ```
 
-Instead of skipping some frames in order to match `g:neovide_refresh_rate`, render every possible
-one.
+With idle `on` (default), neovide won't render new frames when nothing is happening.
+
+With idle `off` (e.g. with `--noidle` flag), neovide will constantly render new frames,
+even when nothing changed. This takes more power and CPU time, but can possibly help
+with frame timing issues.
 
 ### sRGB
 

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -92,7 +92,7 @@ leaking it, be "blocking" and have the shell directly as parent process.
 ### No Idle
 
 ```sh
---noidle or $NEOVIDE_NO_IDLE
+--noidle or $NEOVIDE_IDLE=0|1
 ```
 
 Instead of skipping some frames in order to match `g:neovide_refresh_rate`, render every possible


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Fix: #1885 changed the handling of `--noidle` flag, which caused the behavior to be flipped (so we had `no_idle=true` by default).
I changed the name of the variable and it's usage to reflect the actual behavior.
I also improved the documentation for that option.


## Did this PR introduce a breaking change? 
Technically yes, relative to current main.