### PR TITLE
fix: Add missing Enter special key

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -158,22 +158,15 @@ fn use_alt() -> bool {
 fn get_special_key(key_event: &KeyEvent) -> Option<&str> {
     let key = &key_event.logical_key;
     match key {
-        Key::Backspace => Some("BS"),
-        Key::Space => {
-            // Space can finish a dead key sequence, so treat space as a special key only when
-            // that doesn't happen.
-            if key_event.text == Some(" ".into()) {
-                Some("Space")
-            } else {
-                None
-            }
-        }
-        Key::Escape => Some("Esc"),
-        Key::Delete => Some("Del"),
-        Key::ArrowUp => Some("Up"),
         Key::ArrowDown => Some("Down"),
         Key::ArrowLeft => Some("Left"),
         Key::ArrowRight => Some("Right"),
+        Key::ArrowUp => Some("Up"),
+        Key::Backspace => Some("BS"),
+        Key::Delete => Some("Del"),
+        Key::End => Some("End"),
+        Key::Enter => Some("Enter"),
+        Key::Escape => Some("Esc"),
         Key::F1 => Some("F1"),
         Key::F2 => Some("F2"),
         Key::F3 => Some("F3"),
@@ -209,11 +202,19 @@ fn get_special_key(key_event: &KeyEvent) -> Option<&str> {
         Key::F33 => Some("F33"),
         Key::F34 => Some("F34"),
         Key::F35 => Some("F35"),
-        Key::Insert => Some("Insert"),
         Key::Home => Some("Home"),
-        Key::End => Some("End"),
-        Key::PageUp => Some("PageUp"),
+        Key::Insert => Some("Insert"),
         Key::PageDown => Some("PageDown"),
+        Key::PageUp => Some("PageUp"),
+        Key::Space => {
+            // Space can finish a dead key sequence, so treat space as a special key only when
+            // that doesn't happen.
+            if key_event.text == Some(" ".into()) {
+                Some("Space")
+            } else {
+                None
+            }
+        }
         Key::Tab => Some("Tab"),
         _ => None,
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This fixes the shift+enter key combination, enter was missing from the list of special keys. 

Additionally, the keys are now sorted alphabetically.

Fixes https://github.com/neovide/neovide/issues/1996

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
