### PR TITLE
Center the line by adding half of linespace to y_adjustment

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -194,7 +194,7 @@ impl CachingShaper {
 
     pub fn y_adjustment(&mut self) -> u64 {
         let metrics = self.metrics();
-        (metrics.ascent + metrics.leading).ceil() as u64
+        (metrics.ascent + metrics.leading + self.linespace as f32 / 2.).ceil() as u64
     }
 
     fn build_clusters(


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

Fixes #1852

With linespace set to 14, 
Before:
<img width="316" alt="Screenshot 2023-07-01 at 11 06 47 PM" src="https://github.com/neovide/neovide/assets/24775746/7af38f24-cd84-460e-ae7b-4fc3ab700f21">
After:
<img width="316" alt="Screenshot 2023-07-01 at 11 04 58 PM" src="https://github.com/neovide/neovide/assets/24775746/4a8ce8dd-a37f-4514-94da-0e32d5d65d14">