### PR TITLE
fix: Reposition the floating windows inside the main window

### DIFF
--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -9,6 +9,7 @@ use crate::{
     renderer::{LineFragment, WindowDrawCommand},
 };
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WindowType {
     Editor,
     Message,
@@ -59,7 +60,8 @@ impl Window {
         self.send_command(WindowDrawCommand::Position {
             grid_position: self.grid_position,
             grid_size: (self.grid.width as u64, self.grid.height as u64),
-            floating_order: self.anchor_info.clone().map(|anchor| anchor.sort_order),
+            anchor_info: self.anchor_info.clone(),
+            window_type: self.window_type,
         });
     }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -240,7 +240,7 @@ impl Renderer {
         animating
     }
 
-    pub fn handle_draw_commands(&mut self, padding_as_grid: &Rect) -> DrawCommandResult {
+    pub fn handle_draw_commands(&mut self) -> DrawCommandResult {
         let settings = SETTINGS.get::<RendererSettings>();
         let mut any_handled = false;
         let mut font_changed = false;
@@ -253,7 +253,7 @@ impl Renderer {
                 {
                     font_changed = true;
                 }
-                self.handle_draw_command(draw_command, padding_as_grid);
+                self.handle_draw_command(draw_command);
             }
             self.flush(&settings);
         }
@@ -284,7 +284,7 @@ impl Renderer {
             .for_each(|(_, w)| w.prepare_lines(&mut self.grid_renderer));
     }
 
-    fn handle_draw_command(&mut self, draw_command: DrawCommand, padding_as_grid: &Rect) {
+    fn handle_draw_command(&mut self, draw_command: DrawCommand) {
         match draw_command {
             DrawCommand::Window {
                 grid_id,
@@ -296,7 +296,7 @@ impl Renderer {
                 match self.rendered_windows.entry(grid_id) {
                     Entry::Occupied(mut occupied_entry) => {
                         let rendered_window = occupied_entry.get_mut();
-                        rendered_window.handle_window_draw_command(command, padding_as_grid);
+                        rendered_window.handle_window_draw_command(command);
                     }
                     Entry::Vacant(vacant_entry) => {
                         if let WindowDrawCommand::Position {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -232,11 +232,12 @@ impl Renderer {
         };
 
         let settings = SETTINGS.get::<RendererSettings>();
+        let font_dimensions = self.grid_renderer.font_dimensions;
 
         // Clippy recommends short-circuiting with any which is not what we want
         #[allow(clippy::unnecessary_fold)]
         let mut animating = windows.fold(false, |acc, window| {
-            acc | window.animate(&settings, window_size, dt)
+            acc | window.animate(&settings, window_size, &font_dimensions, dt)
         });
 
         let windows = &self.rendered_windows;

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -184,12 +184,14 @@ impl RenderedWindow {
             self.position_t = (self.position_t + dt / settings.position_animation_length).min(1.0);
         }
 
+        let prev_positon = self.grid_current_position;
         self.grid_current_position = ease_point(
             ease_out_expo,
             self.grid_start_position,
             self.get_target_position(outer_size),
             self.position_t,
         );
+        animating |= self.grid_current_position != prev_positon;
 
         animating |= self
             .scroll_animation

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -294,7 +294,7 @@ impl WinitWindowWrapper {
 
     pub fn animate_frame(&mut self, dt: f32) -> bool {
         tracy_zone!("animate_frame", 0);
-        self.renderer.animate_frame(dt)
+        self.renderer.animate_frame(&self.saved_grid_size, dt)
     }
 
     /// Prepares a frame to render.

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -294,7 +294,8 @@ impl WinitWindowWrapper {
 
     pub fn animate_frame(&mut self, dt: f32) -> bool {
         tracy_zone!("animate_frame", 0);
-        self.renderer.animate_frame(&self.saved_grid_size, dt)
+        self.renderer
+            .animate_frame(&self.get_grid_size_from_window(0, 0), dt)
     }
 
     /// Prepares a frame to render.
@@ -401,7 +402,7 @@ impl WinitWindowWrapper {
         window.set_inner_size(new_size);
     }
 
-    fn get_grid_size_from_window(&self) -> Dimensions {
+    fn get_grid_size_from_window(&self, min_width: u64, min_height: u64) -> Dimensions {
         let window_padding = self.renderer.window_padding;
         let window_padding_width = window_padding.left + window_padding.right;
         let window_padding_height = window_padding.top + window_padding.bottom;
@@ -417,13 +418,13 @@ impl WinitWindowWrapper {
             .convert_physical_to_grid(content_size);
 
         Dimensions {
-            width: grid_size.width.max(MIN_WINDOW_WIDTH),
-            height: grid_size.height.max(MIN_WINDOW_HEIGHT),
+            width: grid_size.width.max(min_width),
+            height: grid_size.height.max(min_height),
         }
     }
 
     fn update_grid_size_from_window(&mut self) {
-        let grid_size = self.get_grid_size_from_window();
+        let grid_size = self.get_grid_size_from_window(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT);
 
         if self.saved_grid_size == grid_size {
             trace!("Grid matched saved size, skip update.");

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -9,7 +9,7 @@ use crate::{
     editor::EditorCommand,
     event_aggregator::EVENT_AGGREGATOR,
     profiling::{emit_frame_mark, tracy_gpu_collect, tracy_gpu_zone, tracy_zone},
-    renderer::{build_context, GlWindow, Renderer, VSync, WindowPadding, WindowedContext},
+    renderer::{build_context, GlWindow, Renderer, VSync, WindowedContext},
     running_tracker::RUNNING_TRACKER,
     settings::{DEFAULT_WINDOW_GEOMETRY, SETTINGS},
     window::{load_last_window_settings, PersistentWindowSettings},
@@ -17,6 +17,7 @@ use crate::{
 };
 
 use log::trace;
+use skia_safe::{scalar, Rect};
 use tokio::sync::mpsc::UnboundedReceiver;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize, Position},
@@ -26,6 +27,14 @@ use winit::{
 
 const MIN_WINDOW_WIDTH: u64 = 20;
 const MIN_WINDOW_HEIGHT: u64 = 6;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct WindowPadding {
+    pub top: u32,
+    pub left: u32,
+    pub right: u32,
+    pub bottom: u32,
+}
 
 pub fn set_background(background: &str) {
     EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::SetBackground(
@@ -57,6 +66,7 @@ pub struct WinitWindowWrapper {
     requested_columns: Option<u64>,
     requested_lines: Option<u64>,
     ui_state: UIState,
+    window_padding: WindowPadding,
 }
 
 impl WinitWindowWrapper {
@@ -108,6 +118,12 @@ impl WinitWindowWrapper {
             requested_columns: None,
             requested_lines: None,
             ui_state: UIState::Initing,
+            window_padding: WindowPadding {
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: 0,
+            },
         };
 
         wrapper.set_ime(ime_enabled);
@@ -294,8 +310,12 @@ impl WinitWindowWrapper {
 
     pub fn animate_frame(&mut self, dt: f32) -> bool {
         tracy_zone!("animate_frame", 0);
-        self.renderer
-            .animate_frame(&self.get_grid_size_from_window(0, 0), dt)
+
+        self.renderer.animate_frame(
+            &self.get_grid_size_from_window(0, 0),
+            &self.padding_as_grid(),
+            dt,
+        )
     }
 
     /// Prepares a frame to render.
@@ -314,7 +334,7 @@ impl WinitWindowWrapper {
             right: window_settings.padding_right,
             bottom: window_settings.padding_bottom,
         };
-        let padding_changed = window_padding != self.renderer.window_padding;
+        let padding_changed = window_padding != self.window_padding;
 
         let resize_requested = self.requested_columns.is_some() || self.requested_lines.is_some();
 
@@ -339,7 +359,7 @@ impl WinitWindowWrapper {
             let new_size = window.inner_size();
             if self.saved_inner_size != new_size || self.font_changed_last_frame || padding_changed
             {
-                self.renderer.window_padding = window_padding;
+                self.window_padding = window_padding;
                 self.font_changed_last_frame = false;
                 self.saved_inner_size = new_size;
 
@@ -351,7 +371,8 @@ impl WinitWindowWrapper {
 
         let prev_cursor_position = self.renderer.get_cursor_position();
 
-        let handle_draw_commands_result = self.renderer.handle_draw_commands();
+        let handle_draw_commands_result =
+            self.renderer.handle_draw_commands(&self.padding_as_grid());
         self.font_changed_last_frame |= handle_draw_commands_result.font_changed;
         should_render |= handle_draw_commands_result.any_handled;
 
@@ -403,7 +424,7 @@ impl WinitWindowWrapper {
     }
 
     fn get_grid_size_from_window(&self, min_width: u64, min_height: u64) -> Dimensions {
-        let window_padding = self.renderer.window_padding;
+        let window_padding = self.window_padding;
         let window_padding_width = window_padding.left + window_padding.right;
         let window_padding_height = window_padding.top + window_padding.bottom;
 
@@ -440,5 +461,15 @@ impl WinitWindowWrapper {
     fn handle_scale_factor_update(&mut self, scale_factor: f64) {
         self.renderer.handle_os_scale_factor_change(scale_factor);
         EVENT_AGGREGATOR.send(EditorCommand::RedrawScreen);
+    }
+
+    fn padding_as_grid(&self) -> Rect {
+        let font_dimensions = self.renderer.grid_renderer.font_dimensions;
+        Rect {
+            left: self.window_padding.left as scalar / font_dimensions.width as scalar,
+            right: self.window_padding.right as scalar / font_dimensions.width as scalar,
+            top: self.window_padding.top as scalar / font_dimensions.height as scalar,
+            bottom: self.window_padding.bottom as scalar / font_dimensions.height as scalar,
+        }
     }
 }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -371,8 +371,8 @@ impl WinitWindowWrapper {
 
         let prev_cursor_position = self.renderer.get_cursor_position();
 
-        let handle_draw_commands_result =
-            self.renderer.handle_draw_commands(&self.padding_as_grid());
+        let handle_draw_commands_result = self.renderer.handle_draw_commands();
+
         self.font_changed_last_frame |= handle_draw_commands_result.font_changed;
         should_render |= handle_draw_commands_result.any_handled;
 


### PR DESCRIPTION
* Note: builds on top of https://github.com/neovide/neovide/pull/2027, so this should be merged and reviewed after that.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The floating windows are now re-positioned to fit inside the main window, as long as it's possible. And the same thing is done for the messages window, so that you don't see a blank screen if there are errors at startup.

* https://github.com/neovide/neovide/issues/1641 will be fixed once it's completely merged to main.

## Did this PR introduce a breaking change? 
- No
