### PR TITLE
fix!: window not showing up

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -96,9 +96,6 @@ impl Handler for NeovimHandler {
                     EVENT_AGGREGATOR.send(WindowCommand::Lines(lines));
                 }
             }
-            "neovide.ui_ready" => {
-                EVENT_AGGREGATOR.send(WindowCommand::UIReady);
-            }
             #[cfg(windows)]
             "neovide.register_right_click" => {
                 EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::RegisterRightClick));

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -15,8 +15,8 @@ use tokio::{
 };
 
 use crate::{
-    cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation,
-    event_aggregator::EVENT_AGGREGATOR, running_tracker::*, settings::*, window::WindowCommand,
+    cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation, running_tracker::*,
+    settings::*,
 };
 use handler::NeovimHandler;
 use session::{NeovimInstance, NeovimSession};
@@ -115,7 +115,6 @@ async fn run(session: NeovimSession) {
         .unwrap_or_explained_panic("Could not attach ui to neovim process");
 
     info!("Neovim process attached");
-    EVENT_AGGREGATOR.send(WindowCommand::UIEnter);
 
     match session.io_handle.await {
         Err(join_error) => error!("Error joining IO loop: '{}'", join_error),

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -15,8 +15,8 @@ use tokio::{
 };
 
 use crate::{
-    cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation, running_tracker::*,
-    settings::*,
+    cmd_line::CmdLineSettings, dimensions::Dimensions, error_handling::ResultPanicExplanation,
+    running_tracker::*, settings::*,
 };
 use handler::NeovimHandler;
 use session::{NeovimInstance, NeovimSession};
@@ -98,16 +98,16 @@ async fn launch() -> NeovimSession {
     session
 }
 
-async fn run(session: NeovimSession) {
+async fn run(session: NeovimSession, geometry: Option<Dimensions>) {
     let settings = SETTINGS.get::<CmdLineSettings>();
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
     options.set_multigrid_external(!settings.no_multi_grid);
     options.set_rgb(true);
 
-    // Triggers loading the user's config
-    // Set to DEFAULT_WINDOW_GEOMETRY first, draw_frame will resize it later
-    let geometry = DEFAULT_WINDOW_GEOMETRY;
+    // Triggers loading the user config
+
+    let geometry = geometry.map_or(DEFAULT_GRID_SIZE, |v| v.clamped_grid_size());
     session
         .neovim
         .ui_attach(geometry.width as i64, geometry.height as i64, &options)
@@ -143,12 +143,12 @@ impl NeovimRuntime {
         self.state = RuntimeState::Launched(self.runtime.block_on(launch()));
     }
 
-    pub fn attach(&mut self) {
+    pub fn attach(&mut self, geometry: Option<Dimensions>) {
         assert!(matches!(self.state, RuntimeState::Launched(..)));
         if let RuntimeState::Launched(session) =
             std::mem::replace(&mut self.state, RuntimeState::Invalid)
         {
-            self.state = RuntimeState::Attached(self.runtime.spawn(run(session)));
+            self.state = RuntimeState::Attached(self.runtime.spawn(run(session, geometry)));
         }
     }
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -98,7 +98,7 @@ async fn launch() -> NeovimSession {
     session
 }
 
-async fn run(session: NeovimSession, geometry: Option<Dimensions>) {
+async fn run(session: NeovimSession, grid_size: Option<Dimensions>) {
     let settings = SETTINGS.get::<CmdLineSettings>();
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
@@ -107,10 +107,10 @@ async fn run(session: NeovimSession, geometry: Option<Dimensions>) {
 
     // Triggers loading the user config
 
-    let geometry = geometry.map_or(DEFAULT_GRID_SIZE, |v| v.clamped_grid_size());
+    let grid_size = grid_size.map_or(DEFAULT_GRID_SIZE, |v| v.clamped_grid_size());
     session
         .neovim
-        .ui_attach(geometry.width as i64, geometry.height as i64, &options)
+        .ui_attach(grid_size.width as i64, grid_size.height as i64, &options)
         .await
         .unwrap_or_explained_panic("Could not attach ui to neovim process");
 
@@ -143,12 +143,12 @@ impl NeovimRuntime {
         self.state = RuntimeState::Launched(self.runtime.block_on(launch()));
     }
 
-    pub fn attach(&mut self, geometry: Option<Dimensions>) {
+    pub fn attach(&mut self, grid_size: Option<Dimensions>) {
         assert!(matches!(self.state, RuntimeState::Launched(..)));
         if let RuntimeState::Launched(session) =
             std::mem::replace(&mut self.state, RuntimeState::Invalid)
         {
-            self.state = RuntimeState::Attached(self.runtime.spawn(run(session, geometry)));
+            self.state = RuntimeState::Attached(self.runtime.spawn(run(session, grid_size)));
         }
     }
 }

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -3,12 +3,7 @@ use nvim_rs::Neovim;
 use rmpv::Value;
 
 use super::setup_intro_message_autocommand;
-use crate::{
-    bridge::NeovimWriter,
-    error_handling::ResultPanicExplanation,
-    settings::{DEFAULT_WINDOW_GEOMETRY, SETTINGS},
-    CmdLineSettings,
-};
+use crate::{bridge::NeovimWriter, error_handling::ResultPanicExplanation};
 
 const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
     local function set_clipboard(register)
@@ -36,28 +31,13 @@ const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
         cache_enabled = 0
     }";
 
-const SETUP_GEOMETRY_LUA: &str = r"
+const UI_ENTER_LUA: &str = r"
     local initial_columns, initial_lines, force = ...
-    -- We want to set the geometry in VimEnter, since after that the UI takes control over the size
-    -- So UIEnter is too late
-    vim.api.nvim_create_autocmd({ 'VimEnter' }, {
+    vim.api.nvim_create_autocmd({ 'UIEnter' }, {
         pattern = '*',
         once = true,
         nested = true,
         callback = function()
-            if force then
-                vim.o.columns = initial_columns
-                vim.o.lines = initial_lines
-            else
-                -- Just set the values again to trigger the OptionSet callback
-                -- It's not automatically run when running init.vim/lua
-                if vim.o.columns ~= initial_columns then
-                    vim.o.columns = vim.o.columns
-                end
-                if vim.o.lines ~= initial_lines then
-                    vim.o.lines = vim.o.lines
-                end
-            end
             vim.rpcnotify(vim.g.neovide_channel_id, 'neovide.ui_ready')
         end
     })";
@@ -191,16 +171,7 @@ pub async fn setup_neovide_specific_state(
     .await
     .ok();
 
-    let (geometry, force) = SETTINGS
-        .get::<CmdLineSettings>()
-        .geometry
-        .map_or_else(|| (DEFAULT_WINDOW_GEOMETRY, false), |v| (v, true));
-    nvim.execute_lua(
-        SETUP_GEOMETRY_LUA,
-        vec![geometry.width.into(), geometry.height.into(), force.into()],
-    )
-    .await
-    .ok();
+    nvim.execute_lua(UI_ENTER_LUA, vec![]).await.ok();
 
     setup_intro_message_autocommand(nvim).await.ok();
 }

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -31,17 +31,6 @@ const REGISTER_CLIPBOARD_PROVIDER_LUA: &str = r"
         cache_enabled = 0
     }";
 
-const UI_ENTER_LUA: &str = r"
-    local initial_columns, initial_lines, force = ...
-    vim.api.nvim_create_autocmd({ 'UIEnter' }, {
-        pattern = '*',
-        once = true,
-        nested = true,
-        callback = function()
-            vim.rpcnotify(vim.g.neovide_channel_id, 'neovide.ui_ready')
-        end
-    })";
-
 pub async fn setup_neovide_remote_clipboard(nvim: &Neovim<NeovimWriter>) {
     // Users can opt-out with
     // vim: `let g:neovide_no_custom_clipboard = v:true`
@@ -170,8 +159,6 @@ pub async fn setup_neovide_specific_state(
     )
     .await
     .ok();
-
-    nvim.execute_lua(UI_ENTER_LUA, vec![]).await.ok();
 
     setup_intro_message_autocommand(nvim).await.ok();
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_files_to_open_with_flag() {
-        let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md", "--geometry=42x24"]
+        let args: Vec<String> = vec!["neovide", "./foo.txt", "./bar.md", "--grid=42x24"]
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -236,29 +236,29 @@ mod tests {
         );
 
         assert_eq!(
-            SETTINGS.get::<CmdLineSettings>().geometry,
-            Some(Dimensions {
+            SETTINGS.get::<CmdLineSettings>().geometry.grid,
+            Some(Some(Dimensions {
                 width: 42,
                 height: 24
-            }),
+            })),
         );
     }
 
     #[test]
     #[serial]
-    fn test_geometry() {
-        let args: Vec<String> = vec!["neovide", "--geometry=42x24"]
+    fn test_grid() {
+        let args: Vec<String> = vec!["neovide", "--grid=42x24"]
             .iter()
             .map(|s| s.to_string())
             .collect();
 
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
-            SETTINGS.get::<CmdLineSettings>().geometry,
-            Some(Dimensions {
+            SETTINGS.get::<CmdLineSettings>().geometry.grid,
+            Some(Some(Dimensions {
                 width: 42,
                 height: 24
-            }),
+            })),
         );
     }
 
@@ -272,7 +272,7 @@ mod tests {
 
         handle_command_line_arguments(args).expect("Could not parse arguments");
         assert_eq!(
-            SETTINGS.get::<CmdLineSettings>().size,
+            SETTINGS.get::<CmdLineSettings>().geometry.size,
             Some(Dimensions {
                 width: 420,
                 height: 240,

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -118,9 +118,9 @@ pub struct CmdLineSettings {
 #[group(required = false, multiple = false)]
 pub struct GeometryArgs {
     /// The initial grid size of the window [<columns>x<lines>]. Defaults to columns/lines from init.vim/lua if no value is given.
-    /// If --geometry is not set then it's inferred from the window size
+    /// If --grid is not set then it's inferred from the window size
     #[arg(long)]
-    pub geometry: Option<Option<Dimensions>>,
+    pub grid: Option<Option<Dimensions>>,
 
     /// The size of the window in pixels.
     #[arg(long)]

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -110,13 +110,13 @@ pub struct CmdLineSettings {
     pub x11_wm_class_instance: String,
 
     #[command(flatten)]
-    pub geometry: Geometry,
+    pub geometry: GeometryArgs,
 }
 
 // geometry, size and maximized are mutually exclusive
 #[derive(Clone, Debug, Args, PartialEq)]
 #[group(required = false, multiple = false)]
-pub struct Geometry {
+pub struct GeometryArgs {
     /// The initial grid size of the window [<columns>x<lines>]. Defaults to columns/lines from init.vim/lua if no value is given.
     /// If --geometry is not set then it's inferred from the window size
     #[arg(long)]

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -28,14 +28,6 @@ pub struct CmdLineSettings {
     )]
     pub neovim_args: Vec<String>,
 
-    /// The geometry of the window
-    #[arg(long)]
-    pub geometry: Option<Dimensions>,
-
-    /// The size of the window in pixel
-    #[arg(long)]
-    pub size: Option<Dimensions>,
-
     /// If to enable logging to a file in the current directory
     #[arg(long = "log")]
     pub log_to_file: bool,
@@ -52,10 +44,6 @@ pub struct CmdLineSettings {
     /// if this is "none")
     #[arg(long, env = "NEOVIDE_FRAME", default_value_t)]
     pub frame: Frame,
-
-    /// Maximize the window on startup (not equivalent to fullscreen)
-    #[arg(long, env = "NEOVIDE_MAXIMIZED", value_parser = FalseyValueParser::new())]
-    pub maximized: bool,
 
     /// Disable the Multigrid extension (disables smooth scrolling, window animations, and floating blur)
     #[arg(long = "no-multigrid", env = "NEOVIDE_NO_MULTIGRID", value_parser = FalseyValueParser::new())]
@@ -120,6 +108,27 @@ pub struct CmdLineSettings {
         default_value = "neovide"
     )]
     pub x11_wm_class_instance: String,
+
+    #[command(flatten)]
+    pub geometry: Geometry,
+}
+
+// geometry, size and maximized are mutually exclusive
+#[derive(Clone, Debug, Args, PartialEq)]
+#[group(required = false, multiple = false)]
+pub struct Geometry {
+    /// The initial grid size of the window [<columns>x<lines>]. Defaults to columns/lines from init.vim/lua if no value is given.
+    /// If --geometry is not set then it's inferred from the window size
+    #[arg(long)]
+    pub geometry: Option<Option<Dimensions>>,
+
+    /// The size of the window in pixels.
+    #[arg(long)]
+    pub size: Option<Dimensions>,
+
+    /// Maximize the window on startup (not equivalent to fullscreen)
+    #[arg(long, env = "NEOVIDE_MAXIMIZED", value_parser = FalseyValueParser::new())]
+    pub maximized: bool,
 }
 
 impl Default for CmdLineSettings {

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -16,9 +16,20 @@ pub struct Dimensions {
     pub height: u64,
 }
 
+impl Dimensions {
+    pub fn clamped_grid_size(&self) -> Self {
+        let min = settings::MIN_GRID_SIZE;
+        let max = settings::MAX_GRID_SIZE;
+        Dimensions {
+            width: self.width.clamp(min.width, max.width),
+            height: self.height.clamp(min.height, max.height),
+        }
+    }
+}
+
 impl Default for Dimensions {
     fn default() -> Self {
-        settings::DEFAULT_WINDOW_GEOMETRY
+        settings::DEFAULT_GRID_SIZE
     }
 }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -63,6 +63,7 @@ pub struct Editor {
     pub mode_list: Vec<CursorMode>,
     pub draw_command_batcher: Rc<DrawCommandBatcher>,
     pub current_mode_index: Option<u64>,
+    pub ui_ready: bool,
 }
 
 impl Editor {
@@ -74,6 +75,7 @@ impl Editor {
             mode_list: Vec::new(),
             draw_command_batcher: Rc::new(DrawCommandBatcher::new()),
             current_mode_index: None,
+            ui_ready: false,
         }
     }
 
@@ -171,6 +173,7 @@ impl Editor {
                     cells,
                 } => {
                     tracy_zone!("EditorGridLine");
+                    self.set_ui_ready();
                     let defined_styles = &self.defined_styles;
                     let window = self.windows.get_mut(&grid);
                     if let Some(window) = window {
@@ -243,9 +246,14 @@ impl Editor {
                     tracy_zone!("EditorWindowClose");
                     self.close_window(grid)
                 }
-                RedrawEvent::MessageSetPosition { grid, row, .. } => {
+                RedrawEvent::MessageSetPosition {
+                    grid,
+                    row,
+                    scrolled,
+                    ..
+                } => {
                     tracy_zone!("EditorMessageSetPosition");
-                    self.set_message_position(grid, row)
+                    self.set_message_position(grid, row, scrolled)
                 }
                 RedrawEvent::WindowViewport {
                     grid,
@@ -254,6 +262,7 @@ impl Editor {
                     ..
                 } => {
                     tracy_zone!("EditorWindowViewport");
+                    self.set_ui_ready();
                     self.send_updated_viewport(grid, scroll_delta)
                 }
                 RedrawEvent::ShowIntro { message } => {
@@ -371,7 +380,7 @@ impl Editor {
         }
     }
 
-    fn set_message_position(&mut self, grid: u64, grid_top: u64) {
+    fn set_message_position(&mut self, grid: u64, grid_top: u64, scrolled: bool) {
         let parent_width = self
             .windows
             .get(&1)
@@ -387,7 +396,7 @@ impl Editor {
         };
 
         if let Some(window) = self.windows.get_mut(&grid) {
-            window.window_type = WindowType::Message;
+            window.window_type = WindowType::Message { scrolled };
             window.position(
                 Some(anchor_info),
                 (parent_width, window.get_height()),
@@ -397,7 +406,7 @@ impl Editor {
         } else {
             let new_window = Window::new(
                 grid,
-                WindowType::Message,
+                WindowType::Message { scrolled },
                 Some(anchor_info),
                 (0.0, grid_top as f64),
                 (parent_width, 1),
@@ -435,7 +444,7 @@ impl Editor {
 
     fn set_cursor_position(&mut self, grid: u64, grid_left: u64, grid_top: u64) {
         if let Some(Window {
-            window_type: WindowType::Message,
+            window_type: WindowType::Message { .. },
             ..
         }) = self.windows.get(&grid)
         {
@@ -520,6 +529,13 @@ impl Editor {
     fn redraw_screen(&mut self) {
         for window in self.windows.values() {
             window.redraw();
+        }
+    }
+
+    fn set_ui_ready(&mut self) {
+        if !self.ui_ready {
+            self.ui_ready = true;
+            self.draw_command_batcher.queue(DrawCommand::UIReady).ok();
         }
     }
 }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -12,7 +12,7 @@ use crate::{
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WindowType {
     Editor,
-    Message,
+    Message { scrolled: bool },
 }
 
 pub struct Window {

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,11 +182,11 @@ fn protected_main() -> ExitCode {
     runtime.launch();
     let event_loop = create_event_loop();
     let window = create_window(&event_loop, &window_size);
-    let geometry = match window_size {
-        WindowSize::Geometry(geometry) => Some(geometry),
+    let grid_size = match window_size {
+        WindowSize::Grid(grid_size) => Some(grid_size),
         _ => None,
     };
-    runtime.attach(geometry);
+    runtime.attach(grid_size);
 
     maybe_disown();
     start_editor();

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -348,6 +348,14 @@ impl Renderer {
     pub fn get_cursor_position(&self) -> Point {
         self.cursor_renderer.get_current_position()
     }
+
+    pub fn get_grid_size(&self) -> Dimensions {
+        if let Some(main_grid) = self.rendered_windows.get(&1) {
+            main_grid.grid_size
+        } else {
+            DEFAULT_GRID_SIZE
+        }
+    }
 }
 
 /// Defines how floating windows are sorted.

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -78,6 +78,7 @@ pub enum DrawCommand {
     LineSpaceChanged(i64),
     DefaultStyleChanged(Style),
     ModeChanged(EditorMode),
+    UIReady,
 }
 
 pub struct Renderer {
@@ -98,6 +99,7 @@ pub struct Renderer {
 pub struct DrawCommandResult {
     pub font_changed: bool,
     pub any_handled: bool,
+    pub should_show: bool,
 }
 
 impl Renderer {
@@ -242,18 +244,17 @@ impl Renderer {
 
     pub fn handle_draw_commands(&mut self) -> DrawCommandResult {
         let settings = SETTINGS.get::<RendererSettings>();
-        let mut any_handled = false;
-        let mut font_changed = false;
+        let mut result = DrawCommandResult {
+            any_handled: false,
+            font_changed: false,
+            should_show: false,
+        };
 
         while let Ok(batch) = self.batched_draw_command_receiver.try_recv() {
-            any_handled = true;
+            result.any_handled = true;
 
             for draw_command in batch {
-                if let DrawCommand::FontChanged(_) | DrawCommand::LineSpaceChanged(_) = draw_command
-                {
-                    font_changed = true;
-                }
-                self.handle_draw_command(draw_command);
+                self.handle_draw_command(draw_command, &mut result);
             }
             self.flush(&settings);
         }
@@ -263,13 +264,10 @@ impl Renderer {
             self.user_scale_factor = user_scale_factor;
             self.grid_renderer
                 .handle_scale_factor_update(self.os_scale_factor * self.user_scale_factor);
-            font_changed = true;
+            result.font_changed = true;
         }
 
-        DrawCommandResult {
-            font_changed,
-            any_handled,
-        }
+        result
     }
 
     pub fn handle_os_scale_factor_change(&mut self, os_scale_factor: f64) {
@@ -284,7 +282,7 @@ impl Renderer {
             .for_each(|(_, w)| w.prepare_lines(&mut self.grid_renderer));
     }
 
-    fn handle_draw_command(&mut self, draw_command: DrawCommand) {
+    fn handle_draw_command(&mut self, draw_command: DrawCommand, result: &mut DrawCommandResult) {
         match draw_command {
             DrawCommand::Window {
                 grid_id,
@@ -322,15 +320,20 @@ impl Renderer {
             }
             DrawCommand::FontChanged(new_font) => {
                 self.grid_renderer.update_font(&new_font);
+                result.font_changed = true;
             }
             DrawCommand::LineSpaceChanged(new_linespace) => {
                 self.grid_renderer.update_linespace(new_linespace);
+                result.font_changed = true;
             }
             DrawCommand::DefaultStyleChanged(new_style) => {
                 self.grid_renderer.default_style = Arc::new(new_style);
             }
             DrawCommand::ModeChanged(new_mode) => {
                 self.current_mode = new_mode;
+            }
+            DrawCommand::UIReady => {
+                result.should_show = true;
             }
             _ => {}
         }

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -148,7 +148,7 @@ impl RenderedWindow {
         };
 
         let mut grid_size = Point::new(self.grid_size.width as f32, self.grid_size.height as f32);
-        if self.window_type == WindowType::Message {
+        if matches!(self.window_type, WindowType::Message { .. }) {
             // The message grid size is always the full window size, so use the relative position to
             // calculate the actual grid size
             grid_size.y -= self.grid_destination.y;
@@ -162,7 +162,7 @@ impl RenderedWindow {
         // For messages the last line is most important, (it shows press enter), so let the position go negative
         // Otherwise ensure that the window start row is within the screen
         let mut y = destination.y.min(valid_rect.bottom - grid_size.y);
-        if self.window_type != WindowType::Message {
+        if matches!(self.window_type, WindowType::Message { .. }) {
             y = y.max(valid_rect.top)
         }
         Point { x, y }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -14,7 +14,8 @@ use std::{
 use crate::{bridge::NeovimWriter, error_handling::ResultPanicExplanation};
 pub use from_value::ParseFromValue;
 pub use window_size::{
-    load_last_window_settings, save_window_size, PersistentWindowSettings, DEFAULT_WINDOW_GEOMETRY,
+    load_last_window_settings, save_window_size, PersistentWindowSettings, DEFAULT_GRID_SIZE,
+    MAX_GRID_SIZE, MIN_GRID_SIZE,
 };
 
 mod config;

--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -7,9 +7,19 @@ use crate::{dimensions::Dimensions, settings::SETTINGS, window::WindowSettings};
 
 const SETTINGS_FILE: &str = "neovide-settings.json";
 
-pub const DEFAULT_WINDOW_GEOMETRY: Dimensions = Dimensions {
+pub const DEFAULT_GRID_SIZE: Dimensions = Dimensions {
     width: 100,
     height: 50,
+};
+
+pub const MIN_GRID_SIZE: Dimensions = Dimensions {
+    width: 20,
+    height: 6,
+};
+
+pub const MAX_GRID_SIZE: Dimensions = Dimensions {
+    width: 10000,
+    height: 1000,
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -63,7 +63,6 @@ pub enum WindowCommand {
     ListAvailableFonts,
     Columns(u64),
     Lines(u64),
-    UIReady,
 }
 
 #[allow(dead_code)]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -199,8 +199,8 @@ pub fn create_window(
 pub enum WindowSize {
     Size(PhysicalSize<u32>),
     Maximized,
-    Geometry(Dimensions),
-    NeovimGeometry, // The geometry is read from init.vim/lua
+    Grid(Dimensions),
+    NeovimGrid, // The geometry is read from init.vim/lua
 }
 
 pub fn determine_window_size() -> WindowSize {
@@ -209,13 +209,12 @@ pub fn determine_window_size() -> WindowSize {
 
     match cmd_line.geometry {
         GeometryArgs {
-            geometry: Some(Some(dimensions)),
+            grid: Some(Some(dimensions)),
             ..
-        } => WindowSize::Geometry(dimensions.clamped_grid_size()),
+        } => WindowSize::Grid(dimensions.clamped_grid_size()),
         GeometryArgs {
-            geometry: Some(None),
-            ..
-        } => WindowSize::NeovimGeometry,
+            grid: Some(None), ..
+        } => WindowSize::NeovimGrid,
         GeometryArgs {
             size: Some(dimensions),
             ..

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -95,16 +95,19 @@ pub fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
         _ => None,
     };
 
-    log::trace!("Settings geometry {:?}", cmd_line_settings.geometry,);
-    log::trace!("Settings size {:?}", cmd_line_settings.size);
+    log::trace!(
+        "Settings geometry {:?}",
+        cmd_line_settings.geometry.geometry,
+    );
+    log::trace!("Settings size {:?}", cmd_line_settings.geometry.size);
 
     let default_size = PhysicalSize {
         width: 500,
         height: 500,
     };
-    let inner_size = if let Some(size) = cmd_line_settings.size {
+    let inner_size = if let Some(size) = cmd_line_settings.geometry.size {
         size.into()
-    } else if cmd_line_settings.geometry.is_some() {
+    } else if cmd_line_settings.geometry.geometry.is_some() {
         default_size
     } else {
         match window_settings {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -63,7 +63,6 @@ pub enum WindowCommand {
     ListAvailableFonts,
     Columns(u64),
     Lines(u64),
-    UIEnter,
     UIReady,
 }
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -339,13 +339,13 @@ impl WinitWindowWrapper {
                     self.windowed_context.window().set_visible(true);
                     self.windowed_context.window().set_maximized(true);
                 }
-                WindowSize::Geometry(Dimensions { width, height }) => {
+                WindowSize::Grid(Dimensions { width, height }) => {
                     self.requested_columns = Some(width);
                     self.requested_lines = Some(height);
                     log::info!("Showing window {width}, {height}");
                     // The visibility is changed after the size is adjusted
                 }
-                WindowSize::NeovimGeometry => {
+                WindowSize::NeovimGrid => {
                     let grid_size = self.renderer.get_grid_size();
                     self.requested_columns = Some(grid_size.width);
                     self.requested_lines = Some(grid_size.height);

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -179,12 +179,6 @@ impl WinitWindowWrapper {
                     log::info!("Requested lines {lines}");
                     self.requested_lines = Some(lines);
                 }
-                WindowCommand::UIReady => {
-                    log::info!("UIReady");
-                    if self.ui_state == UIState::Initing {
-                        self.ui_state = UIState::ShouldShow;
-                    }
-                }
             }
         }
     }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -44,8 +44,8 @@ pub fn set_background(background: &str) {
 
 #[derive(PartialEq)]
 enum UIState {
-    Initing,    // Running init.vim/lua
-    Ready,      // No pending resizes
+    Initing, // Running init.vim/lua
+    Ready,   // No pending resizes
 }
 
 pub struct WinitWindowWrapper {
@@ -337,7 +337,7 @@ impl WinitWindowWrapper {
             should_render = true;
 
             self.windowed_context.window().set_visible(true);
-            if SETTINGS.get::<CmdLineSettings>().maximized
+            if SETTINGS.get::<CmdLineSettings>().geometry.maximized
                 || matches!(
                     load_last_window_settings().ok(),
                     Some(PersistentWindowSettings::Maximized)

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -47,7 +47,7 @@ Can be set to:
 
 Sets the initial neovide window size in pixels.
 
-Can not be used together with `--maximized`, or `--geometry`.
+Can not be used together with `--maximized`, or `--grid`.
 
 ### Maximized
 
@@ -61,22 +61,23 @@ visible.
 This is not the same as `g:neovide_fullscreen`, which runs Neovide in "exclusive fullscreen",
 covering up the entire screen.
 
-Can not be used together with `--size`, or `--geometry`.
+Can not be used together with `--size`, or `--grid`.
 
-### Geometry
-**Unreleased-yet**
+### Grid Size
 
 ```sh
---geometry [<columns>x<lines>]
+--grid [<columns>x<lines>]
 
 ```
+
+**Unreleased-yet.**
 
 Sets the initial grid size of the window. If no value is given, it defaults to
 columns/lines from `init.vim/lua`, see
 [columns](https://neovim.io/doc/user/options.html#'columns') and
-[lines](https://neovim.io/doc/user/options.html#'lines'). 
+[lines](https://neovim.io/doc/user/options.html#'lines').
 
-If the `--geometry` argument is not set then the geometry is inferred from the
+If the `--grid` argument is not set then the grid size is inferred from the
 window size.
 
 Note: After the initial size has been determined and `init.vim/lua` processed,

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -47,14 +47,7 @@ Can be set to:
 
 Sets the initial neovide window size in pixels.
 
-### Log File
-
-```sh
---log
-```
-
-Enables the log file for debugging purposes. This will write a file next to the executable
-containing trace events which may help debug an issue.
+Can not be used together with `--maximized`, or `--geometry`.
 
 ### Maximized
 
@@ -67,6 +60,43 @@ visible.
 
 This is not the same as `g:neovide_fullscreen`, which runs Neovide in "exclusive fullscreen",
 covering up the entire screen.
+
+Can not be used together with `--size`, or `--geometry`.
+
+### Geometry
+**Unreleased-yet**
+
+```sh
+--geometry [<columns>x<lines>]
+
+```
+
+Sets the initial grid size of the window. If no value is given, it defaults to
+columns/lines from `init.vim/lua`, see
+[columns](https://neovim.io/doc/user/options.html#'columns') and
+[lines](https://neovim.io/doc/user/options.html#'lines'). 
+
+If the `--geometry` argument is not set then the geometry is inferred from the
+window size.
+
+Note: After the initial size has been determined and `init.vim/lua` processed,
+you can set [columns](https://neovim.io/doc/user/options.html#'columns') and
+[lines](https://neovim.io/doc/user/options.html#'lines') inside neovim
+regardless of the command line arguments used. This has to be done before any
+redraws are made, so it's recommended to put it at the start of the
+`init.vim/lua` along with `guifont` and other related settings that can affect
+the geometry.
+
+Can not be used together with `--size`, or `--maximized`.
+
+### Log File
+
+```sh
+--log
+```
+
+Enables the log file for debugging purposes. This will write a file next to the executable
+containing trace events which may help debug an issue.
 
 ### Multigrid
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* Fixes the window not showing up when there are error messages or `lazy.nvim` is updating for example. This was reported by @9mm here https://github.com/neovide/neovide/pull/2035#issuecomment-1732360990
* The initial size can now be specified by `--grid`, if a size is given then that's used, otherwise the grid will be read from `init.vim/lua`
* The arguments `--size`, `--maximized` and `--grid` are now mutually exclusive

The implementation is a bit hackier than I would want and shows the window when `win_viewport` or `grid_line` is recieved. This is due to the neovim limitations discussed here:
* https://github.com/neovim/neovim/issues/25377

And the main reason for supporting an empty `--grid` argument is because of this:
* https://github.com/neovim/neovim/issues/25378

**NOTE:** Includes the changes from, so they should be reviewed and merged first
* https://github.com/neovide/neovide/pull/2035

## Did this PR introduce a breaking change? 
* Yes, `--geometry` has been renamed to `--grid`. But this argument was not documented and does not work properly in our release versions.