### PR TITLE
Fix broken link - Change Arch repository to extra

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -90,7 +90,7 @@ brew install --cask neovide
 ### Arch Linux
 
 Stable releases are
-[packaged in the community repository](https://archlinux.org/packages/community/x86_64/neovide).
+[packaged in the extra repository](https://archlinux.org/packages/extra/x86_64/neovide).
 
 ```sh
 pacman -S neovide


### PR DESCRIPTION
In the recent [git migration](https://archlinux.org/news/git-migration-completed/), Arch has merged the "community" repository into "extra". This PR is just to update the name and link in the install steps :) 

## What kind of change does this PR introduce?
Documentation

## Did this PR introduce a breaking change? 
No
