### PR TITLE
fix: could not draw floating_window with transparent background (when multigrid is enabled)

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use log::trace;
 use skia_safe::{
-    colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, Point, Rect, HSV, ClipOp,
+    colors, dash_path_effect, BlendMode, Canvas, ClipOp, Color, Paint, Path, Point, Rect, HSV,
 };
 use winit::dpi::PhysicalSize;
 
@@ -118,6 +118,7 @@ impl GridRenderer {
             self.paint
                 .set_color(style.background(&self.default_style.colors).to_color());
         }
+
         let window_transparency = &SETTINGS.get::<WindowSettings>().transparency;
         if is_floating {
             if self.paint.color() != self.get_default_background() {
@@ -132,7 +133,8 @@ impl GridRenderer {
                 {
                     self.paint.set_argb(*a, *r, *g, *b);
                 } else {
-                    self.paint.set_argb(( window_transparency * 255.0 ) as u8, 0, 0, 0);
+                    self.paint
+                        .set_argb((window_transparency * 255.0) as u8, 0, 0, 0);
                 }
             }
         } else if (window_transparency - 1.0).abs() > f32::EPSILON

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use log::trace;
 use skia_safe::{
-    colors, dash_path_effect, BlendMode, Canvas, ClipOp, Color, Paint, Path, Point, Rect, HSV,
+    colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, Point, Rect, HSV,
 };
 use winit::dpi::PhysicalSize;
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -105,12 +105,14 @@ impl GridRenderer {
         is_floating: bool,
     ) {
         tracy_zone!("draw_background");
-        self.paint.set_blend_mode(BlendMode::Src);
+        let debug = SETTINGS.get::<RendererSettings>().debug_renderer;
 
         let region = self.compute_text_region(grid_position, cell_width);
         let style = style.as_ref().unwrap_or(&self.default_style);
 
-        if SETTINGS.get::<RendererSettings>().debug_renderer {
+        self.paint.set_blend_mode(BlendMode::Src);
+
+        if debug {
             let random_hsv: HSV = (rand::random::<f32>() * 360.0, 0.3, 0.3).into();
             let random_color = random_hsv.to_color(255);
             self.paint.set_color(random_color);
@@ -143,6 +145,7 @@ impl GridRenderer {
         {
             self.paint.set_alpha(0);
         }
+
         canvas.draw_rect(region, &self.paint);
     }
 


### PR DESCRIPTION
**Overview**
- close #1819 
- close #1508
 
<img width="600" alt="image" src="https://github.com/neovide/neovide/assets/84216737/9c48df70-1f54-4c6d-af14-68925dc48d3a">

<br/>
<br/>

### What kind of change does this PR introduce?
- Fix: Changed the handling of colors when grid_renderer draws the background of a floating window.

<br/>

### Description
The original problem was that the `MsgArea` was not transparent, but the immediate cause was that specifying a transparent colour (`guibg=none`) on the Floating Window did not work properly.

In this PR, if a transparent colour is specified, a background colour with an alpha value is specified and returned.
<br/>

### Why I am still Drafting this:
- [ ] I have only installed neovide on my mac and have not tested it enough in other environments.
- [ ] This may have side-effects on the color reversing setting.
- [ ] This may have side-effects on the blur setting.
- [ ] There is room for performance improvements, such as parsing the background_color each time.

<br/>

### Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

<br/>

I apologize if there are any mistakes in my English writing. Actually, I am a Japanese student learning English ;) 
