### PR TITLE
fix: Fix disappearing characters on Neovim 0.9.2 and greater

### DIFF
--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -130,6 +130,11 @@ impl Window {
         // Compute text.
         let mut text = cell.text;
         if let Some(times) = cell.repeat {
+            // Repeats of zero times should be ignored, they are mostly useful for terminal Neovim
+            // to distinguish between empty lines and lines ending with spaces.
+            if times == 0 {
+                return;
+            }
             text = text.repeat(times as usize);
         }
 


### PR DESCRIPTION

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?

This fixes the problem with some characters disappearing when using Neovim 0.9.2 and greater. See https://github.com/neovim/neovim/issues/25011

Repeats of zero times should be ignored, they are mostly useful for terminal Neovim to distinguish between empty lines and lines ending with spaces.

## Did this PR introduce a breaking change? 
- No
