### PR TITLE
fix: Fix deadkey sequences ending with space

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -67,7 +67,7 @@ impl KeyboardManager {
     }
 
     fn format_key(&self, key_event: &KeyEvent) -> Option<String> {
-        if let Some(text) = get_special_key(&key_event.logical_key) {
+        if let Some(text) = get_special_key(key_event) {
             Some(self.format_key_text(text, true))
         } else {
             self.format_normal_key(key_event)
@@ -154,10 +154,19 @@ fn use_alt() -> bool {
     settings.macos_alt_is_meta
 }
 
-fn get_special_key(key: &Key) -> Option<&str> {
+fn get_special_key(key_event: &KeyEvent) -> Option<&str> {
+    let key = &key_event.logical_key;
     match key {
         Key::Backspace => Some("BS"),
-        Key::Space => Some("Space"),
+        Key::Space => {
+            // Space can finish a dead key sequence, so only threat space as a special key when
+            // that doesn't happen.
+            if key_event.text == Some(" ".into()) {
+                Some("Space")
+            } else {
+                None
+            }
+        }
         Key::Escape => Some("Esc"),
         Key::Delete => Some("Del"),
         Key::ArrowUp => Some("Up"),

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -98,7 +98,7 @@ impl KeyboardManager {
 
     fn format_key_text(&self, text: &str, is_special: bool) -> String {
         let modifiers = self.format_modifier_string(is_special);
-        // < needs to be formatted as a special character, but note that it's not threated as a
+        // < needs to be formatted as a special character, but note that it's not treated as a
         // special key for the modifier formatting, so S- and -M are still potentially stripped
         let (text, is_special) = if text == "<" {
             ("lt", true)
@@ -159,7 +159,7 @@ fn get_special_key(key_event: &KeyEvent) -> Option<&str> {
     match key {
         Key::Backspace => Some("BS"),
         Key::Space => {
-            // Space can finish a dead key sequence, so only threat space as a special key when
+            // Space can finish a dead key sequence, so treat space as a special key only when
             // that doesn't happen.
             if key_event.text == Some(" ".into()) {
                 Some("Space")


### PR DESCRIPTION

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

A dead key followed by space will usually result in the character itself. However, Neovide resolved this wrongly, and always treated space as a special key, so the sequence was resolved as space instead.

## Did this PR introduce a breaking change? 
- No
