### PR TITLE
chore: proc_macro2 1.0.59 Fails to build with nightly-2023-06-28+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Update proc-macro2 to the latest version.

proc_macro2 1.0.59 Fails to build with Rust nightly-2023-06-28+, but succeeds building on Rust nightly-2023-06-27.

https://github.com/rust-lang/rust/issues/113152

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Other

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
