### PR TITLE
chore: Fix new clippy warnings from rust 1.72

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -4,7 +4,7 @@ mod grid;
 mod style;
 mod window;
 
-use std::{collections::HashMap, sync::Arc, thread};
+use std::{collections::HashMap, rc::Rc, sync::Arc, thread};
 
 use log::{error, trace};
 
@@ -62,7 +62,7 @@ pub struct Editor {
     pub cursor: Cursor,
     pub defined_styles: HashMap<u64, Arc<Style>>,
     pub mode_list: Vec<CursorMode>,
-    pub draw_command_batcher: Arc<DrawCommandBatcher>,
+    pub draw_command_batcher: Rc<DrawCommandBatcher>,
     pub current_mode_index: Option<u64>,
 }
 
@@ -73,7 +73,7 @@ impl Editor {
             cursor: Cursor::new(),
             defined_styles: HashMap::new(),
             mode_list: Vec::new(),
-            draw_command_batcher: Arc::new(DrawCommandBatcher::new()),
+            draw_command_batcher: Rc::new(DrawCommandBatcher::new()),
             current_mode_index: None,
         }
     }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc, sync::Arc};
 
 use log::warn;
 use unicode_segmentation::UnicodeSegmentation;
@@ -22,7 +22,7 @@ pub struct Window {
     pub anchor_info: Option<AnchorInfo>,
     grid_position: (f64, f64),
 
-    draw_command_batcher: Arc<DrawCommandBatcher>,
+    draw_command_batcher: Rc<DrawCommandBatcher>,
 }
 
 impl Window {
@@ -32,7 +32,7 @@ impl Window {
         anchor_info: Option<AnchorInfo>,
         grid_position: (f64, f64),
         grid_size: (u64, u64),
-        draw_command_batcher: Arc<DrawCommandBatcher>,
+        draw_command_batcher: Rc<DrawCommandBatcher>,
     ) -> Window {
         let window = Window {
             grid_id,
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn window_separator_modifies_grid_and_sends_draw_command() {
         let mut draw_command_receiver = EVENT_AGGREGATOR.register_event::<Vec<DrawCommand>>();
-        let draw_command_batcher = Arc::new(DrawCommandBatcher::new());
+        let draw_command_batcher = Rc::new(DrawCommandBatcher::new());
 
         let mut window = Window::new(
             1,

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -310,12 +310,11 @@ impl CursorRenderer {
             ^ matches!(current_mode, EditorMode::CmdLine);
 
         let center_destination = self.destination + cursor_dimensions * 0.5;
-        let new_cursor = Some(self.cursor.shape.clone());
 
-        if self.previous_cursor_shape != new_cursor {
-            self.previous_cursor_shape = new_cursor.clone();
+        if self.previous_cursor_shape.as_ref() != Some(&self.cursor.shape) {
+            self.previous_cursor_shape = Some(self.cursor.shape.clone());
             self.set_cursor_shape(
-                &new_cursor.unwrap(),
+                &self.cursor.shape.clone(),
                 self.cursor
                     .cell_percentage
                     .unwrap_or(DEFAULT_CELL_PERCENTAGE),

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -195,10 +195,7 @@ impl Renderer {
 
             floating_windows.sort_by(floating_sort);
 
-            root_windows
-                .into_iter()
-                .chain(floating_windows.into_iter())
-                .collect()
+            root_windows.into_iter().chain(floating_windows).collect()
         };
 
         let settings = SETTINGS.get::<RendererSettings>();


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This fixes some clippy warnings caused by rust 1.72.

The DrawComandBatcher is not `send+sync` and not moved between threads so it does not need atomic reference counts.

## Did this PR introduce a breaking change? 
- No
