### PR TITLE
Fix config change notification using remote neovim

### DIFF
--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -153,7 +153,7 @@ pub async fn setup_neovide_specific_state(
         .ok();
 
     // Create auto command for retrieving exit code from neovim on quit.
-    nvim.command("autocmd VimLeave * call rpcnotify(1, 'neovide.quit', v:exiting)")
+    nvim.command("autocmd VimLeave * call rpcnotify(g:neovide_channel_id, 'neovide.quit', v:exiting)")
         .await
         .ok();
 

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -153,9 +153,11 @@ pub async fn setup_neovide_specific_state(
         .ok();
 
     // Create auto command for retrieving exit code from neovim on quit.
-    nvim.command("autocmd VimLeave * call rpcnotify(g:neovide_channel_id, 'neovide.quit', v:exiting)")
-        .await
-        .ok();
+    nvim.command(
+        "autocmd VimLeave * call rpcnotify(g:neovide_channel_id, 'neovide.quit', v:exiting)",
+    )
+    .await
+    .ok();
 
     setup_intro_message_autocommand(nvim).await.ok();
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -112,7 +112,7 @@ impl Settings {
                 concat!(
                     "exe \"",
                     "fun! NeovideNotify{0}Changed(d, k, z)\n",
-                    "call rpcnotify(1, 'setting_changed', '{0}', g:neovide_{0})\n",
+                    "call rpcnotify(g:neovide_channel_id, 'setting_changed', '{0}', g:neovide_{0})\n",
                     "endf\n",
                     "call dictwatcheradd(g:, 'neovide_{0}', 'NeovideNotify{0}Changed')\"",
                 ),


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix

## Did this PR introduce a breaking change? 

_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

## Background

I got the error below connecting remote neovim on my machine.

```console
Error detected while processing function NeovideNotifycursor_animation_lengthChanged:
line     1:
E475: Invalid argument: Channel doesn't exist.
```

<img width="816" alt="スクリーンショット 2023-10-06 19 23 09" src="https://github.com/neovide/neovide/assets/1330045/fa22e7cd-ca01-4f61-8f8a-3b37f44c7bdd">

`g:neovide_channel_id` has 3 in my environment.
But the embedded Vim script always uses 1.

## What I did

This PR just makes it use `g:neovide_channel_id`.
I don't know how to write the tests.
Please tell me where I should put the tests or merge the PR and add tests in another PR 🙏 

## How to reproduce

macOS Monterey 12.6.7

```console
> /opt/homebrew/bin/nvim --version
NVIM v0.9.2
Build type: Release
LuaJIT 2.1.0-beta3

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/opt/homebrew/Cellar/neovim/0.9.2/share/nvim"

Run :checkhealth for more info

> /opt/homebrew/bin/nvim --headless --listen localhost:6666 -u NONE
```

```console
> neovide --version
neovide 0.11.2

> neovide --server=localhost:6666
```

Change a neovide config via command line mode on neovide started above.
```vim
let g:neovide_scroll_animation_length = 0.3
```

Then, neovide causes the error.