### PR TITLE
fix: Fix some mappings involving shift

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -135,16 +135,16 @@ impl KeyboardManager {
         // In all other cases the resulting character is enough.
         // Note that, in Neovim <C-a> and <C-A> are the same, but <C-S-A> is different.
         // Actually, <C-S-a> is the same as <C-S-A>, since Neovim converts all shifted
-        // lowercase alphas to uppercase internally in its mapppings.
+        // lowercase alphas to uppercase internally in its mappings.
         // Also note that mappings that do not include CTRL work differently, they are always
         // normalized in combination with ascii alphas. For example <M-S-a> is normalized to
         // uppercase without shift, or <M-A> .
-        // But in combination with ohter characters, such as <M-S-$> they are not,
+        // But in combination with other characters, such as <M-S-$> they are not,
         // so we don't want to send shift when that's the case.
         let include_shift =
             is_special || (self.modifiers.state().control_key() && is_ascii_alphabetic_char(text));
 
-        // Always send meta (alt) togehter with special keys, or when alt is meta on macOS
+        // Always send meta (alt) together with special keys, or when alt is meta on macOS
         let include_alt = use_alt() || is_special;
 
         let state = self.modifiers.state();

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -178,7 +178,7 @@ impl MouseManager {
                     button: self.dragging.as_ref().unwrap().to_owned(),
                     grid_id: relevant_window_details.id,
                     position: self.drag_position.into(),
-                    modifier_string: keyboard_manager.format_modifier_string(true),
+                    modifier_string: keyboard_manager.format_modifier_string("", true),
                 }));
             } else {
                 // otherwise, update the window_id_under_mouse to match the one selected
@@ -191,7 +191,7 @@ impl MouseManager {
                     action: "".into(), // this is ignored by nvim
                     grid_id: relevant_window_details.id,
                     position: self.relative_position.into(),
-                    modifier_string: keyboard_manager.format_modifier_string(true),
+                    modifier_string: keyboard_manager.format_modifier_string("", true),
                 }))
             }
 
@@ -228,7 +228,7 @@ impl MouseManager {
                         action,
                         grid_id: details.id,
                         position: position.into(),
-                        modifier_string: keyboard_manager.format_modifier_string(true),
+                        modifier_string: keyboard_manager.format_modifier_string("", true),
                     }));
                 }
 
@@ -269,7 +269,7 @@ impl MouseManager {
                     .map(|details| details.id)
                     .unwrap_or(0),
                 position: self.drag_position.into(),
-                modifier_string: keyboard_manager.format_modifier_string(true),
+                modifier_string: keyboard_manager.format_modifier_string("", true),
             }
             .into();
             for _ in 0..(new_y - previous_y).abs() {
@@ -296,7 +296,7 @@ impl MouseManager {
                     .map(|details| details.id)
                     .unwrap_or(0),
                 position: self.drag_position.into(),
-                modifier_string: keyboard_manager.format_modifier_string(true),
+                modifier_string: keyboard_manager.format_modifier_string("", true),
             }
             .into();
             for _ in 0..(new_x - previous_x).abs() {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

**NOTE:** this needs careful testing before merging, so that something else does not break,

## What kind of change does this PR introduce?

This fixes https://github.com/neovide/neovide/issues/2017  - "can't map `<c-s-v>`". This is done by sending shfit when it's combined with CTRL and an ascii alpha character. See the corresponding logic here https://github.com/neovim/neovim/blob/c422722b2e94b94d7f9374dbae12f17580cd1d41/src/nvim/keycodes.c#L764-L799 

It also partially fixes the following issue https://github.com/neovide/neovide/issues/1237 - "CMD + SHIFT works as CMD only". Partially because it's likely not dealing with all the cases. The real issue is in Winit. The fix is to normalize shifted asicii alpha characters already on the Neovide side. This is always done one the Neovim side anyway, so it should be a safe thing to do. 

Note that only the following form of mapping work: `<D-A>`.  There appears to be a bug in Neovim https://github.com/neovim/neovim/issues/25068, preventing the alternative forms `<D-S-A>` and `<D-S-a>` from working, but once that's fixed all forms should work. The `<D-A>` form was chosen because that's the most basic form, for example `<M-S-a>` also simplifies down to `<M-A>` in Neovide, so it's consistent with that. Furthermore, this format of mapping will work, even after the Winit bug https://github.com/rust-windowing/winit/issues/3078 is fixed.

The same non `<S->` form should also always be use for non-alpha mappings for all modifiers. The only special case is CTRL + SHIFT + alpha, which should be mapped like `<C-S-A>` due to legacy reasons.
From https://neovim.io/doc/user/intro.html (the notation section)

> CTRL-{char} {char} typed as a control character; that is, typing {char}
while holding the CTRL key down. The case of {char} is
ignored; thus CTRL-A and CTRL-a are equivalent. But in
some terminals and environments, using the SHIFT key will
produce a distinct code (e.g. CTRL-SHIFT-a); in these
environments using the SHIFT key will not trigger commands
such as CTRL-A

## Did this PR introduce a breaking change? 
No