### PR TITLE
Tell neovim focus was gained/lost via 'ui_set_focus'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "nvim-rs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e98dcbd3b0ece3cf2b76ebc1e33e6511777ea7322884f4b7150cbc253afa37e"
+checksum = "9156b04d79079937abae1eb912669c48c360fb5d86138052a9bbae9c5220a71e"
 dependencies = [
  "async-trait",
  "futures 0.3.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "1.4.0"
 log = "0.4.16"
 lru = "0.7.5"
 neovide-derive = { path = "neovide-derive" }
-nvim-rs = { version = "0.5.0", features = ["use_tokio"] }
+nvim-rs = { version = "0.6.0", features = ["use_tokio"] }
 parking_lot = "0.12.0"
 pin-project = "1.0.10"
 rand = "0.8.5"

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -144,11 +144,11 @@ impl ParallelCommand {
                 .await
                 .expect("Resize failed"),
             ParallelCommand::FocusLost => nvim
-                .command("if exists('#FocusLost') | doautocmd <nomodeline> FocusLost | endif")
+                .ui_set_focus(false)
                 .await
                 .expect("Focus Lost Failed"),
             ParallelCommand::FocusGained => nvim
-                .command("if exists('#FocusGained') | doautocmd <nomodeline> FocusGained | endif")
+                .ui_set_focus(true)
                 .await
                 .expect("Focus Gained Failed"),
             ParallelCommand::FileDrop(path) => {

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -143,14 +143,12 @@ impl ParallelCommand {
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)
                 .await
                 .expect("Resize failed"),
-            ParallelCommand::FocusLost => nvim
-                .ui_set_focus(false)
-                .await
-                .expect("Focus Lost Failed"),
-            ParallelCommand::FocusGained => nvim
-                .ui_set_focus(true)
-                .await
-                .expect("Focus Gained Failed"),
+            ParallelCommand::FocusLost => {
+                nvim.ui_set_focus(false).await.expect("Focus Lost Failed")
+            }
+            ParallelCommand::FocusGained => {
+                nvim.ui_set_focus(true).await.expect("Focus Gained Failed")
+            }
             ParallelCommand::FileDrop(path) => {
                 nvim.command(format!("e {path}").as_str()).await.ok();
             }


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fixes https://github.com/neovide/neovide/issues/1477

This will use the newly added [nvim_ui_set_focus](https://neovim.io/doc/user/api.html#api-ui) function to notify neovim of focus gained/loss.

## Did this PR introduce a breaking change? 
- No
