### PR TITLE
Fix option as meta

### DIFF
--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,3 +1,14 @@
+#[cfg(target_os = "macos")]
+use {
+    log::error,
+    rmpv::{Utf8String, Value},
+    serde::{
+        de::{value, IntoDeserializer},
+        Deserialize,
+    },
+    winit::platform::macos::OptionAsAlt,
+};
+
 use crate::{cmd_line::CmdLineSettings, settings::*};
 
 #[derive(Clone, SettingGroup)]
@@ -49,10 +60,36 @@ impl Default for WindowSettings {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OptionAsMeta(pub OptionAsAlt);
+
+#[cfg(target_os = "macos")]
+impl ParseFromValue for OptionAsMeta {
+    fn parse_from_value(&mut self, value: Value) {
+        let s = value.as_str().unwrap();
+        match OptionAsAlt::deserialize(s.into_deserializer()) as Result<OptionAsAlt, value::Error> {
+            Ok(oa) => *self = OptionAsMeta(oa),
+            Err(e) => error!("Setting neovide_input_macos_option_key_is_meta expected one of OnlyLeft, OnlyRight, Both, or None, but received {:?}: {:?}", e, value),
+        };
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl From<OptionAsMeta> for Value {
+    fn from(oam: OptionAsMeta) -> Self {
+        let s = serde_json::to_string(&oam.0).unwrap();
+        Value::String(Utf8String::from(s))
+    }
+}
+
 #[derive(Clone, SettingGroup)]
 #[setting_prefix = "input"]
 pub struct KeyboardSettings {
     pub macos_alt_is_meta: bool,
+    #[cfg(target_os = "macos")]
+    pub macos_option_key_is_meta: OptionAsMeta,
     pub ime: bool,
 }
 
@@ -61,6 +98,8 @@ impl Default for KeyboardSettings {
     fn default() -> Self {
         Self {
             macos_alt_is_meta: false,
+            #[cfg(target_os = "macos")]
+            macos_option_key_is_meta: OptionAsMeta(OptionAsAlt::None),
             ime: true,
         }
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix
This re-implements support for the alt_is_meta feature for macOS using winit's `OptionAsMeta` interface, [as requested](https://github.com/neovide/neovide/issues/2017#issuecomment-1712955629).

It also introduces the ability to map only the left or only the right 'option' key to the virtual key 'meta',  which leaves the other 'option' key free so that it can be used to access the additional two layers of the macOS input source. (E.g. with the u.s. english input source selected, option-c produces "ç" and option-shift-c produces "Ç".) This is done by setting the nvim variable:

```
vim.g.neovide_input_macos_option_key_is_meta
```

Possible values (defined by winit::platform::macos::OptionAsAlt) are:
```
    "Both"
    "OnlyLeft"
    "OnlyRight"
    "None"
```

The preëxisting variable `vim.g.neovide_input_macos_alt_is_meta` can still be used, and if true, it will internally result in the use of OptionAsAlt::Both.

This PR also fixes an issue where, on macOS, format_modifier_string() [would include "S-" for "meta + shift + cmd + y"](https://github.com/neovide/neovide/issues/2017#issuecomment-1712827024) (producing `<M-S-D-Y>` instead of `<M-D-Y>`)

## Did this PR introduce a breaking change?
if the user changes the nvim variable `vim.g.neovide_input_macos_alt_is_meta` after startup, it will now be ignored. This is not ideal, but from within `WinitWindowWrapper::synchronize_settings()`, there isn't a way to tell whether the legacy variable setting happened before or after a use of the new variable (`vim.g.neovide_input_macos_option_key_is_meta`). The workaround is to use the new variable.

Potentially, this breaking change could be avoided; see the comment in `WinitWindowWrapper::new()`

Fwiw, this is my first attempt at using the Rust programming language (outside of small toy examples from several years ago), so I probably made some mistakes that a beginner would make.

Also note that this PR is based on [fredizzimo:fsundvik/fix-ctrl-shift](https://github.com/neovide/neovide/pull/2018).