### PR TITLE
fix: run :edit command with nvim_cmd to escape special characters

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -152,21 +152,9 @@ impl ParallelCommand {
             ParallelCommand::FileDrop(path) => {
                 nvim.cmd(
                     vec![
-                        (
-                            "cmd".into(),
-                            "edit".into(),
-                        ),
-                        (
-                            "magic".into(),
-                            vec![(
-                                "file".into(),
-                                false.into(),
-                            )].into(),
-                        ),
-                        (
-                            "args".into(),
-                            vec![Value::from(path)].into(),
-                        ),
+                        ("cmd".into(), "edit".into()),
+                        ("magic".into(), vec![("file".into(), false.into())].into()),
+                        ("args".into(), vec![Value::from(path)].into()),
                     ],
                     vec![],
                 )

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -150,30 +150,25 @@ impl ParallelCommand {
                 nvim.ui_set_focus(true).await.expect("Focus Gained Failed")
             }
             ParallelCommand::FileDrop(path) => {
-                nvim.call_function(
-                    "nvim_cmd",
-                    call_args![
-                        Value::Map(vec![
-                            (
-                                Value::String("cmd".to_owned().into()),
-                                Value::String("edit".to_owned().into()),
-                            ),
-                            (
-                                Value::String("magic".to_owned().into()),
-                                Value::Map(vec![
-                                    (
-                                        Value::String("file".to_owned().into()),
-                                        Value::Boolean(false),
-                                    ),
-                                ]),
-                            ),
-                            (
-                                Value::String("args".to_owned().into()),
-                                Value::Array(vec![Value::String(path.to_owned().into())]),
-                            ),
-                        ]),
-                        Value::Map(vec![]),
+                nvim.cmd(
+                    vec![
+                        (
+                            Value::String("cmd".to_owned().into()),
+                            Value::String("edit".to_owned().into()),
+                        ),
+                        (
+                            Value::String("magic".to_owned().into()),
+                            Value::Map(vec![(
+                                Value::String("file".to_owned().into()),
+                                Value::Boolean(false),
+                            )]),
+                        ),
+                        (
+                            Value::String("args".to_owned().into()),
+                            Value::Array(vec![Value::String(path.to_owned().into())]),
+                        ),
                     ],
+                    vec![],
                 )
                 .await
                 .ok();

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -153,19 +153,19 @@ impl ParallelCommand {
                 nvim.cmd(
                     vec![
                         (
-                            Value::String("cmd".to_owned().into()),
-                            Value::String("edit".to_owned().into()),
+                            "cmd".into(),
+                            "edit".into(),
                         ),
                         (
-                            Value::String("magic".to_owned().into()),
-                            Value::Map(vec![(
-                                Value::String("file".to_owned().into()),
-                                Value::Boolean(false),
-                            )]),
+                            "magic".into(),
+                            vec![(
+                                "file".into(),
+                                false.into(),
+                            )].into(),
                         ),
                         (
-                            Value::String("args".to_owned().into()),
-                            Value::Array(vec![Value::String(path.to_owned().into())]),
+                            "args".into(),
+                            vec![Value::from(path)].into(),
                         ),
                     ],
                     vec![],


### PR DESCRIPTION
I tested this commit by dragging and dropping file named `W:\tmp\neovide\(abc)\example#abc%def.txt` and it was opened successfully.

Fixes #1983

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
