### PR TITLE
Add command to focus the neovide window

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -3,9 +3,12 @@ use log::trace;
 use nvim_rs::{Handler, Neovim};
 use rmpv::Value;
 
-use crate::bridge::clipboard::{get_clipboard_contents, set_clipboard_contents};
 #[cfg(windows)]
 use crate::bridge::ui_commands::{ParallelCommand, UiCommand};
+use crate::{
+    bridge::clipboard::{get_clipboard_contents, set_clipboard_contents},
+    window::WindowCommand,
+};
 use crate::{
     bridge::{events::parse_redraw_event, NeovimWriter},
     editor::EditorCommand,
@@ -92,6 +95,9 @@ impl Handler for NeovimHandler {
             #[cfg(windows)]
             "neovide.unregister_right_click" => {
                 EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::UnregisterRightClick));
+            }
+            "neovide.focus_window" => {
+                EVENT_AGGREGATOR.send(WindowCommand::FocusWindow);
             }
             _ => {}
         }

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -126,6 +126,17 @@ pub async fn setup_neovide_specific_state(
         .await
         .ok();
 
+        // Create a command for focusing the platform window.
+        #[cfg(windows)]
+        nvim.command(&build_neovide_command(
+            neovide_channel,
+            0,
+            "NeovideFocus",
+            "focus_window",
+        ))
+        .await
+        .ok();
+
         if should_handle_clipboard {
             setup_neovide_remote_clipboard(nvim, neovide_channel).await;
         }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -50,6 +50,7 @@ pub enum WindowCommand {
     TitleChanged(String),
     SetMouseEnabled(bool),
     ListAvailableFonts,
+    FocusWindow,
 }
 
 pub fn create_window() {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -184,6 +184,9 @@ impl WinitWindowWrapper {
                     self.mouse_manager.enabled = mouse_enabled
                 }
                 WindowCommand::ListAvailableFonts => self.send_font_names(),
+                WindowCommand::FocusWindow => {
+                    self.windowed_context.window().focus_window();
+                }
             }
         }
     }

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -1,0 +1,20 @@
+# Commands
+
+On startup, Neovide registers some commands for interacting
+with the os and platform window. These are neovim commands
+accessible via `:{command name}`.
+
+## Register/Unregister Right Click
+
+On windows you can register a right click context menu item
+to edit a given file with Neovide. This can be done at any
+time by running the `NeovideRegisterRightClick` command. This can
+be undone with the `NeovideUnregisterRightClick` command.
+
+## Focus Window
+
+Running the `NeovideFocus` command will bring the platform
+window containing Neovide to the front and activate it. This
+is useful for tools like neovim_remote which can manipulate
+neovim remotely or if long running tasks would like to
+activate the Neovide window after finishing.


### PR DESCRIPTION
Adds a command which focuses the Neovide window. This is useful for things like neovim_remote which causes neovim to do some action such as opening a file. Without a feature like this, it is impossible to bring the neovide window to the front as a part of remotely opening a file to edit.

Adds `NeovideFocus` which sends a notification to the bridge. This notification triggers sending a WindowCommand::FocusWindow event which is handled on the WindowWrapper to focus the winit platform window.

Addresses https://github.com/neovide/neovide/issues/1974

## What kind of change does this PR introduce?
Feature

## Did this PR introduce a breaking change? 
No

Tested by executing `call timer_start(2000, { tid -> execute('NeovideFocus')})` and switching to another window quickly. After a 2 second delay, the neovide window is correctly focused.
