### PR TITLE
fix: Show intro message when the ui command msg_intro is received

### DIFF
--- a/lua/intro.lua
+++ b/lua/intro.lua
@@ -147,6 +147,7 @@ local function setup_autocommand()
     vim.api.nvim_create_autocmd({ "VimEnter" }, {
         pattern = "*",
         group = autogroup,
+        once = true,
         callback = function()
             -- Don't show when disabled
             if vim.o.shortmess:find("I") then

--- a/lua/intro.lua
+++ b/lua/intro.lua
@@ -1,56 +1,6 @@
-local function show_intro()
-    -- Don't show the intro if a buffer is loaded
-    if vim.api.nvim_buf_line_count(0) > 1 or vim.api.nvim_buf_get_name(0) ~= "" then
-        return
-    end
-
+local function show_intro(lines)
     -- Create a new unlisted buffer
     local buf = vim.api.nvim_create_buf(false, true)
-    local version_string = vim.api.nvim_exec2("version", { output = true }).output
-    -- we only need the first line of the version
-    version_string = version_string:sub(2, version_string:find("\n", 2) - 1)
-    local version = vim.version()
-
-    local lines = {
-        version_string,
-        "",
-        "Nvim is open source and freely distributable",
-        "https://neovim.io/#chat",
-        "",
-        "type  :help nvim<Enter>       if you are new! ",
-        "type  :checkhealth<Enter>     to optimize Nvim",
-        "type  :q<Enter>               to exit         ",
-        "type  :help<Enter>            for help        ",
-        "",
-        string.format("type  :help news<Enter> to see changes in v%d.%d", version.major, version.minor),
-        "",
-    }
-
-    local help_messages = {
-        {
-            "Sponsor Vim development!",
-            "type  :help sponsor<Enter>    for information ",
-        },
-        {
-            "Become a registered Vim user!",
-            "type  :help register<Enter>   for information ",
-        },
-        {
-            "Help poor children in Uganda!",
-            "type  :help iccf<Enter>       for information ",
-        },
-    }
-
-    -- Show the sponsor and register message one out of four times, the Uganda
-    -- message two out of four times.
-    math.randomseed(os.time())
-    local help_type = math.random(4)
-    if help_type <= 2 then
-        vim.list_extend(lines, help_messages[help_type])
-    else
-        vim.list_extend(lines, help_messages[3])
-    end
-
     local longest_line = 0
     for i, line in ipairs(lines) do
         if line:len() > 0 then
@@ -141,10 +91,90 @@ local function show_intro()
         })
 end
 
+-- Only used for Nvim 0.9.2, nvim sends the message on newer versions
+local function get_intro_lines()
+    local version_string = vim.api.nvim_exec2("version", { output = true }).output
+    -- we only need the first line of the version
+    version_string = version_string:sub(2, version_string:find("\n", 2) - 1)
+    local version = vim.version()
 
-local autogroup = vim.api.nvim_create_augroup("neovide_intro", { clear = true })
-vim.api.nvim_create_autocmd({ "VimEnter" }, {
-    pattern = "*",
-    group = autogroup,
-    callback = show_intro
-})
+    local lines = {
+        version_string,
+        "",
+        "Nvim is open source and freely distributable",
+        "https://neovim.io/#chat",
+        "",
+        "type  :help nvim<Enter>       if you are new! ",
+        "type  :checkhealth<Enter>     to optimize Nvim",
+        "type  :q<Enter>               to exit         ",
+        "type  :help<Enter>            for help        ",
+        "",
+        string.format("type  :help news<Enter> to see changes in v%d.%d", version.major, version.minor),
+        "",
+    }
+
+    local help_messages = {
+        {
+            "Sponsor Vim development!",
+            "type  :help sponsor<Enter>    for information ",
+        },
+        {
+            "Become a registered Vim user!",
+            "type  :help register<Enter>   for information ",
+        },
+        {
+            "Help poor children in Uganda!",
+            "type  :help iccf<Enter>       for information ",
+        },
+    }
+
+    -- Show the sponsor and register message one out of four times, the Uganda
+    -- message two out of four times.
+    -- Use Vim rather tha lua  for rand to avoid polluting the random seed
+    local seed = vim.fn.srand()
+    local help_type = (vim.fn.rand(seed) % 4) + 1
+    if help_type <= 2 then
+        vim.list_extend(lines, help_messages[help_type])
+    else
+        vim.list_extend(lines, help_messages[3])
+    end
+    return lines
+end
+
+
+local function setup_autocommand()
+    local autogroup = vim.api.nvim_create_augroup("neovide_intro", { clear = true })
+    vim.api.nvim_create_autocmd({ "VimEnter" }, {
+        pattern = "*",
+        group = autogroup,
+        callback = function()
+            -- Don't show when disabled
+            if vim.o.shortmess:find("I") then
+                return
+            end
+
+            -- Don't show the intro if a buffer is loaded
+            if vim.api.nvim_buf_line_count(0) > 1 or vim.api.nvim_buf_get_name(0) ~= "" then
+                return
+            end
+
+            show_intro(get_intro_lines())
+        end
+    })
+end
+
+
+local function entry(function_name, ...)
+    local nvim_version = vim.version()
+    local has_show_intro = vim.version.gt(nvim_version, vim.version.parse("0.9.1", nil))
+
+    if has_show_intro then
+        if function_name == "show_intro" then
+            show_intro({...})
+        end
+    elseif function_name == "setup_autocommand" then
+        setup_autocommand()
+    end
+end
+
+entry(...)

--- a/lua/intro.lua
+++ b/lua/intro.lua
@@ -166,10 +166,12 @@ end
 
 
 local function entry(function_name, ...)
-    local nvim_version = vim.version()
-    local has_show_intro = vim.version.gt(nvim_version, vim.version.parse("0.9.1", nil))
+    local api_metadata = vim.fn.api_info()
+    local has_msg_intro = vim.tbl_contains(api_metadata.ui_events, function(v)
+        return v.name == "msg_intro"
+    end, { predicate = true })
 
-    if has_show_intro then
+    if has_msg_intro then
         if function_name == "show_intro" then
             show_intro({...})
         end

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -275,6 +275,9 @@ pub enum RedrawEvent {
     MessageHistoryShow {
         entries: Vec<(MessageKind, StyledContent)>,
     },
+    ShowIntro {
+        message: Vec<String>,
+    },
 }
 
 fn unpack_color(packed_color: u64) -> Color4f {
@@ -823,6 +826,17 @@ fn parse_msg_history_show(msg_history_show_arguments: Vec<Value>) -> Result<Redr
     })
 }
 
+fn parse_msg_intro(msg_intro_arguments: Vec<Value>) -> Result<RedrawEvent> {
+    let [lines] = extract_values(msg_intro_arguments)?;
+
+    Ok(RedrawEvent::ShowIntro {
+        message: parse_array(lines)?
+            .into_iter()
+            .map(parse_string)
+            .collect::<Result<_>>()?,
+    })
+}
+
 pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
     let mut event_contents = parse_array(event_value)?.into_iter();
     let event_name = event_contents
@@ -875,6 +889,7 @@ pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
             "msg_showcmd" => Some(parse_msg_showcmd(event_parameters)),
             "msg_ruler" => Some(parse_msg_ruler(event_parameters)),
             "msg_history_show" => Some(parse_msg_history_show(event_parameters)),
+            "msg_intro" => Some(parse_msg_intro(event_parameters)),
             _ => None,
         };
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -9,7 +9,7 @@ mod ui_commands;
 use std::{process::exit, sync::Arc, thread};
 
 use log::{error, info};
-use nvim_rs::UiAttachOptions;
+use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
 
 use crate::{
     cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation, running_tracker::*,
@@ -23,6 +23,8 @@ pub use session::NeovimWriter;
 use session::{NeovimInstance, NeovimSession};
 use setup::setup_neovide_specific_state;
 pub use ui_commands::{start_ui_command_handler, ParallelCommand, SerialCommand, UiCommand};
+
+const INTRO_MESSAGE_LUA: &str = include_str!("../../lua/intro.lua");
 
 fn neovim_instance() -> NeovimInstance {
     if let Some(address) = SETTINGS.get::<CmdLineSettings>().server {
@@ -38,6 +40,23 @@ pub fn start_bridge() {
     thread::spawn(|| {
         start_neovim_runtime(instance);
     });
+}
+
+pub async fn setup_intro_message_autocommand(
+    nvim: &Neovim<NeovimWriter>,
+) -> Result<Value, Box<CallError>> {
+    let args = vec![Value::from("setup_autocommand")];
+    nvim.exec_lua(INTRO_MESSAGE_LUA, args).await
+}
+
+pub async fn show_intro_message(
+    nvim: &Neovim<NeovimWriter>,
+    message: &[String],
+) -> Result<Value, Box<CallError>> {
+    let mut args = vec![Value::from("show_intro")];
+    let lines = message.iter().map(|line| Value::from(line.as_str()));
+    args.extend(lines);
+    nvim.exec_lua(INTRO_MESSAGE_LUA, args).await
 }
 
 #[tokio::main]

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -2,6 +2,7 @@ use log::{info, warn};
 use nvim_rs::Neovim;
 use rmpv::Value;
 
+use super::setup_intro_message_autocommand;
 use crate::{bridge::NeovimWriter, error_handling::ResultPanicExplanation};
 
 const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
@@ -29,8 +30,6 @@ const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
         },
         cache_enabled = 0
     }";
-
-const INTRO_MESSAGE_LUA: &str = include_str!("../../lua/intro.lua");
 
 pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<NeovimWriter>, neovide_channel: u64) {
     // Users can opt-out with
@@ -147,7 +146,7 @@ pub async fn setup_neovide_specific_state(
         .await
         .ok();
 
-    nvim.exec_lua(INTRO_MESSAGE_LUA, Vec::new()).await.ok();
+    setup_intro_message_autocommand(nvim).await.ok();
 }
 
 #[cfg(windows)]

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -11,6 +11,8 @@ use tokio::sync::mpsc::unbounded_channel;
 use crate::windows_utils::{
     register_rightclick_directory, register_rightclick_file, unregister_rightclick,
 };
+
+use super::show_intro_message;
 use crate::{
     bridge::NeovimWriter, event_aggregator::EVENT_AGGREGATOR, running_tracker::RUNNING_TRACKER,
 };
@@ -122,6 +124,9 @@ pub enum ParallelCommand {
     RegisterRightClick,
     #[cfg(windows)]
     UnregisterRightClick,
+    ShowIntro {
+        message: Vec<String>,
+    },
 }
 
 impl ParallelCommand {
@@ -224,6 +229,9 @@ impl ParallelCommand {
                     nvim.err_writeln(msg).await.ok();
                     error!("{}", msg);
                 }
+            }
+            ParallelCommand::ShowIntro { message } => {
+                show_intro_message(nvim, &message).await.ok();
             }
         }
     }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, sync::Arc, thread};
 use log::{error, trace};
 
 use crate::{
-    bridge::{GuiOption, RedrawEvent, WindowAnchor},
+    bridge::{GuiOption, ParallelCommand, RedrawEvent, UiCommand, WindowAnchor},
     event_aggregator::EVENT_AGGREGATOR,
     profiling::tracy_zone,
     redraw_scheduler::REDRAW_SCHEDULER,
@@ -261,6 +261,10 @@ impl Editor {
                 } => {
                     tracy_zone!("EditorWindowViewport");
                     self.send_updated_viewport(grid, scroll_delta)
+                }
+                RedrawEvent::ShowIntro { message } => {
+                    EVENT_AGGREGATOR
+                        .send(UiCommand::Parallel(ParallelCommand::ShowIntro { message }));
                 }
                 _ => {}
             },


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

`msg_intro` is now used to show the intro message, when it's available. That will happen once this Neovim PR is merged and released https://github.com/neovim/neovim/pull/24764. Otherwise the message text it built manually like before, and showed using `VimEnter`

In addition to this it fixes these two issues
* The `shortmess`+=I` option now works
* The message now closes properly when using `dashboard-nvim`. And most likely in some other situations that did not work previously. The issue was that the lazy loading of `packer.nvim` (and maybe lazy.nvim) with `event=VimEnter` causes `VimEnter`to be called twice.

It also changes the use of lua random to VIM random to avoid polluting the global lua random seed.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No