### PR TITLE
fix: Improve windows creation and sizing

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -96,6 +96,9 @@ impl Handler for NeovimHandler {
                     EVENT_AGGREGATOR.send(WindowCommand::Lines(lines));
                 }
             }
+            "neovide.ui_ready" => {
+                EVENT_AGGREGATOR.send(WindowCommand::UIReady);
+            }
             #[cfg(windows)]
             "neovide.register_right_click" => {
                 EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::RegisterRightClick));

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -13,6 +13,7 @@ use crate::{
     event_aggregator::EVENT_AGGREGATOR,
     running_tracker::*,
     settings::SETTINGS,
+    window::WindowCommand,
 };
 
 #[derive(Clone)]
@@ -84,6 +85,16 @@ impl Handler for NeovimHandler {
                     .as_i64()
                     .expect("Could not parse error code from neovim");
                 RUNNING_TRACKER.quit_with_code(error_code as i32, "Quit from neovim");
+            }
+            "neovide.columns" => {
+                if let Some(columns) = arguments[0].as_u64() {
+                    EVENT_AGGREGATOR.send(WindowCommand::Columns(columns));
+                }
+            }
+            "neovide.lines" => {
+                if let Some(lines) = arguments[0].as_u64() {
+                    EVENT_AGGREGATOR.send(WindowCommand::Lines(lines));
+                }
             }
             #[cfg(windows)]
             "neovide.register_right_click" => {

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -12,8 +12,8 @@ use log::{error, info};
 use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
 
 use crate::{
-    cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation, running_tracker::*,
-    settings::*,
+    cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation,
+    event_aggregator::EVENT_AGGREGATOR, running_tracker::*, settings::*, window::WindowCommand,
 };
 
 pub use command::create_nvim_command;
@@ -100,6 +100,7 @@ async fn start_neovim_runtime(instance: NeovimInstance) {
         .unwrap_or_explained_panic("Could not attach ui to neovim process");
 
     info!("Neovim process attached");
+    EVENT_AGGREGATOR.send(WindowCommand::UIEnter);
 
     start_ui_command_handler(nvim.clone());
     SETTINGS.read_initial_values(&nvim).await;

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -3,7 +3,10 @@ use nvim_rs::Neovim;
 use rmpv::Value;
 
 use super::setup_intro_message_autocommand;
-use crate::{bridge::NeovimWriter, error_handling::ResultPanicExplanation};
+use crate::{
+    bridge::NeovimWriter, error_handling::ResultPanicExplanation, settings::SETTINGS,
+    CmdLineSettings,
+};
 
 const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
     local function set_clipboard(register)
@@ -156,6 +159,16 @@ pub async fn setup_neovide_specific_state(
     )
     .await
     .ok();
+
+    if let Some(geometry) = SETTINGS.get::<CmdLineSettings>().geometry {
+        let lines = geometry.height;
+        let columns = geometry.width;
+        nvim.command(&format!(
+            "autocmd VimEnter * ++once ++nested set lines={lines} | set columns={columns}"
+        ))
+        .await
+        .ok();
+    }
 
     setup_intro_message_autocommand(nvim).await.ok();
 }

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -62,7 +62,7 @@ const SETUP_GEOMETRY_LUA: &str = r"
         end
     })";
 
-pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<NeovimWriter>, neovide_channel: u64) {
+pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<NeovimWriter>) {
     // Users can opt-out with
     // vim: `let g:neovide_no_custom_clipboard = v:true`
     // lua: `vim.g.neovide_no_custom_clipboard = true`
@@ -76,9 +76,6 @@ pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<NeovimWriter>, neovide
         return;
     }
 
-    nvim.set_var("neovide_channel_id", Value::from(neovide_channel))
-        .await
-        .ok();
     nvim.execute_lua(REGISTER_CLIPBOARD_PROVIDER_LUA, vec![])
         .await
         .ok();
@@ -135,6 +132,10 @@ pub async fn setup_neovide_specific_state(
             neovide_channel
         );
 
+        nvim.set_var("neovide_channel_id", Value::from(neovide_channel))
+            .await
+            .ok();
+
         // Create a command for registering right click context hooking.
         #[cfg(windows)]
         nvim.command(&build_neovide_command(
@@ -158,7 +159,7 @@ pub async fn setup_neovide_specific_state(
         .ok();
 
         if should_handle_clipboard {
-            setup_neovide_remote_clipboard(nvim, neovide_channel).await;
+            setup_neovide_remote_clipboard(nvim).await;
         }
     } else {
         warn!("Neovide could not find the correct channel id. Some functionality may be disabled.");

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -162,17 +162,19 @@ pub async fn setup_neovide_specific_state(
         .ok();
 
     // Create auto command for retrieving exit code from neovim on quit.
-    nvim.command("autocmd VimLeave * call rpcnotify(1, 'neovide.quit', v:exiting)")
-        .await
-        .ok();
+    nvim.command(
+        "autocmd VimLeave * call rpcnotify(g:neovide_channel_id, 'neovide.quit', v:exiting)",
+    )
+    .await
+    .ok();
 
     nvim.command(
-        "autocmd OptionSet columns call rpcnotify(1, 'neovide.columns', str2nr(v:option_new))",
+        "autocmd OptionSet columns call rpcnotify(g:neovide_channel_id, 'neovide.columns', str2nr(v:option_new))",
     )
     .await
     .ok();
     nvim.command(
-        "autocmd OptionSet lines call rpcnotify(1, 'neovide.lines', str2nr(v:option_new))",
+        "autocmd OptionSet lines call rpcnotify(g:neovide_channel_id, 'neovide.lines', str2nr(v:option_new))",
     )
     .await
     .ok();

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -146,6 +146,17 @@ pub async fn setup_neovide_specific_state(
         .await
         .ok();
 
+    nvim.command(
+        "autocmd OptionSet columns call rpcnotify(1, 'neovide.columns', str2nr(v:option_new))",
+    )
+    .await
+    .ok();
+    nvim.command(
+        "autocmd OptionSet lines call rpcnotify(1, 'neovide.lines', str2nr(v:option_new))",
+    )
+    .await
+    .ok();
+
     setup_intro_message_autocommand(nvim).await.ok();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ use std::panic::{set_hook, PanicInfo};
 use std::time::SystemTime;
 use time::macros::format_description;
 use time::OffsetDateTime;
-use window::{create_window, KeyboardSettings, WindowSettings};
+use window::{create_event_loop, create_window, main_loop, KeyboardSettings, WindowSettings};
 
 pub use channel_utils::*;
 pub use event_aggregator::*;
@@ -175,8 +175,10 @@ fn protected_main() {
     start_editor();
     maybe_disown();
 
+    let event_loop = create_event_loop();
+    let window = create_window(&event_loop);
     // implicitly takes control over the thread
-    create_window();
+    main_loop(window, event_loop);
 }
 
 #[cfg(not(test))]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -35,7 +35,7 @@ pub use rendered_window::{
     LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails, WindowPadding,
 };
 
-pub use opengl::{build_context, build_window, Context as WindowedContext};
+pub use opengl::{build_context, build_window, Context as WindowedContext, GlWindow};
 pub use vsync::VSync;
 
 #[derive(SettingGroup, Clone)]

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -24,6 +24,11 @@ use winit::{
     window::{Window, WindowBuilder},
 };
 
+pub struct GlWindow {
+    pub window: Window,
+    config: Config,
+}
+
 pub struct Context {
     surface: Surface<WindowSurface>,
     context: PossiblyCurrentContext,
@@ -79,7 +84,7 @@ fn gen_config(mut config_iterator: Box<dyn Iterator<Item = Config> + '_>) -> Con
 pub fn build_window<TE>(
     winit_window_builder: WindowBuilder,
     event_loop: &EventLoop<TE>,
-) -> (Window, Config) {
+) -> GlWindow {
     let template_builder = ConfigTemplateBuilder::new()
         .with_stencil_size(8)
         .with_transparency(true);
@@ -87,14 +92,13 @@ pub fn build_window<TE>(
         .with_window_builder(Some(winit_window_builder))
         .build(event_loop, template_builder, gen_config)
         .expect("Failed to create Window");
-    (window.expect("Could not create Window"), config)
+    let window = window.expect("Could not create Window");
+    GlWindow { window, config }
 }
 
-pub fn build_context(
-    window: Window,
-    config: Config,
-    cmd_line_settings: &CmdLineSettings,
-) -> Context {
+pub fn build_context(window: GlWindow, cmd_line_settings: &CmdLineSettings) -> Context {
+    let config = window.config;
+    let window = window.window;
     let gl_display = config.display();
     let raw_window_handle = window.raw_window_handle();
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -366,7 +366,6 @@ impl RenderedWindow {
                 row,
                 line_fragments,
             } => {
-                log::trace!("Handling DrawLine {}", self.id);
                 tracy_zone!("draw_line_cmd", 0);
 
                 self.actual_lines[row] = Some(Arc::new(Mutex::new(Line {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -171,33 +171,29 @@ pub fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
     let window = &gl_window.window;
 
     // Check that window is visible in some monitor, and reposition it if not.
-    let did_reposition = window
-        .current_monitor()
-        .and_then(|current_monitor| {
-            let monitor_position = current_monitor.position();
-            let monitor_size = current_monitor.size();
-            let monitor_width = monitor_size.width as i32;
-            let monitor_height = monitor_size.height as i32;
+    window.current_monitor().and_then(|current_monitor| {
+        let monitor_position = current_monitor.position();
+        let monitor_size = current_monitor.size();
+        let monitor_width = monitor_size.width as i32;
+        let monitor_height = monitor_size.height as i32;
 
-            let window_position = previous_position.or_else(|| window.outer_position().ok())?;
+        let window_position = previous_position.or_else(|| window.outer_position().ok())?;
 
-            let window_size = window.outer_size();
-            let window_width = window_size.width as i32;
-            let window_height = window_size.height as i32;
+        let window_size = window.outer_size();
+        let window_width = window_size.width as i32;
+        let window_height = window_size.height as i32;
 
-            if window_position.x + window_width < monitor_position.x
-                || window_position.y + window_height < monitor_position.y
-                || window_position.x > monitor_position.x + monitor_width
-                || window_position.y > monitor_position.y + monitor_height
-            {
-                window.set_outer_position(monitor_position);
-            }
+        if window_position.x + window_width < monitor_position.x
+            || window_position.y + window_height < monitor_position.y
+            || window_position.x > monitor_position.x + monitor_width
+            || window_position.y > monitor_position.y + monitor_height
+        {
+            window.set_outer_position(monitor_position);
+        }
 
-            Some(())
-        })
-        .is_some();
+        Some(())
+    });
 
-    log::trace!("repositioned window: {}", did_reposition);
     gl_window
 }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -13,7 +13,7 @@ use std::env;
 
 use winit::{
     dpi::PhysicalSize,
-    event_loop::EventLoopBuilder,
+    event_loop::{EventLoop, EventLoopBuilder},
     window::{Icon, WindowBuilder},
 };
 
@@ -49,7 +49,7 @@ use window_wrapper::WinitWindowWrapper;
 use crate::{
     cmd_line::CmdLineSettings,
     frame::Frame,
-    renderer::build_window,
+    renderer::{build_window, GlWindow},
     running_tracker::*,
     settings::{load_last_window_settings, save_window_size, PersistentWindowSettings, SETTINGS},
 };
@@ -72,7 +72,11 @@ pub enum UserEvent {
     ScaleFactorChanged(f64),
 }
 
-pub fn create_window() {
+pub fn create_event_loop() -> EventLoop<UserEvent> {
+    EventLoopBuilder::<UserEvent>::with_user_event().build()
+}
+
+pub fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
     let icon = {
         let icon = load_from_memory(ICON).expect("Failed to parse icon data");
         let (width, height) = icon.dimensions();
@@ -82,8 +86,6 @@ pub fn create_window() {
         }
         Icon::from_rgba(rgba, width, height).expect("Failed to create icon object")
     };
-
-    let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
 
     let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
 
@@ -172,7 +174,8 @@ pub fn create_window() {
     #[cfg(target_os = "macos")]
     let winit_window_builder = winit_window_builder.with_accepts_first_mouse(false);
 
-    let (window, config) = build_window(winit_window_builder, &event_loop);
+    let gl_window = build_window(winit_window_builder, event_loop);
+    let window = &gl_window.window;
 
     // Check that window is visible in some monitor, and reposition it if not.
     let did_reposition = window
@@ -204,102 +207,105 @@ pub fn create_window() {
         .is_some();
 
     log::trace!("repositioned window: {}", did_reposition);
+    gl_window
+}
 
-    // Use a render thread on Windows to work around performance issues with Winit
-    // see: https://github.com/rust-windowing/winit/issues/2782
-    #[cfg(target_os = "windows")]
-    {
-        let (txtemp, rx) = channel::<Event<UserEvent>>();
-        let mut tx = Some(txtemp);
-        let mut render_thread_handle = Some(thread::spawn(move || {
-            let mut window_wrapper = WinitWindowWrapper::new(window, config, &cmd_line_settings);
-            let mut update_loop = UpdateLoop::new(
-                cmd_line_settings.vsync,
-                cmd_line_settings.idle,
-                &window_wrapper.windowed_context,
-            );
-            #[allow(unused_assignments)]
-            loop {
-                let (wait_duration, _) = update_loop.get_event_wait_time();
-                let event = if wait_duration.as_nanos() == 0 {
-                    rx.try_recv()
-                        .map_err(|e| matches!(e, TryRecvError::Disconnected))
-                } else {
-                    rx.recv_timeout(wait_duration)
-                        .map_err(|e| matches!(e, RecvTimeoutError::Disconnected))
-                };
+// Use a render thread on Windows to work around performance issues with Winit
+// see: https://github.com/rust-windowing/winit/issues/2782
+#[cfg(target_os = "windows")]
+pub fn main_loop(window: GlWindow, event_loop: EventLoop<UserEvent>) {
+    let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
+    let (txtemp, rx) = channel::<Event<UserEvent>>();
+    let mut tx = Some(txtemp);
+    let mut render_thread_handle = Some(thread::spawn(move || {
+        let mut window_wrapper = WinitWindowWrapper::new(window);
+        let mut update_loop = UpdateLoop::new(
+            cmd_line_settings.vsync,
+            cmd_line_settings.idle,
+            &window_wrapper.windowed_context,
+        );
+        #[allow(unused_assignments)]
+        loop {
+            let (wait_duration, _) = update_loop.get_event_wait_time();
+            let event = if wait_duration.as_nanos() == 0 {
+                rx.try_recv()
+                    .map_err(|e| matches!(e, TryRecvError::Disconnected))
+            } else {
+                rx.recv_timeout(wait_duration)
+                    .map_err(|e| matches!(e, RecvTimeoutError::Disconnected))
+            };
 
-                if update_loop.step(&mut window_wrapper, event).is_err() {
-                    break;
-                }
+            if update_loop.step(&mut window_wrapper, event).is_err() {
+                break;
             }
+        }
+        let window = window_wrapper.windowed_context.window();
+        save_window_size(
+            window.is_maximized(),
+            window.inner_size(),
+            window.outer_position().ok(),
+        );
+        std::process::exit(RUNNING_TRACKER.exit_code());
+    }));
+
+    event_loop.run(move |e, _window_target, control_flow| {
+        let e = match e {
+            Event::WindowEvent {
+                event: WindowEvent::ScaleFactorChanged { scale_factor, .. },
+                ..
+            } => {
+                // It's really unfortunate that we have to do this, but
+                // https://github.com/rust-windowing/winit/issues/1387
+                Some(Event::UserEvent(UserEvent::ScaleFactorChanged(
+                    scale_factor,
+                )))
+            }
+            Event::MainEventsCleared => None,
+            _ => {
+                // With the current Winit version, all events, except ScaleFactorChanged are static
+                Some(e.to_static().expect("Unexpected event received"))
+            }
+        };
+        if let Some(e) = e {
+            let _ = tx.as_ref().unwrap().send(e);
+        }
+
+        if !RUNNING_TRACKER.is_running() {
+            let tx = tx.take().unwrap();
+            drop(tx);
+            let handle = render_thread_handle.take().unwrap();
+            handle.join().unwrap();
+        }
+        // We need to wake up regularly to check the running tracker, so that we can exit
+        *control_flow = ControlFlow::WaitUntil(
+            std::time::Instant::now() + std::time::Duration::from_millis(100),
+        );
+    });
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn main_loop(window: GlWindow, event_loop: EventLoop<UserEvent>) {
+    let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
+    let mut window_wrapper = WinitWindowWrapper::new(window);
+
+    let mut update_loop = UpdateLoop::new(
+        cmd_line_settings.vsync,
+        cmd_line_settings.idle,
+        &window_wrapper.windowed_context,
+    );
+
+    event_loop.run(move |e, _window_target, control_flow| {
+        *control_flow = update_loop.step(&mut window_wrapper, Ok(e)).unwrap();
+
+        if !RUNNING_TRACKER.is_running() {
             let window = window_wrapper.windowed_context.window();
             save_window_size(
                 window.is_maximized(),
                 window.inner_size(),
                 window.outer_position().ok(),
             );
+
             std::process::exit(RUNNING_TRACKER.exit_code());
-        }));
-
-        event_loop.run(move |e, _window_target, control_flow| {
-            let e = match e {
-                Event::WindowEvent {
-                    event: WindowEvent::ScaleFactorChanged { scale_factor, .. },
-                    ..
-                } => {
-                    // It's really unfortunate that we have to do this, but
-                    // https://github.com/rust-windowing/winit/issues/1387
-                    Some(Event::UserEvent(UserEvent::ScaleFactorChanged(
-                        scale_factor,
-                    )))
-                }
-                Event::MainEventsCleared => None,
-                _ => {
-                    // With the current Winit version, all events, except ScaleFactorChanged are static
-                    Some(e.to_static().expect("Unexpected event received"))
-                }
-            };
-            if let Some(e) = e {
-                let _ = tx.as_ref().unwrap().send(e);
-            }
-
-            if !RUNNING_TRACKER.is_running() {
-                let tx = tx.take().unwrap();
-                drop(tx);
-                let handle = render_thread_handle.take().unwrap();
-                handle.join().unwrap();
-            }
-            // We need to wake up regularly to check the running tracker, so that we can exit
-            *control_flow = ControlFlow::WaitUntil(
-                std::time::Instant::now() + std::time::Duration::from_millis(100),
-            );
-        });
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        let mut window_wrapper = WinitWindowWrapper::new(window, config, &cmd_line_settings);
-
-        let mut update_loop = UpdateLoop::new(
-            cmd_line_settings.vsync,
-            cmd_line_settings.idle,
-            &window_wrapper.windowed_context,
-        );
-
-        event_loop.run(move |e, _window_target, control_flow| {
-            *control_flow = update_loop.step(&mut window_wrapper, Ok(e)).unwrap();
-
-            if !RUNNING_TRACKER.is_running() {
-                let window = window_wrapper.windowed_context.window();
-                save_window_size(
-                    window.is_maximized(),
-                    window.inner_size(),
-                    window.outer_position().ok(),
-                );
-
-                std::process::exit(RUNNING_TRACKER.exit_code());
-            }
-        });
-    }
+        }
+    });
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -91,7 +91,9 @@ pub fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
 
     let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
 
-    let previous_position = match load_last_window_settings() {
+    let window_settings = load_last_window_settings();
+
+    let previous_position = match window_settings {
         Ok(PersistentWindowSettings::Windowed { position, .. }) => Some(position),
         _ => None,
     };
@@ -107,14 +109,14 @@ pub fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
         size.into()
     } else if cmd_line_settings.geometry.is_some() {
         default_size
-    } else if let Ok(PersistentWindowSettings::Windowed {
-        pixel_size: Some(size),
-        ..
-    }) = load_last_window_settings()
-    {
-        size
     } else {
-        default_size
+        match window_settings {
+            Ok(PersistentWindowSettings::Windowed {
+                pixel_size: Some(size),
+                ..
+            }) => size,
+            _ => default_size,
+        }
     };
 
     let winit_window_builder = WindowBuilder::new()

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -61,6 +61,8 @@ pub enum WindowCommand {
     TitleChanged(String),
     SetMouseEnabled(bool),
     ListAvailableFonts,
+    Columns(u64),
+    Lines(u64),
 }
 
 #[allow(dead_code)]
@@ -187,12 +189,8 @@ pub fn create_window() {
         let (txtemp, rx) = channel::<Event<UserEvent>>();
         let mut tx = Some(txtemp);
         let mut render_thread_handle = Some(thread::spawn(move || {
-            let mut window_wrapper = WinitWindowWrapper::new(
-                window,
-                config,
-                &cmd_line_settings,
-                maximized,
-            );
+            let mut window_wrapper =
+                WinitWindowWrapper::new(window, config, &cmd_line_settings, maximized);
             let mut update_loop = UpdateLoop::new(
                 cmd_line_settings.vsync,
                 cmd_line_settings.idle,
@@ -259,12 +257,8 @@ pub fn create_window() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        let mut window_wrapper = WinitWindowWrapper::new(
-            window,
-            config,
-            &cmd_line_settings,
-            maximized,
-        );
+        let mut window_wrapper =
+            WinitWindowWrapper::new(window, config, &cmd_line_settings, maximized);
 
         let mut update_loop = UpdateLoop::new(
             cmd_line_settings.vsync,

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -164,9 +164,11 @@ impl WinitWindowWrapper {
                     self.requested_lines = Some(lines);
                 }
                 WindowCommand::UIEnter => {
+                    log::info!("UIEnter");
                     self.ui_state = UIState::Entered;
                 }
                 WindowCommand::UIReady => {
+                    log::info!("UIReady");
                     self.ui_state = UIState::ShouldShow;
                 }
             }
@@ -314,10 +316,8 @@ impl WinitWindowWrapper {
         let padding_changed = window_padding != self.renderer.window_padding;
 
         let resize_requested = self.requested_columns.is_some() || self.requested_lines.is_some();
-        log::info!("Resize requested: {resize_requested}");
 
         if self.ui_state == UIState::ShouldShow && !resize_requested {
-            log::info!("UI Ready");
             self.ui_state = UIState::Ready;
             should_render = true;
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -9,19 +9,18 @@ use crate::{
     editor::EditorCommand,
     event_aggregator::EVENT_AGGREGATOR,
     profiling::{emit_frame_mark, tracy_gpu_collect, tracy_gpu_zone, tracy_zone},
-    renderer::{build_context, Renderer, VSync, WindowPadding, WindowedContext},
+    renderer::{build_context, GlWindow, Renderer, VSync, WindowPadding, WindowedContext},
     running_tracker::RUNNING_TRACKER,
     settings::{DEFAULT_WINDOW_GEOMETRY, SETTINGS},
     CmdLineSettings,
 };
 
-use glutin::config::Config;
 use log::trace;
 use tokio::sync::mpsc::UnboundedReceiver;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize, Position},
     event::{Event, WindowEvent},
-    window::{Fullscreen, Theme, Window},
+    window::{Fullscreen, Theme},
 };
 
 const MIN_WINDOW_WIDTH: u64 = 20;
@@ -51,8 +50,9 @@ pub struct WinitWindowWrapper {
 }
 
 impl WinitWindowWrapper {
-    pub fn new(window: Window, config: Config, cmd_line_settings: &CmdLineSettings) -> Self {
-        let windowed_context = build_context(window, config, cmd_line_settings);
+    pub fn new(window: GlWindow) -> Self {
+        let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
+        let windowed_context = build_context(window, &cmd_line_settings);
         let window = windowed_context.window();
 
         let scale_factor = windowed_context.window().scale_factor();

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -145,9 +145,11 @@ impl WinitWindowWrapper {
                 }
                 WindowCommand::ListAvailableFonts => self.send_font_names(),
                 WindowCommand::Columns(columns) => {
+                    log::info!("Requested columns {columns}");
                     self.requested_columns = Some(columns);
                 }
                 WindowCommand::Lines(lines) => {
+                    log::info!("Requested lines {lines}");
                     self.requested_lines = Some(lines);
                 }
             }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -342,7 +342,7 @@ impl WinitWindowWrapper {
                 self.font_changed_last_frame = false;
                 self.saved_inner_size = new_size;
 
-                self.update_grid_size_from_window(new_size);
+                self.update_grid_size_from_window();
                 self.skia_renderer.resize(&self.windowed_context);
                 should_render = true;
             }
@@ -401,14 +401,14 @@ impl WinitWindowWrapper {
         window.set_inner_size(new_size);
     }
 
-    fn update_grid_size_from_window(&mut self, new_size: PhysicalSize<u32>) {
+    fn get_grid_size_from_window(&self) -> Dimensions {
         let window_padding = self.renderer.window_padding;
         let window_padding_width = window_padding.left + window_padding.right;
         let window_padding_height = window_padding.top + window_padding.bottom;
 
         let content_size = PhysicalSize {
-            width: new_size.width - window_padding_width,
-            height: new_size.height - window_padding_height,
+            width: self.saved_inner_size.width - window_padding_width,
+            height: self.saved_inner_size.height - window_padding_height,
         };
 
         let grid_size = self
@@ -416,10 +416,14 @@ impl WinitWindowWrapper {
             .grid_renderer
             .convert_physical_to_grid(content_size);
 
-        // Have a minimum size
-        if grid_size.width < MIN_WINDOW_WIDTH || grid_size.height < MIN_WINDOW_HEIGHT {
-            return;
+        Dimensions {
+            width: grid_size.width.max(MIN_WINDOW_WIDTH),
+            height: grid_size.height.max(MIN_WINDOW_HEIGHT),
         }
+    }
+
+    fn update_grid_size_from_window(&mut self) {
+        let grid_size = self.get_grid_size_from_window();
 
         if self.saved_grid_size == grid_size {
             trace!("Grid matched saved size, skip update.");

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -57,43 +57,11 @@ impl WinitWindowWrapper {
         window: Window,
         config: Config,
         cmd_line_settings: &CmdLineSettings,
-        previous_position: Option<PhysicalPosition<i32>>,
         maximized: bool,
     ) -> Self {
         let windowed_context = build_context(window, config, cmd_line_settings);
         let window = windowed_context.window();
         let initial_size = window.inner_size();
-
-        // Check that window is visible in some monitor, and reposition it if not.
-        let did_reposition = window
-            .current_monitor()
-            .and_then(|current_monitor| {
-                let monitor_position = current_monitor.position();
-                let monitor_size = current_monitor.size();
-                let monitor_width = monitor_size.width as i32;
-                let monitor_height = monitor_size.height as i32;
-
-                let window_position = previous_position
-                    .filter(|_| !maximized)
-                    .or_else(|| window.outer_position().ok())?;
-
-                let window_size = window.outer_size();
-                let window_width = window_size.width as i32;
-                let window_height = window_size.height as i32;
-
-                if window_position.x + window_width < monitor_position.x
-                    || window_position.y + window_height < monitor_position.y
-                    || window_position.x > monitor_position.x + monitor_width
-                    || window_position.y > monitor_position.y + monitor_height
-                {
-                    window.set_outer_position(monitor_position);
-                }
-
-                Some(())
-            })
-            .is_some();
-
-        log::trace!("repositioned window: {}", did_reposition);
 
         let scale_factor = windowed_context.window().scale_factor();
         let renderer = Renderer::new(scale_factor);


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

**NOTE: This code targets the `improve-render-loop` branch**

## What kind of change does this PR introduce?
* The window is now created as hidden at startup with the correct size from the start, unless `geometry` is specified. 
* Adds support for `:columns` and `:lines`, to change the geometry at any time, including from `init.vim/lua`
* The resizing during startup happens once at `VimEnter` to make it robust against apparent race conditions like https://github.com/neovide/neovide/issues/1972 and https://github.com/neovide/neovide/issues/1580
* https://github.com/neovide/neovide/issues/1965
* https://github.com/neovide/neovide/issues/1958
* https://github.com/neovide/neovide/issues/181
* https://github.com/neovide/neovide/discussions/1857
* Refactors the code to separate `create_window` and `main_loop`.

TODO: Check for open issues about to see other ones that this possibly fixes. NOTE: Don't mark anything to close the issue before the `improve-render-loop` branch has been merged.

## Did this PR introduce a breaking change? 
- No
