### PR TITLE
Make window title customizable

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -97,6 +97,14 @@ pub struct CmdLineSettings {
     #[arg(long = "neovim-bin", env = "NEOVIM_BIN")]
     pub neovim_bin: Option<String>,
 
+    /// Window title
+    #[arg(
+        long = "window-title",
+        env = "NEOVIDE_WINDOW_TITLE",
+        default_value = "Neovide"
+    )]
+    pub window_title: String,
+
     /// The app ID to show to the compositor (Wayland only, useful for setting WM rules)
     #[arg(
         long = "wayland_app_id",

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -361,7 +361,7 @@ pub fn create_window() {
     }
 
     let winit_window_builder = window::WindowBuilder::new()
-        .with_title("Neovide")
+        .with_title(&cmd_line_settings.window_title)
         .with_window_icon(Some(icon))
         .with_maximized(maximized)
         .with_transparent(true);

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -165,6 +165,12 @@ Sets where to find neovim's executable. If unset, neovide will try to find `nvim
 environment variable instead. If you're running a Unix-alike, be sure that binary has the executable
 permission bit set.
 
+### Window Title
+
+```sh
+--window-title <window_title> or $NEOVIDE_WINDOW_TITLE
+```
+
 ### Wayland / X11
 
 ```sh


### PR DESCRIPTION
Let the user customize the default “Neovide” window title via `--window-title` command-line arguments option.

This change is addressing https://github.com/neovide/neovide/issues/1904 but it doesn’t fully resolve it. It’s still to figure out how to set `WM_NAME` to make the feature complete for X11. Most of the X11 applications seems to set both the title and the `WM_NAME` property.

## What kind of change does this PR introduce?

- Feature

## Did this PR introduce a breaking change? 

- No