### PR TITLE
macOS configuration options for using only the left or right alt key …

### DIFF
--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -53,6 +53,8 @@ impl Default for WindowSettings {
 #[setting_prefix = "input"]
 pub struct KeyboardSettings {
     pub macos_alt_is_meta: bool,
+    pub macos_left_alt_is_meta: bool,
+    pub macos_right_alt_is_meta: bool,
     pub ime: bool,
 }
 
@@ -61,6 +63,8 @@ impl Default for KeyboardSettings {
     fn default() -> Self {
         Self {
             macos_alt_is_meta: false,
+            macos_left_alt_is_meta: false,
+            macos_right_alt_is_meta: false,
             ime: true,
         }
     }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -438,6 +438,30 @@ Lua:
 vim.g.neovide_input_macos_alt_is_meta = false
 ```
 
+It is also possible to only use the left or right alt key as meta:
+
+VimScript:
+
+```vim
+" macos_alt_is_meta must be set to false for this to work
+let g:neovide_input_macos_alt_is_meta = v:false
+
+let g:neovide_input_macos_left_alt_is_meta = v:true
+" or
+let g:neovide_input_macos_right_alt_is_meta = v:true
+```
+
+Lua:
+
+```lua
+-- macos_alt_is_meta must be set to false for this to work
+vim.g.neovide_input_macos_alt_is_meta = false
+
+vim.g.neovide_input_macos_left_alt_is_meta = true
+-- or
+vim.g.neovide_input_macos_right_alt_is_meta = true
+```
+
 **Available since 0.10.**
 
 Interprets <kbd>Alt</kbd> + <kbd>whatever</kbd> actually as `<M-whatever>`, instead of sending the


### PR DESCRIPTION
…as meta

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

I'm using the [EurKEY Keyboard Layout](https://eurkey.steffen.bruentjen.eu/?lang=en). To access certain characters (e.g. ä, ö, ü, ß) I need the alt key. But I also need the alt key as meta key for certain terminal applications. 
I configured the right alt key in my terminal program to switch the characters in the EurKEY-Layout and the left alt key is used as meta key. I created a patch for neovide to allow the separate configuration of the right and the left alt key (branch: macos-left-right-alt-meta).

## Did this PR introduce a breaking change? 
- No
