### PR TITLE
Custom Menu Bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,7 +239,16 @@ version = "0.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
 dependencies = [
- "objc-sys",
+ "objc-sys 0.2.0-beta.2",
+]
+
+[[package]]
+name = "block-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92"
+dependencies = [
+ "objc-sys 0.3.1",
 ]
 
 [[package]]
@@ -237,8 +257,18 @@ version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
 dependencies = [
- "block-sys",
- "objc2-encode",
+ "block-sys 0.1.0-beta.1",
+ "objc2-encode 2.0.0-pre.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
+dependencies = [
+ "block-sys 0.2.0",
+ "objc2 0.4.1",
 ]
 
 [[package]]
@@ -899,7 +929,7 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading 0.7.4",
- "objc2",
+ "objc2 0.3.0-beta.3.patch-leaks.3",
  "once_cell",
  "raw-window-handle",
  "wayland-sys 0.30.1",
@@ -954,7 +984,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -982,6 +1012,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "icrate"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
+dependencies = [
+ "block2 0.3.0",
+ "objc2 0.4.1",
 ]
 
 [[package]]
@@ -1201,6 +1241,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "menubar"
+version = "0.0.2"
+source = "git+https://github.com/madsmtm/menubar?rev=4690f2a193e387b32273f4c3f31e4a3ae203c41e#4690f2a193e387b32273f4c3f31e4a3ae203c41e"
+dependencies = [
+ "ahash 0.8.3",
+ "icrate",
+ "objc2 0.4.1",
+ "raw-window-handle",
+ "tinyvec",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1360,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru",
+ "menubar",
  "mockall",
  "neovide-derive",
  "nix 0.26.4",
@@ -1585,14 +1639,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
 
 [[package]]
+name = "objc-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e1d07c6eab1ce8b6382b8e3c7246fe117ff3f8b34be065f5ebace6749fe845"
+
+[[package]]
 name = "objc2"
 version = "0.3.0-beta.3.patch-leaks.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
 dependencies = [
- "block2",
- "objc-sys",
- "objc2-encode",
+ "block2 0.2.0-alpha.6",
+ "objc-sys 0.2.0-beta.2",
+ "objc2-encode 2.0.0-pre.2",
+]
+
+[[package]]
+name = "objc2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
+dependencies = [
+ "objc-sys 0.3.1",
+ "objc2-encode 3.0.0",
 ]
 
 [[package]]
@@ -1601,8 +1671,14 @@ version = "2.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
 dependencies = [
- "objc-sys",
+ "objc-sys 0.2.0-beta.2",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc_id"
@@ -3046,6 +3122,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -3198,7 +3289,7 @@ dependencies = [
  "memmap2",
  "ndk",
  "ndk-sys",
- "objc2",
+ "objc2 0.3.0-beta.3.patch-leaks.3",
  "once_cell",
  "orbclient",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.16"
 lru = "0.7.5"
+menubar = { git = "https://github.com/madsmtm/menubar", rev = "4690f2a193e387b32273f4c3f31e4a3ae203c41e" }
 neovide-derive = { path = "neovide-derive" }
 num = "0.4.1"
 nvim-rs = { version = "0.6.0", features = ["use_tokio"] }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -18,8 +18,9 @@ use winit::{
 };
 
 #[cfg(target_os = "macos")]
+use winit::platform::macos::EventLoopBuilderExtMacOS;
+#[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS;
-
 #[cfg(target_os = "macos")]
 use draw_background::draw_background;
 
@@ -75,7 +76,12 @@ pub enum UserEvent {
 }
 
 pub fn create_event_loop() -> EventLoop<UserEvent> {
-    EventLoopBuilder::<UserEvent>::with_user_event().build()
+    let mut winit_event_loop_builder = EventLoopBuilder::<UserEvent>::with_user_event();
+
+    #[cfg(target_os = "macos")]
+    winit_event_loop_builder.with_default_menu(false);
+
+    winit_event_loop_builder.build()
 }
 
 pub fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -318,22 +318,20 @@ fn create_menu() {
         let mut services_menu = None;
 
         let mut menubar = MenuBar::new(mtm, |menu| {
-            menu.add(MenuItemWrapper::new("item 1", "a", None));
+            menu.add(MenuItemWrapper::new("About Neovide", "", None));
             menu.add(MenuItemWrapper::new_separator());
             menu.add({
                 let item = MenuItemWrapper::new("Services", "", None);
                 services_menu = item.set_submenu({
                     let submenu = MenuWrapper::new(mtm);
-                    submenu.add(MenuItemWrapper::new(
-                        "will get removed or disappear?",
-                        "",
-                        None,
-                    ));
                     Some(submenu)
                 });
                 item
             });
             menu.add(MenuItemWrapper::new_separator());
+            menu.add(MenuItemWrapper::new("Hide Neovide", "h", None));
+            menu.add(MenuItemWrapper::new_separator());
+            menu.add(MenuItemWrapper::new("Quit Neovide", "q", None));
         });
 
         let window_menu = menubar.add("Window", |_menu| {});


### PR DESCRIPTION
**Currently WIP**

This PR seeks to solve the problem of needing certain native hotkeys, such as `⌘-Q` on mac to quit. Up until now, winit includes a default menu which handles this functionality, but it's impossible to capture that event, so we can't properly shut down neovide down and simultaneously acknolwedge config options like `vim.g.neovide_confirm_quit`.

So instead, we create our own menu using the `menubar` crate.

I'm new to rust so please feel free to correct anything and everything aggressively as I chip away at these issues. You wont offend me.

Todo:
- [ ] implement for `windows` and `linux` targets. all items below applies to `macos`
- [ ] on mac, use the `⌘` key instead of the globe key for all the default system hotkeys
- [ ] implement basic core functionality:
  - [ ] about
  - [ ] hide / hide others
  - [ ] quit
- [ ] implement window menu functionality
  - [ ] implement minimize which doesn't seem to be in the default
- [ ] implement help menu, similar to macvim:
  - [ ] neovide website
  - [ ] I'm open to others... below is a screenshot of macvim
- [ ] change `neovide` to `Neovide` proper capitalization on Mac (maybe related to the process name?)

<img width="386" alt="image" src="https://github.com/neovide/neovide/assets/1386207/3713e3b8-0b6f-4596-a149-7c931fcab379">

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- Yes, please list breaking changes

The breaking changes to my knowledge is that because some portions of the menu are now being handled natively, certain people's keymaps may need to be made sure they still work.