### PR TITLE
feat: Show intro message

### DIFF
--- a/lua/intro.lua
+++ b/lua/intro.lua
@@ -43,6 +43,7 @@ local function show_intro()
 
     -- Show the sponsor and register message one out of four times, the Uganda
     -- message two out of four times.
+    math.randomseed(os.time())
     local help_type = math.random(4)
     if help_type <= 2 then
         vim.list_extend(lines, help_messages[help_type])

--- a/lua/intro.lua
+++ b/lua/intro.lua
@@ -1,0 +1,149 @@
+local function show_intro()
+    -- Don't show the intro if a buffer is loaded
+    if vim.api.nvim_buf_line_count(0) > 1 or vim.api.nvim_buf_get_name(0) ~= "" then
+        return
+    end
+
+    -- Create a new unlisted buffer
+    local buf = vim.api.nvim_create_buf(false, true)
+    local version_string = vim.api.nvim_exec2("version", { output = true }).output
+    -- we only need the first line of the version
+    version_string = version_string:sub(2, version_string:find("\n", 2) - 1)
+    local version = vim.version()
+
+    local lines = {
+        version_string,
+        "",
+        "Nvim is open source and freely distributable",
+        "https://neovim.io/#chat",
+        "",
+        "type  :help nvim<Enter>       if you are new! ",
+        "type  :checkhealth<Enter>     to optimize Nvim",
+        "type  :q<Enter>               to exit         ",
+        "type  :help<Enter>            for help        ",
+        "",
+        string.format("type  :help news<Enter> to see changes in v%d.%d", version.major, version.minor),
+        "",
+    }
+
+    local help_messages = {
+        {
+            "Sponsor Vim development!",
+            "type  :help sponsor<Enter>    for information ",
+        },
+        {
+            "Become a registered Vim user!",
+            "type  :help register<Enter>   for information ",
+        },
+        {
+            "Help poor children in Uganda!",
+            "type  :help iccf<Enter>       for information ",
+        },
+    }
+
+    -- Show the sponsor and register message one out of four times, the Uganda
+    -- message two out of four times.
+    local help_type = math.random(4)
+    if help_type <= 2 then
+        vim.list_extend(lines, help_messages[help_type])
+    else
+        vim.list_extend(lines, help_messages[3])
+    end
+
+    local longest_line = 0
+    for i, line in ipairs(lines) do
+        if line:len() > 0 then
+            -- translate
+            line = vim.fn.gettext(line)
+        end
+        longest_line = math.max(longest_line, line:len())
+        lines[i] = line
+    end
+
+    -- add padding to the lines
+    for i, line in ipairs(lines) do
+        local padding = math.floor((longest_line - line:len()) / 2) + 1
+        lines[i] = string.rep(" ", padding) .. line
+    end
+
+    -- add highlight to the special keys
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    for i, line in ipairs(lines) do
+        local s, e = line:find("<.*>")
+        if s ~= nil then
+            vim.api.nvim_buf_add_highlight(buf, -1, "SpecialKey", i - 1, s - 1, e)
+        end
+    end
+
+    local width = longest_line + 2
+    local height = #lines
+
+    local function get_config()
+        return {
+            relative = "editor",
+            width = width,
+            height = height,
+            col = math.max(0, math.ceil((vim.o.columns - width) / 2)),
+            row = math.max(0, math.ceil((vim.o.lines - height) / 2)),
+            style = "minimal",
+            border = "none"
+        }
+    end
+
+    local win = vim.api.nvim_open_win(buf, false, get_config())
+    vim.api.nvim_win_set_option(win, "winhighlight", "NormalFloat:Normal")
+
+    local win_autogroup = vim.api.nvim_create_augroup("neovide_intro_win", { clear = true })
+
+    local function close()
+        vim.api.nvim_del_augroup_by_id(win_autogroup)
+        if vim.api.nvim_buf_is_valid(buf) then
+            vim.api.nvim_buf_delete(buf, { force = true })
+        end
+        if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+        end
+    end
+
+    vim.api.nvim_create_autocmd({ "VimResized" }, {
+        pattern = "*",
+        group = win_autogroup,
+        callback = function()
+            vim.api.nvim_win_set_config(win, get_config())
+        end
+    })
+
+    local first_cursor_move = false
+
+    vim.api.nvim_create_autocmd(
+        {
+            "BufEnter",
+            "ModeChanged",
+            "CursorMoved", "CursorMovedI",
+            "TextChanged", "TextChangedI", "TextChangedP", "TextChangedT"
+        },
+        {
+            pattern = "*",
+            group = win_autogroup,
+            callback = function(param)
+                -- Allow changing from and to command mode
+                if param.event == "ModeChanged" and param.match:find("c") ~= nil then
+                    return
+                end
+                -- The first cursor move is ignored, since it happens after the message is shown
+                if not first_cursor_move and param.event == "CursorMoved" then
+                    first_cursor_move = true
+                    return
+                end
+                close()
+            end
+        })
+end
+
+
+local autogroup = vim.api.nvim_create_augroup("neovide_intro", { clear = true })
+vim.api.nvim_create_autocmd({ "VimEnter" }, {
+    pattern = "*",
+    group = autogroup,
+    callback = show_intro
+})

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -30,7 +30,7 @@ const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
         cache_enabled = 0
     }";
 
-const INTRO_MESSAGE: &str = include_str!("../../lua/intro.lua");
+const INTRO_MESSAGE_LUA: &str = include_str!("../../lua/intro.lua");
 
 pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<NeovimWriter>, neovide_channel: u64) {
     // Users can opt-out with
@@ -147,7 +147,7 @@ pub async fn setup_neovide_specific_state(
         .await
         .ok();
 
-    nvim.exec_lua(INTRO_MESSAGE, Vec::new()).await.ok();
+    nvim.exec_lua(INTRO_MESSAGE_LUA, Vec::new()).await.ok();
 }
 
 #[cfg(windows)]

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -30,6 +30,8 @@ const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
         cache_enabled = 0
     }";
 
+const INTRO_MESSAGE: &str = include_str!("../../lua/intro.lua");
+
 pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<NeovimWriter>, neovide_channel: u64) {
     // Users can opt-out with
     // vim: `let g:neovide_no_custom_clipboard = v:true`
@@ -144,6 +146,8 @@ pub async fn setup_neovide_specific_state(
     nvim.command("autocmd VimLeave * call rpcnotify(1, 'neovide.quit', v:exiting)")
         .await
         .ok();
+
+    nvim.exec_lua(INTRO_MESSAGE, Vec::new()).await.ok();
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce

This emulates the standard Neovim `:intro` message at startup. It's shown if the current buffer is empty and not backed by a file. The message is always centered and does not close when the window is resized, unlike the standard message. Another difference is that this message closes directly on any mode chance except changes from/to cmd mode, while the standard message stays visible if you go into insert mode, until you type something.  

NOTE: That this is not a maintainable solution, so the goal is to get this or something similar implemented in Neovim itself, but for now I think this is good enough for us.

Fixes: https://github.com/neovide/neovide/issues/620

For the corresponding Neovim issue see https://github.com/neovim/neovim/issues/24705

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
