### PR TITLE
feat: Add ime preedit text support

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -76,6 +76,7 @@ pub enum DrawCommand {
     LineSpaceChanged(i64),
     DefaultStyleChanged(Style),
     ModeChanged(EditorMode),
+    IMEPreeditChanged(String, Option<(usize, usize)>),
 }
 
 pub struct Renderer {
@@ -278,6 +279,9 @@ impl Renderer {
             }
             DrawCommand::UpdateCursor(new_cursor) => {
                 self.cursor_renderer.update_cursor(new_cursor);
+            }
+            DrawCommand::IMEPreeditChanged(text, size) => {
+                self.cursor_renderer.update_ime_preedit(text, size);
             }
             DrawCommand::FontChanged(new_font) => {
                 self.grid_renderer.update_font(&new_font);

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -1,6 +1,7 @@
 use crate::{
     bridge::{SerialCommand, UiCommand},
     event_aggregator::EVENT_AGGREGATOR,
+    renderer::DrawCommand,
 };
 #[cfg(target_os = "macos")]
 use crate::{settings::SETTINGS, window::KeyboardSettings};
@@ -53,7 +54,14 @@ impl KeyboardManager {
             Event::WindowEvent {
                 event: WindowEvent::Ime(Ime::Preedit(text, cursor_offset)),
                 ..
-            } => self.ime_preedit = (text.to_string(), *cursor_offset),
+            } => {
+                self.ime_preedit = (text.to_string(), *cursor_offset);
+                log::trace!("Ime preedit {text}");
+                EVENT_AGGREGATOR.send(vec![DrawCommand::IMEPreeditChanged(
+                    text.to_string(),
+                    *cursor_offset,
+                )]);
+            }
             Event::WindowEvent {
                 event: WindowEvent::ModifiersChanged(modifiers),
                 ..

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -50,6 +50,7 @@ pub enum WindowCommand {
     TitleChanged(String),
     SetMouseEnabled(bool),
     ListAvailableFonts,
+    UpdateIMEPosition(f32, f32),
 }
 
 pub fn create_window() {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -184,6 +184,13 @@ impl WinitWindowWrapper {
                     self.mouse_manager.enabled = mouse_enabled
                 }
                 WindowCommand::ListAvailableFonts => self.send_font_names(),
+                WindowCommand::UpdateIMEPosition(x, y) => {
+                    let window = self.windowed_context.window();
+                    window.set_ime_cursor_area(
+                        PhysicalPosition::new(x, y),
+                        PhysicalSize::new(100, 100),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Since some neovim gui (e.g. Neovim qt) support ime support, including ime preedit text display, and candidate window in correct position.
![image](https://github.com/neovide/neovide/assets/20034116/29ae5335-b6ba-4329-9f6b-03a9ec692327)

This pull request introduce such support to neovide.
![image](https://github.com/neovide/neovide/assets/20034116/55bbc05e-2faa-441e-89f2-82b94d036f17)

The approach is to send event from `keyboard_manager` to renderer and add additional text rendered in `cursor_renderer`.

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

