### PR TITLE
fix!: Report errors at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -215,7 +215,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.37",
+ "syn 2.0.38",
  "which",
 ]
 
@@ -289,9 +289,9 @@ checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -411,7 +411,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -875,7 +875,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1229,9 +1229,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -1637,7 +1637,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1866,7 +1866,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1895,7 +1895,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1972,7 +1972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
 dependencies = [
  "unicode-ident",
 ]
@@ -2197,9 +2197,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.15"
+version = "0.38.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
+checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2309,7 +2309,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2354,7 +2354,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2417,9 +2417,11 @@ version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fb5ab010b9e90ab2d639650ddb2cba6bfad6d8742f93131968de865abc2c4a"
 dependencies = [
+ "base64",
  "bitflags 2.4.0",
  "lazy_static",
  "skia-bindings",
+ "ureq",
 ]
 
 [[package]]
@@ -2566,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2609,7 +2611,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2708,7 +2710,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2904,7 +2906,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -2938,7 +2940,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3369,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,7 @@ dependencies = [
  "simple_moving_average",
  "skia-safe",
  "spin_sleep",
+ "strum",
  "swash",
  "time",
  "tokio",
@@ -2544,6 +2545,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "swash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,11 +2421,9 @@ version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fb5ab010b9e90ab2d639650ddb2cba6bfad6d8742f93131968de865abc2c4a"
 dependencies = [
- "base64",
  "bitflags 2.4.0",
  "lazy_static",
  "skia-bindings",
- "ureq",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -671,23 +671,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -800,6 +789,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "fork"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2ca97a59201425e7ee4d197c9c4fea282fe87a97d666a580bda889b95b8e88"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1190,9 +1188,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
@@ -1258,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
@@ -1429,6 +1427,7 @@ dependencies = [
  "dirs",
  "euclid",
  "flexi_logger",
+ "fork",
  "futures 0.3.28",
  "gl",
  "glutin",
@@ -1606,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -1991,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2124,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2136,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2147,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "ring"
@@ -2201,9 +2200,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2698,9 +2697,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
@@ -3147,12 +3146,11 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19353897b48e2c4d849a2d73cb0aeb16dc2be4e00c565abfc11eb65a806e47de"
+checksum = "8208e3fdbc243c8fd30805721869242a7f6de3e2e9f3b057652ab36e52ae1e87"
 dependencies = [
  "js-sys",
- "once_cell",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,9 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5110f1c78cf582855d895ecd0746b653db010cec6d9f5575293f27934d980a39"
+checksum = "b1061f3ff92c2f65800df1f12fc7b4ff44ee14783104187dd04dfee6f11b0fd2"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -82,9 +82,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -96,15 +96,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -120,13 +120,19 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arrayref"
@@ -159,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-waker"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -376,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.4"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -386,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.4"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -577,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -633,7 +639,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.0",
+ "libloading 0.8.1",
 ]
 
 [[package]]
@@ -662,9 +668,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1052,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -1114,12 +1120,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -1239,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -1249,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "lock_api"
@@ -1289,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
@@ -1408,6 +1414,7 @@ dependencies = [
 name = "neovide"
 version = "0.11.2"
 dependencies = [
+ "anyhow",
  "async-trait",
  "backtrace",
  "cfg-if",
@@ -2113,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2125,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2190,9 +2197,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2209,18 +2216,8 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.6",
+ "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -2597,18 +2594,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2635,9 +2632,9 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tiny-skia"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e37fdc219ee3d551882d24dc5e4df5f72fd9723cbca1ffaa57f7348bf7a47d"
+checksum = "3b72a92a05db376db09fe6d50b7948d106011761c05a6a45e23e17ee9b556222"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -2649,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a323d1de20dad9bc8b32daf57702c585ce76e80792d8151de1fc9dfc8d1ca7"
+checksum = "6ac3865b9708fc7e1961a65c3a4fa55e984272f33092d3c859929f887fceb647"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2821,16 +2818,16 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
 dependencies = [
  "base64",
  "flate2",
  "log",
  "once_cell",
  "rustls",
- "rustls-webpki 0.100.3",
+ "rustls-webpki",
  "url",
  "webpki-roots",
 ]
@@ -3135,12 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.23.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.3",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
@@ -3516,6 +3510,6 @@ checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
 
 [[package]]
 name = "zeno"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c110ba09c9b3a43edd4803d570df0da2414fed6e822e22b976a4e3ef50860701"
+checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 shlex = "1.1.0"
 simple_moving_average = "0.1.2"
+skia-safe = { version = "0.62.0", features = ["gl", "textlayout"] }
 spin_sleep = "1.1.1"
 strum = { version = "0.25.0", features = ["derive"] }
 swash = "0.1.8"
@@ -70,19 +71,16 @@ serial_test = "2.0.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 # NOTE: winerror is only needed because the indirect dependency parity-tokio-ipc does not set it even if it uses it
 winapi = { version = "0.3.9", features = ["winuser", "wincon", "winerror", "dwmapi"] }
-skia-safe = { version = "0.62.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"
 objc = "0.2.7"
-skia-safe = { version = "0.62.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.26.2", features = ["poll"] }
 wayland-client = "0.30.2"
 wayland-sys = "0.30.1"
 wayland-backend = "0.1.2"
-skia-safe = { version = "0.62.0", features = ["egl", "gl", "svg", "textlayout", "wayland", "x11"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ profiling = ["dep:tracy-client-sys"]
 gpu_profiling = ["profiling"]
 
 [dependencies]
+anyhow = "1.0.75"
 async-trait = "0.1.53"
 backtrace = "0.3.67"
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,11 @@ winapi = { version = "0.3.9", features = ["winuser", "wincon", "winerror", "dwma
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"
+fork = "0.1.22"
 objc = "0.2.7"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+fork = "0.1.22"
 nix = { version = "0.26.2", features = ["poll"] }
 wayland-client = "0.30.2"
 wayland-sys = "0.30.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,35 +66,25 @@ mockall = "0.11.0"
 scoped-env = "2.1.0"
 serial_test = "2.0.0"
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 # NOTE: winerror is only needed because the indirect dependency parity-tokio-ipc does not set it even if it uses it
 winapi = { version = "0.3.9", features = ["winuser", "wincon", "winerror", "dwmapi"] }
+skia-safe = { version = "0.62.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"
 objc = "0.2.7"
+skia-safe = { version = "0.62.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.26.2", features = ["poll"] }
 wayland-client = "0.30.2"
 wayland-sys = "0.30.1"
 wayland-backend = "0.1.2"
+skia-safe = { version = "0.62.0", features = ["egl", "gl", "svg", "textlayout", "wayland", "x11"] }
 
-[target.'cfg(windows)'.build-dependencies]
+[target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1.12"
-
-[target.'cfg(windows)'.dependencies.skia-safe]
-# NOTE: Including textlayout for pre-built binaries
-features = ["gl", "textlayout"]
-version = "0.62.0"
-
-[target.'cfg(linux)'.dependencies.skia-safe]
-features = ["egl", "gl", "textlayout", "wayland", "x11"]
-version = "0.62.0"
-
-[target.'cfg(not(linux))'.dependencies.skia-safe]
-features = ["gl"]
-version = "0.62.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ profiling = ["dep:tracy-client-sys"]
 gpu_profiling = ["profiling"]
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = { version = "1.0.75", features = ["backtrace"] }
 async-trait = "0.1.53"
 backtrace = "0.3.67"
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serde_json = "1.0.79"
 shlex = "1.1.0"
 simple_moving_average = "0.1.2"
 spin_sleep = "1.1.1"
+strum = { version = "0.25.0", features = ["derive"] }
 swash = "0.1.8"
 time = "0.3.9"
 tokio = { version = "1.25.0", features = ["full"] }

--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -7,7 +7,7 @@ pub fn setting_group(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
     let prefix = setting_prefix(input.attrs.as_ref())
         .map(|p| format!("{p}_"))
-        .unwrap_or_else(|| "".to_string());
+        .unwrap_or_default();
     stream(input, prefix)
 }
 

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -1,15 +1,16 @@
 use std::{
-    env, eprintln,
+    env,
     process::{Command as StdCommand, Stdio},
 };
 
+use anyhow::{bail, Result};
 use log::debug;
 use tokio::process::Command as TokioCommand;
 
 use crate::{cmd_line::CmdLineSettings, settings::*};
 
-pub fn create_nvim_command() -> TokioCommand {
-    let mut cmd = build_nvim_cmd();
+pub fn create_nvim_command() -> Result<TokioCommand> {
+    let mut cmd = build_nvim_cmd()?;
 
     debug!("Starting neovim with: {:?}", cmd);
 
@@ -22,7 +23,7 @@ pub fn create_nvim_command() -> TokioCommand {
     #[cfg(windows)]
     set_windows_creation_flags(&mut cmd);
 
-    cmd
+    Ok(cmd)
 }
 
 #[cfg(target_os = "windows")]
@@ -30,21 +31,19 @@ fn set_windows_creation_flags(cmd: &mut TokioCommand) {
     cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
 }
 
-fn build_nvim_cmd() -> TokioCommand {
+fn build_nvim_cmd() -> Result<TokioCommand> {
     if let Some(cmdline) = SETTINGS.get::<CmdLineSettings>().neovim_bin {
-        if let Some((bin, args)) = lex_nvim_cmdline(&cmdline) {
-            return build_nvim_cmd_with_args(bin, args);
+        if let Some((bin, args)) = lex_nvim_cmdline(&cmdline)? {
+            return Ok(build_nvim_cmd_with_args(bin, args));
         }
 
-        eprintln!("ERROR: NEOVIM_BIN='{}' was not found.", cmdline);
-        std::process::exit(1);
+        bail!("ERROR: NEOVIM_BIN='{}' was not found.", cmdline);
     } else if let Some(path) = platform_which("nvim") {
-        if neovim_ok(&path, &[]) {
-            return build_nvim_cmd_with_args(path, vec![]);
+        if neovim_ok(&path, &[])? {
+            return Ok(build_nvim_cmd_with_args(path, vec![]));
         }
     }
-    eprintln!("ERROR: nvim not found!");
-    std::process::exit(1);
+    bail!("ERROR: nvim not found!")
 }
 
 // Creates a shell command if needed on this platform (wsl or macos)
@@ -79,7 +78,7 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> StdCommand {
     }
 }
 
-fn neovim_ok(bin: &str, args: &[String]) -> bool {
+fn neovim_ok(bin: &str, args: &[String]) -> Result<bool> {
     let is_wsl = SETTINGS.get::<CmdLineSettings>().wsl;
     let mut args = args.iter().map(String::as_str).collect::<Vec<_>>();
     args.push("-v");
@@ -102,29 +101,33 @@ fn neovim_ok(bin: &str, args: &[String]) -> bool {
                 );
 
                 if is_wsl {
-                    eprintln!("{error_message_prefix}wsl '$SHELL' -lc '{bin} -v'");
+                    bail!("{error_message_prefix}wsl '$SHELL' -lc '{bin} -v'");
                 } else {
-                    eprintln!("{error_message_prefix}$SHELL -lc '{bin} -v'");
+                    bail!("{error_message_prefix}$SHELL -lc '{bin} -v'");
                 }
-                std::process::exit(1);
             }
-            return true;
+            return Ok(true);
         }
     }
-    false
+    Ok(false)
 }
 
-fn lex_nvim_cmdline(cmdline: &str) -> Option<(String, Vec<String>)> {
-    let mut tokens = shlex::split(cmdline).filter(|t| !t.is_empty())?;
-    let (mut bin, args) = (tokens.remove(0), tokens);
-
-    // if neovim_bin contains a path separator, then try to launch it directly
-    // otherwise use which to find the fully path
-    if !bin.contains('/') && !bin.contains('\\') {
-        bin = platform_which(&bin)?;
-    }
-
-    neovim_ok(&bin, &args).then_some((bin, args))
+fn lex_nvim_cmdline(cmdline: &str) -> Result<Option<(String, Vec<String>)>> {
+    shlex::split(cmdline)
+        .filter(|t| !t.is_empty())
+        .map(|mut tokens| (tokens.remove(0), tokens))
+        .and_then(|(bin, args)| {
+            // if neovim_bin contains a path separator, then try to launch it directly
+            // otherwise use which to find the full path
+            if !bin.contains('/') && !bin.contains('\\') {
+                platform_which(&bin).map(|bin| (bin, args))
+            } else {
+                Some((bin, args))
+            }
+        })
+        .map_or(Ok(None), |(bin, args)| {
+            neovim_ok(&bin, &args).map(|res| res.then_some((bin, args)))
+        })
 }
 
 fn platform_which(bin: &str) -> Option<String> {

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -86,7 +86,7 @@ async fn launch(grid_size: Option<Dimensions>) -> Result<NeovimSession> {
     let settings = SETTINGS.get::<CmdLineSettings>();
 
     let should_handle_clipboard = settings.wsl || settings.server.is_some();
-    setup_neovide_specific_state(&session.neovim, should_handle_clipboard).await;
+    setup_neovide_specific_state(&session.neovim, should_handle_clipboard).await?;
 
     start_ui_command_handler(Arc::clone(&session.neovim));
     SETTINGS.read_initial_values(&session.neovim).await;

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -6,7 +6,7 @@ pub mod session;
 mod setup;
 mod ui_commands;
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use log::{error, info};
 use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
 use std::{io::Error, process::exit, sync::Arc};
@@ -74,7 +74,7 @@ async fn launch() -> Result<NeovimSession> {
     let handler = NeovimHandler::new();
     let session = NeovimSession::new(neovim_instance, handler)
         .await
-        .unwrap_or_explained_panic("Could not locate or start neovim process");
+        .context("Could not locate or start neovim process")?;
 
     // Check the neovim version to ensure its high enough
     match session
@@ -85,8 +85,7 @@ async fn launch() -> Result<NeovimSession> {
     {
         Ok("1") => {} // This is just a guard
         _ => {
-            error!("Neovide requires nvim version {NEOVIM_REQUIRED_VERSION} or higher. Download the latest version here https://github.com/neovim/neovim/wiki/Installing-Neovim");
-            exit(0);
+            bail!("Neovide requires nvim version {NEOVIM_REQUIRED_VERSION} or higher. Download the latest version here https://github.com/neovim/neovim/wiki/Installing-Neovim");
         }
     }
     let settings = SETTINGS.get::<CmdLineSettings>();

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -89,8 +89,8 @@ async fn launch(grid_size: Option<Dimensions>) -> Result<NeovimSession> {
     setup_neovide_specific_state(&session.neovim, should_handle_clipboard).await?;
 
     start_ui_command_handler(Arc::clone(&session.neovim));
-    SETTINGS.read_initial_values(&session.neovim).await;
-    SETTINGS.setup_changed_listeners(&session.neovim).await;
+    SETTINGS.read_initial_values(&session.neovim).await?;
+    SETTINGS.setup_changed_listeners(&session.neovim).await?;
 
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 use clap::{builder::FalseyValueParser, ArgAction, Parser};
 
 #[cfg(target_os = "windows")]
-const SRGB_DEFAULT: &str = "1";
+pub const SRGB_DEFAULT: &str = "1";
 #[cfg(not(target_os = "windows"))]
-const SRGB_DEFAULT: &str = "0";
+pub const SRGB_DEFAULT: &str = "0";
 
 #[derive(Clone, Debug, Parser)]
 #[command(version, about, long_about = None)]

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -2,6 +2,7 @@ use std::{iter, mem};
 
 use crate::{dimensions::Dimensions, frame::Frame, settings::*};
 
+use anyhow::Result;
 use clap::{builder::FalseyValueParser, ArgAction, Parser};
 
 #[cfg(target_os = "windows")]
@@ -137,8 +138,8 @@ impl Default for CmdLineSettings {
     }
 }
 
-pub fn handle_command_line_arguments(args: Vec<String>) -> Result<(), String> {
-    let mut cmdline = CmdLineSettings::parse_from(args);
+pub fn handle_command_line_arguments(args: Vec<String>) -> Result<()> {
+    let mut cmdline = CmdLineSettings::try_parse_from(args)?;
 
     // The neovim_args in cmdline are unprocessed, actually add options to it
     let maybe_tab_flag = (!cmdline.no_tabs).then(|| "-p".to_string());

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -52,9 +52,15 @@ fn handle_terminal_startup_errors(err: Error) -> i32 {
     }
 }
 
-fn handle_gui_startup_errors(_err: Error, event_loop: EventLoop<UserEvent>) -> i32 {
-    show_error_window("Hello World", event_loop);
-    1
+fn handle_gui_startup_errors(err: Error, event_loop: EventLoop<UserEvent>) -> i32 {
+    if let Some(clap_error) = err.downcast_ref::<ClapError>() {
+        let text = clap_error.render().to_string();
+        show_error_window(&text, event_loop);
+        clap_error.exit_code()
+    } else {
+        eprintln!("ERROR: {}", err);
+        1
+    }
 }
 
 pub fn handle_startup_errors(err: Error, event_loop: EventLoop<UserEvent>) -> i32 {

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -50,7 +50,13 @@ impl<T> OptionPanicExplanation<T> for Option<T> {
 }
 
 fn format_and_log_error_message(err: Error) -> String {
-    let msg = format!("{:?}", err);
+    let msg = format!("\
+Neovide just crashed :(
+This is the error that caused the crash. In case you don't know what to do with this, please feel free to report this on https://github.com/neovide/neovide/issues!
+
+{:?}",
+        err
+    );
     log::error!("{}", msg);
     msg
 }

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -42,12 +42,18 @@ impl<T> OptionPanicExplanation<T> for Option<T> {
     }
 }
 
+fn format_and_log_error_message(err: Error) -> String {
+    let msg = format!("{:?}", err);
+    log::error!("{}", msg);
+    msg
+}
+
 fn handle_terminal_startup_errors(err: Error) -> i32 {
     if let Some(clap_error) = err.downcast_ref::<ClapError>() {
         let _ = clap_error.print();
         clap_error.exit_code()
     } else {
-        eprintln!("ERROR: {}", err);
+        eprintln!("{}", &format_and_log_error_message(err));
         1
     }
 }
@@ -58,8 +64,7 @@ fn handle_gui_startup_errors(err: Error, event_loop: EventLoop<UserEvent>) -> i3
         show_error_window(&text, event_loop);
         clap_error.exit_code()
     } else {
-        let msg = format!("{:?}", err);
-        show_error_window(&msg, event_loop);
+        show_error_window(&format_and_log_error_message(err), event_loop);
         1
     }
 }

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -1,3 +1,5 @@
+use anyhow::Error;
+use clap::error::Error as ClapError;
 use log::error;
 
 fn show_error(explanation: &str) -> ! {
@@ -33,5 +35,15 @@ impl<T> OptionPanicExplanation<T> for Option<T> {
             }
             Some(content) => content,
         }
+    }
+}
+
+pub fn handle_startup_errors(err: Error) -> i32 {
+    if let Some(clap_error) = err.downcast_ref::<ClapError>() {
+        let _ = clap_error.print();
+        clap_error.exit_code()
+    } else {
+        eprintln!("ERROR: {}", err);
+        1
     }
 }

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -58,7 +58,7 @@ fn handle_gui_startup_errors(err: Error, event_loop: EventLoop<UserEvent>) -> i3
         show_error_window(&text, event_loop);
         clap_error.exit_code()
     } else {
-        eprintln!("ERROR: {}", err);
+        show_error_window(&err.to_string(), event_loop);
         1
     }
 }

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -58,7 +58,8 @@ fn handle_gui_startup_errors(err: Error, event_loop: EventLoop<UserEvent>) -> i3
         show_error_window(&text, event_loop);
         clap_error.exit_code()
     } else {
-        show_error_window(&err.to_string(), event_loop);
+        let msg = format!("{:?}", err);
+        show_error_window(&msg, event_loop);
         1
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ extern crate derive_new;
 extern crate lazy_static;
 
 use anyhow::Result;
+use clap::error::Error as ClapError;
 use log::trace;
 use std::env::{self, args};
 use std::fs::{File, OpenOptions};
@@ -83,8 +84,13 @@ fn main() -> ExitCode {
 
     match setup() {
         Err(err) => {
-            eprintln!("ERROR: {}", err);
-            1
+            if let Some(clap_error) = err.downcast_ref::<ClapError>() {
+                let _ = clap_error.print();
+                clap_error.exit_code() as u8
+            } else {
+                eprintln!("ERROR: {}", err);
+                1
+            }
         }
         Ok((window, window_size, event_loop)) => {
             maybe_disown();

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn main() -> ExitCode {
     let event_loop = create_event_loop();
 
     match setup() {
-        Err(err) => handle_startup_errors(err) as u8,
+        Err(err) => handle_startup_errors(err, event_loop) as u8,
         Ok((window_size, _runtime)) => {
             maybe_disown();
             start_editor();

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ fn setup() -> Result<(WindowSize, NeovimRuntime)> {
     let window_size = determine_window_size();
 
     let mut runtime = NeovimRuntime::new()?;
-    runtime.launch();
+    runtime.launch()?;
     let grid_size = match window_size {
         WindowSize::Grid(grid_size) => Some(grid_size),
         _ => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(not(test), windows_subsystem = "windows")]
 // Test naming occasionally uses camelCase with underscores to separate sections of
 // the test name.
 #![cfg_attr(test, allow(non_snake_case))]
@@ -83,7 +83,6 @@ fn main() -> NeovideExitCode {
     #[cfg(target_os = "windows")]
     {
         windows_fix_dpi();
-        windows_attach_to_console();
     }
 
     let event_loop = create_event_loop();
@@ -167,6 +166,7 @@ fn setup() -> Result<(WindowSize, NeovimRuntime)> {
 
     //Will exit if -h or -v
     cmd_line::handle_command_line_arguments(args().collect())?;
+    #[cfg(not(target_os = "windows"))]
     maybe_disown();
     startup_profiler();
 
@@ -210,8 +210,10 @@ pub fn init_logger() {
     logger.start().expect("Could not start logger");
 }
 
+#[cfg(not(target_os = "windows"))]
 fn maybe_disown() {
-    use std::process;
+    use fork::{daemon, Fork};
+    use std::process::exit;
 
     let settings = SETTINGS.get::<CmdLineSettings>();
 
@@ -219,21 +221,16 @@ fn maybe_disown() {
         return;
     }
 
-    #[cfg(target_os = "windows")]
-    windows_detach_from_console();
-
-    if let Ok(current_exe) = env::current_exe() {
-        assert!(process::Command::new(current_exe)
-            .stdin(process::Stdio::null())
-            .stdout(process::Stdio::null())
-            .stderr(process::Stdio::null())
-            .arg("--no-fork")
-            .args(env::args().skip(1))
-            .spawn()
-            .is_ok());
-        process::exit(0);
-    } else {
-        eprintln!("error in disowning process, cannot obtain the path for the current executable, continuing without disowning...");
+    let nochdir = true;
+    let noclose = false;
+    match daemon(nochdir, noclose) {
+        Ok(Fork::Child) => {}
+        Ok(Fork::Parent(_)) => {
+            exit(0);
+        }
+        Err(_) => {
+            eprintln!("error in disowning process, cannot obtain the path for the current executable, continuing without disowning...");
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,6 @@ fn main() -> NeovideExitCode {
 
         log_panic_to_file(panic_info, &backtrace);
     }));
-    startup_profiler();
 
     #[cfg(target_os = "windows")]
     {
@@ -92,7 +91,6 @@ fn main() -> NeovideExitCode {
     match setup() {
         Err(err) => handle_startup_errors(err, event_loop).into(),
         Ok((window_size, _runtime)) => {
-            maybe_disown();
             start_editor();
             let window = create_window(&event_loop, &window_size);
             main_loop(window, window_size, event_loop).into()
@@ -169,6 +167,8 @@ fn setup() -> Result<(WindowSize, NeovimRuntime)> {
 
     //Will exit if -h or -v
     cmd_line::handle_command_line_arguments(args().collect())?;
+    maybe_disown();
+    startup_profiler();
 
     #[cfg(not(test))]
     init_logger();

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,15 +190,12 @@ fn setup() -> Result<(WindowSize, NeovimRuntime)> {
     CursorSettings::register();
     KeyboardSettings::register();
     let window_size = determine_window_size();
-
-    let mut runtime = NeovimRuntime::new()?;
-    runtime.launch()?;
     let grid_size = match window_size {
         WindowSize::Grid(grid_size) => Some(grid_size),
         _ => None,
     };
-
-    runtime.attach(grid_size);
+    let mut runtime = NeovimRuntime::new()?;
+    runtime.launch(grid_size)?;
     Ok((window_size, runtime))
 }
 

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -5,8 +5,6 @@ use std::{
     num::NonZeroU32,
 };
 
-use crate::cmd_line::CmdLineSettings;
-
 use gl::MAX_RENDERBUFFER_SIZE;
 use glutin::surface::SwapInterval;
 use glutin::{
@@ -96,7 +94,7 @@ pub fn build_window<TE>(
     GlWindow { window, config }
 }
 
-pub fn build_context(window: GlWindow, cmd_line_settings: &CmdLineSettings) -> Context {
+pub fn build_context(window: GlWindow, srgb: bool, vsync: bool) -> Context {
     let config = window.config;
     let window = window.window;
     let gl_display = config.display();
@@ -105,7 +103,7 @@ pub fn build_context(window: GlWindow, cmd_line_settings: &CmdLineSettings) -> C
     let size = clamp_render_buffer_size(window.inner_size());
 
     let surface_attributes = SurfaceAttributesBuilder::<WindowSurface>::new()
-        .with_srgb(Some(cmd_line_settings.srgb))
+        .with_srgb(Some(srgb))
         .build(
             raw_window_handle,
             NonZeroU32::new(size.width).unwrap(),
@@ -125,7 +123,7 @@ pub fn build_context(window: GlWindow, cmd_line_settings: &CmdLineSettings) -> C
     // NOTE: We don't care if these fails, the driver can override the SwapInterval in any case, so it needs to work in all cases
     // The OpenGL VSync is always disabled on Wayland and Windows, since they have their own
     // implementation
-    let _ = if cmd_line_settings.vsync && env::var("WAYLAND_DISPLAY").is_err() && OS != "windows" {
+    let _ = if vsync && env::var("WAYLAND_DISPLAY").is_err() && OS != "windows" {
         surface.set_swap_interval(&context, SwapInterval::Wait(NonZeroU32::new(1).unwrap()))
     } else {
         surface.set_swap_interval(&context, SwapInterval::DontWait)

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -256,7 +256,7 @@ mod tests {
         //TODO: this sets a static variable. Can this have side effects on other tests?
         SETTINGS.set::<CmdLineSettings>(&CmdLineSettings::default());
 
-        let instance = NeovimInstance::Embedded(create_nvim_command());
+        let instance = NeovimInstance::Embedded(create_nvim_command()?);
         let NeovimSession { neovim: nvim, .. } = NeovimSession::new(instance, NeovimHandler())
             .await
             .unwrap_or_explained_panic("Could not locate or start the neovim process");

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -182,10 +182,8 @@ impl<'a> ErrorWindow<'a> {
     }
 
     fn render(&mut self) {
-        let size = Size::new(self.size.width as f32, self.size.height as f32);
         let (message_rect, help_message_rect) = self.layout();
 
-        self.paragraphs.message.layout(size.width - 2.0 * PADDING);
         let (offset, possible_scroll_direction) =
             self.handle_scrolling(message_rect.height() as f64);
 

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -29,8 +29,8 @@ const BACKGROUND_COLOR: Color4f = BLACK;
 const FONT_SIZE: f32 = 12.0 * 96.0 / 72.0;
 const PADDING: f32 = 10.0;
 const MAX_LINES: i32 = 9999;
-const MIN_SIZE: PhysicalSize<u32> = PhysicalSize::new(800, 600);
-const DEFAULT_SIZE: PhysicalSize<u32> = PhysicalSize::new(500, 500);
+const MIN_SIZE: PhysicalSize<u32> = PhysicalSize::new(500, 500);
+const DEFAULT_SIZE: PhysicalSize<u32> = PhysicalSize::new(800, 600);
 
 pub fn show_error_window(message: &str, event_loop: EventLoop<UserEvent>) {
     let mut error_window = ErrorWindow::new(message, &event_loop);
@@ -481,8 +481,8 @@ fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
         .with_transparent(false)
         .with_visible(false)
         .with_decorations(true)
-        .with_inner_size(MIN_SIZE)
-        .with_min_inner_size(DEFAULT_SIZE);
+        .with_inner_size(DEFAULT_SIZE)
+        .with_min_inner_size(MIN_SIZE);
 
     build_window(winit_window_builder, event_loop)
 }

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -1,14 +1,21 @@
 use skia_safe::{
-    textlayout::{FontCollection, ParagraphBuilder, ParagraphStyle, TextStyle},
-    Color, Color4f, FontMgr, Paint, Point,
+    canvas::SaveLayerRec,
+    colors::{BLACK, WHITE},
+    textlayout::{
+        FontCollection, Paragraph, ParagraphBuilder, ParagraphStyle, TextHeightBehavior, TextIndex,
+        TextStyle,
+    },
+    Color4f, FontMgr, Paint, Point, Rect, Size,
 };
 #[cfg(target_os = "linux")]
 use std::env;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS;
 use winit::{
-    event::{Event, WindowEvent},
-    event_loop::EventLoop,
+    dpi::PhysicalSize,
+    event::{ElementState, Event, KeyEvent, Modifiers, WindowEvent},
+    event_loop::{EventLoop, EventLoopWindowTarget},
+    keyboard::Key,
     window::WindowBuilder,
 };
 
@@ -18,47 +25,301 @@ use crate::{
     window::{load_icon, SkiaRenderer, UserEvent},
 };
 
+const TEXT_COLOR: Color4f = WHITE;
+const BACKGROUND_COLOR: Color4f = BLACK;
+const FONT_SIZE: f32 = 12.0 * 96.0 / 72.0;
+const PADDING: f32 = 10.0;
+const MAX_LINES: i32 = 9999;
+
 pub fn show_error_window(message: &str, event_loop: EventLoop<UserEvent>) {
-    let font_manager = FontMgr::new();
-    let mut font_collection = FontCollection::new();
-    font_collection.set_default_font_manager(Some(font_manager), None);
+    let mut error_window = ErrorWindow::new(message, &event_loop);
+    error_window.run_event_loop(event_loop);
+}
 
-    let srgb = SRGB_DEFAULT == "1";
-    let vsync = true;
-    let window = create_window(&event_loop);
-    let context = build_context(window, srgb, vsync);
-    let mut scale_factor = context.window().scale_factor();
-    let mut skia_renderer = SkiaRenderer::new(&context);
+#[derive(Debug)]
+enum Scroll {
+    None,
+    Line(i32),
+    Page(f32),
+    Start,
+    End,
+}
 
-    let _ = event_loop.run(move |e, window_target| match e {
-        Event::LoopExiting => {}
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            ..
-        } => {
-            window_target.exit();
+struct ErrorWindow<'a> {
+    skia_renderer: SkiaRenderer,
+    context: WindowedContext,
+    font_collection: FontCollection,
+    size: PhysicalSize<u32>,
+    scale_factor: f64,
+    paragraph: Paragraph,
+    message: &'a str,
+    scroll: Scroll,
+    current_position: TextIndex,
+    modifiers: Modifiers,
+}
+
+impl<'a> ErrorWindow<'a> {
+    fn new(message: &'a str, event_loop: &EventLoop<UserEvent>) -> Self {
+        let font_manager = FontMgr::new();
+        let mut font_collection = FontCollection::new();
+        font_collection.set_default_font_manager(Some(font_manager), None);
+
+        let srgb = SRGB_DEFAULT == "1";
+        let vsync = true;
+        let window = create_window(event_loop);
+        let context = build_context(window, srgb, vsync);
+        let scale_factor = context.window().scale_factor();
+        let size = context.window().inner_size();
+        let skia_renderer = SkiaRenderer::new(&context);
+        let paragraph = create_paragraph(message, scale_factor as f32, &font_collection);
+        let scroll = Scroll::None;
+        let current_position = 0;
+        let modifiers = Modifiers::default();
+
+        Self {
+            skia_renderer,
+            context,
+            font_collection,
+            size,
+            scale_factor,
+            paragraph,
+            message,
+            scroll,
+            current_position,
+            modifiers,
         }
-        Event::AboutToWait => {}
-        Event::WindowEvent {
-            event: WindowEvent::RedrawRequested,
-            ..
-        } => {
-            render(message, &mut skia_renderer, &context, &font_collection, scale_factor);
+    }
+
+    fn run_event_loop(&mut self, event_loop: EventLoop<UserEvent>) {
+        let _ = event_loop.run(move |e, window_target| {
+            if let Event::WindowEvent { event, .. } = e {
+                self.handle_window_event(event, window_target);
+            }
+        });
+    }
+
+    fn handle_window_event(
+        &mut self,
+        event: WindowEvent,
+        window_target: &EventLoopWindowTarget<UserEvent>,
+    ) {
+        match event {
+            WindowEvent::CloseRequested => {
+                window_target.exit();
+            }
+            WindowEvent::RedrawRequested => {
+                self.render();
+            }
+            WindowEvent::Resized(size) => {
+                self.size = size;
+                self.skia_renderer.resize(&self.context);
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                self.scale_factor = scale_factor;
+                self.paragraph =
+                    create_paragraph(self.message, scale_factor as f32, &self.font_collection);
+            }
+            WindowEvent::KeyboardInput {
+                event,
+                is_synthetic: false,
+                ..
+            } => {
+                if self.handle_keyboard_input(event, window_target) {
+                    self.context.window().request_redraw();
+                }
+            }
+            WindowEvent::ModifiersChanged(modifiers) => self.modifiers = modifiers,
+            _ => {}
         }
-        Event::WindowEvent {
-            event: WindowEvent::Resized(..),
-            ..
-        } => {
-            skia_renderer.resize(&context);
+    }
+
+    fn render(&mut self) {
+        let size = Size::new(self.size.width as f32, self.size.height as f32);
+        let padding_top_left = Point::new(PADDING, PADDING);
+        let rect = Rect::from_point_and_size(
+            padding_top_left,
+            Size::new(size.width - 2.0 * PADDING, size.height - 2.0 * PADDING),
+        );
+
+        self.paragraph.layout(size.width - 2.0 * PADDING);
+        let offset = self.handle_scrolling(rect.height() as f64);
+
+        let canvas = self.skia_renderer.canvas();
+        canvas.save();
+        canvas.clear(BACKGROUND_COLOR);
+
+        let save_layer_rec = SaveLayerRec::default().bounds(&rect);
+        canvas.save_layer(&save_layer_rec);
+        self.paragraph
+            .paint(canvas, Point::new(PADDING, PADDING - offset as f32));
+        canvas.restore();
+
+        canvas.restore();
+
+        self.skia_renderer.gr_context.flush_and_submit();
+        self.context.window().pre_present_notify();
+        self.context.swap_buffers().unwrap();
+    }
+
+    fn handle_keyboard_input(
+        &mut self,
+        event: KeyEvent,
+
+        window_target: &EventLoopWindowTarget<UserEvent>,
+    ) -> bool {
+        if event.state != ElementState::Pressed {
+            return false;
         }
-        Event::WindowEvent {
-            event: WindowEvent::ScaleFactorChanged { scale_factor: new_scale_factor, .. },
-            ..
-        } => {
-            scale_factor = new_scale_factor;
+        let handled = if self.modifiers.state().control_key() {
+            // Ctrl is pressed
+            match &event.logical_key {
+                Key::Character(c) => match c.as_str() {
+                    "e" => self.scroll_line(1),
+                    "y" => self.scroll_line(-1),
+                    "n" => self.scroll_line(1),
+                    _ => false,
+                },
+                _ => false,
+            }
+        } else {
+            // Ctrl is not pressed
+            match &event.logical_key {
+                Key::Character(c) => match c.as_str() {
+                    "j" => self.scroll_line(1),
+                    "g" => {
+                        self.scroll = Scroll::Start;
+                        true
+                    }
+                    "G" => {
+                        self.scroll = Scroll::End;
+                        true
+                    }
+                    "q" => {
+                        window_target.exit();
+                        true
+                    }
+
+                    _ => false,
+                },
+                Key::ArrowDown => self.scroll_line(1),
+                Key::ArrowUp => self.scroll_line(-1),
+                Key::Space => self.scroll_page(1.0),
+                Key::Enter => self.scroll_line(1),
+                Key::Home => {
+                    self.scroll = Scroll::Start;
+                    true
+                }
+                Key::End => {
+                    self.scroll = Scroll::End;
+                    true
+                }
+                Key::Escape => {
+                    window_target.exit();
+                    true
+                }
+                _ => false,
+            }
+        };
+        if handled {
+            return true;
         }
-        _ => {}
-    });
+
+        match event.logical_key {
+            // NOTE: These work regardless of the ctrl state, mimicking "less"
+            Key::Character(c) => match c.as_str() {
+                "k" => self.scroll_line(-1),
+                "d" => self.scroll_page(0.5),
+                "u" => self.scroll_page(-0.5),
+                "f" => self.scroll_page(1.0),
+                "b" => self.scroll_page(-1.0),
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    fn scroll_line(&mut self, count: i32) -> bool {
+        self.scroll = match self.scroll {
+            Scroll::Line(prev_count) => Scroll::Line(prev_count + count),
+            _ => Scroll::Line(count),
+        };
+        true
+    }
+
+    fn scroll_page(&mut self, amount: f32) -> bool {
+        self.scroll = match self.scroll {
+            Scroll::Page(prev_amount) => Scroll::Page(prev_amount + amount),
+            _ => Scroll::Page(amount),
+        };
+        true
+    }
+
+    fn handle_scrolling(&mut self, allowed_height: f64) -> f64 {
+        let metrics = self.paragraph.get_line_metrics();
+        let mut current_line =
+            metrics.partition_point(|v| v.start_index <= self.current_position) - 1;
+
+        let lines_to_scroll = match self.scroll {
+            Scroll::Line(lines) => lines,
+            Scroll::Page(amount) => {
+                let mut height = 0.0;
+                let count = metrics[current_line..]
+                    .iter()
+                    .take_while(|line| {
+                        height += line.height;
+                        height <= allowed_height
+                    })
+                    .count() as f32;
+                (count * amount).round() as i32
+            }
+            Scroll::Start => -MAX_LINES,
+            Scroll::End => MAX_LINES,
+            Scroll::None => 0,
+        };
+        current_line =
+            (current_line as i32 + lines_to_scroll).clamp(0, metrics.len() as i32 - 1) as usize;
+        let mut current_line_metrics = &metrics[current_line];
+
+        self.scroll = Scroll::None;
+
+        let mut offset = current_line_metrics.baseline - current_line_metrics.ascent;
+
+        let last_line_metrix = metrics.last().unwrap();
+        let last_line_pos = last_line_metrix.baseline + last_line_metrix.descent;
+        while current_line > 0 && allowed_height > last_line_pos - offset {
+            current_line -= 1;
+            current_line_metrics = &metrics[current_line];
+            offset = current_line_metrics.baseline - current_line_metrics.ascent;
+        }
+
+        self.current_position = current_line_metrics.start_index;
+        current_line_metrics.baseline - current_line_metrics.ascent
+    }
+}
+
+fn create_paragraph(
+    message: &str,
+    scale_factor: f32,
+    font_collection: &FontCollection,
+) -> Paragraph {
+    let text_paint = Paint::new(TEXT_COLOR, None);
+
+    let mut text_style = TextStyle::new();
+    text_style.set_font_families(&["monospace"]);
+    text_style.set_foreground_color(&text_paint);
+    text_style.set_font_size(FONT_SIZE * scale_factor);
+
+    let mut paragraph_style = ParagraphStyle::new();
+    paragraph_style.set_text_style(&text_style);
+    paragraph_style.set_max_lines(MAX_LINES as usize);
+    paragraph_style.set_text_height_behavior(TextHeightBehavior::DisableAll);
+
+    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
+    paragraph_builder.push_style(&text_style);
+    paragraph_builder.add_text(message);
+    paragraph_builder.pop();
+
+    paragraph_builder.build()
 }
 
 fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
@@ -75,43 +336,4 @@ fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
     let winit_window_builder = winit_window_builder.with_accepts_first_mouse(false);
 
     build_window(winit_window_builder, event_loop)
-}
-
-fn render(
-    msg: &str,
-    renderer: &mut SkiaRenderer,
-    context: &WindowedContext,
-    font_collection: &FontCollection,
-    scale: f64,
-) {
-    let canvas = renderer.canvas();
-    let text_color: Color4f = Color::from_rgb(255, 255, 255).into();
-    let background_color: Color4f = Color::from_rgb(0, 0, 0).into();
-    let font_size = scale * 12.0 * 96.0 / 72.0;
-
-    canvas.clear(background_color);
-
-    let text_paint = Paint::new(text_color, None);
-
-    let mut text_style = TextStyle::new();
-    text_style.set_font_families(&["monospace"]);
-    text_style.set_foreground_color(&text_paint);
-    text_style.set_font_size(font_size as f32);
-
-    let mut paragraph_style = ParagraphStyle::new();
-    paragraph_style.set_text_style(&text_style);
-    paragraph_style.set_max_lines(100);
-
-    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
-    paragraph_builder.push_style(&text_style);
-    paragraph_builder.add_text(msg);
-    paragraph_builder.pop();
-
-    let mut paragraph = paragraph_builder.build();
-    paragraph.layout(500.0);
-
-    paragraph.paint(canvas, Point::new(0.0, 0.0));
-    renderer.gr_context.flush_and_submit();
-    context.window().pre_present_notify();
-    context.swap_buffers().unwrap();
 }

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -29,6 +29,8 @@ const BACKGROUND_COLOR: Color4f = BLACK;
 const FONT_SIZE: f32 = 12.0 * 96.0 / 72.0;
 const PADDING: f32 = 10.0;
 const MAX_LINES: i32 = 9999;
+const MIN_SIZE: PhysicalSize<u32> = PhysicalSize::new(800, 600);
+const DEFAULT_SIZE: PhysicalSize<u32> = PhysicalSize::new(500, 500);
 
 pub fn show_error_window(message: &str, event_loop: EventLoop<UserEvent>) {
     let mut error_window = ErrorWindow::new(message, &event_loop);
@@ -480,7 +482,9 @@ fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
         .with_window_icon(Some(icon))
         .with_transparent(false)
         .with_visible(false)
-        .with_decorations(true);
+        .with_decorations(true)
+        .with_inner_size(MIN_SIZE)
+        .with_min_inner_size(DEFAULT_SIZE);
 
     build_window(winit_window_builder, event_loop)
 }

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -7,10 +7,6 @@ use skia_safe::{
     },
     Color4f, FontMgr, Paint, Point, Rect, Size,
 };
-#[cfg(target_os = "linux")]
-use std::env;
-#[cfg(target_os = "macos")]
-use winit::platform::macos::WindowBuilderExtMacOS;
 use winit::{
     dpi::PhysicalSize,
     event::{ElementState, Event, KeyEvent, Modifiers, WindowEvent},
@@ -23,6 +19,7 @@ use crate::{
     cmd_line::SRGB_DEFAULT,
     renderer::{build_context, build_window, GlWindow, WindowedContext},
     window::{load_icon, SkiaRenderer, UserEvent},
+    clipboard,
 };
 
 const TEXT_COLOR: Color4f = WHITE;
@@ -172,6 +169,7 @@ impl<'a> ErrorWindow<'a> {
         }
         let handled = if self.modifiers.state().control_key() {
             // Ctrl is pressed
+            // Require e and y to be combined with ctrl, since y is copy
             match &event.logical_key {
                 Key::Character(c) => match c.as_str() {
                     "e" => self.scroll_line(1),
@@ -198,7 +196,10 @@ impl<'a> ErrorWindow<'a> {
                         window_target.exit();
                         true
                     }
-
+                    "y" => {
+                        let _ = clipboard::set_contents(self.message.to_string());
+                        true
+                    }
                     _ => false,
                 },
                 Key::ArrowDown => self.scroll_line(1),

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -1,0 +1,57 @@
+use winit::{
+    event::{Event, WindowEvent},
+    event_loop::EventLoop,
+    window::WindowBuilder,
+};
+
+use crate::{
+    cmd_line::SRGB_DEFAULT,
+    renderer::{build_context, build_window, GlWindow},
+    window::{load_icon, UserEvent},
+};
+
+pub fn show_error_window(_message: &str, event_loop: EventLoop<UserEvent>) {
+    let srgb = SRGB_DEFAULT == "1";
+    let vsync = true;
+    let window = create_window(&event_loop);
+    let _context = build_context(window, srgb, vsync);
+
+    let _ = event_loop.run(move |e, window_target| match e {
+        Event::LoopExiting => {}
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } => {
+            window_target.exit();
+        }
+        _ => {}
+    });
+}
+
+fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
+    let icon = load_icon();
+
+    let winit_window_builder = WindowBuilder::new()
+        .with_title("Neovide")
+        .with_window_icon(Some(icon))
+        .with_transparent(false)
+        .with_visible(true)
+        .with_decorations(true);
+
+    #[cfg(target_os = "linux")]
+    let winit_window_builder = {
+        if env::var("WAYLAND_DISPLAY").is_ok() {
+            let app_id = &cmd_line_settings.wayland_app_id;
+            WindowBuilderExtWayland::with_name(winit_window_builder, "neovide", app_id.clone())
+        } else {
+            let class = &cmd_line_settings.x11_wm_class;
+            let instance = &cmd_line_settings.x11_wm_class_instance;
+            WindowBuilderExtX11::with_name(winit_window_builder, class, instance)
+        }
+    };
+
+    #[cfg(target_os = "macos")]
+    let winit_window_builder = winit_window_builder.with_accepts_first_mouse(false);
+
+    build_window(winit_window_builder, event_loop)
+}

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -1,3 +1,11 @@
+use skia_safe::{
+    textlayout::{FontCollection, ParagraphBuilder, ParagraphStyle, TextStyle},
+    Color, Color4f, FontMgr, Paint, Point,
+};
+#[cfg(target_os = "linux")]
+use std::env;
+#[cfg(target_os = "macos")]
+use winit::platform::macos::WindowBuilderExtMacOS;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -6,15 +14,21 @@ use winit::{
 
 use crate::{
     cmd_line::SRGB_DEFAULT,
-    renderer::{build_context, build_window, GlWindow},
-    window::{load_icon, UserEvent},
+    renderer::{build_context, build_window, GlWindow, WindowedContext},
+    window::{load_icon, SkiaRenderer, UserEvent},
 };
 
-pub fn show_error_window(_message: &str, event_loop: EventLoop<UserEvent>) {
+pub fn show_error_window(message: &str, event_loop: EventLoop<UserEvent>) {
+    let font_manager = FontMgr::new();
+    let mut font_collection = FontCollection::new();
+    font_collection.set_default_font_manager(Some(font_manager), None);
+
     let srgb = SRGB_DEFAULT == "1";
     let vsync = true;
     let window = create_window(&event_loop);
-    let _context = build_context(window, srgb, vsync);
+    let context = build_context(window, srgb, vsync);
+    let mut scale_factor = context.window().scale_factor();
+    let mut skia_renderer = SkiaRenderer::new(&context);
 
     let _ = event_loop.run(move |e, window_target| match e {
         Event::LoopExiting => {}
@@ -23,6 +37,25 @@ pub fn show_error_window(_message: &str, event_loop: EventLoop<UserEvent>) {
             ..
         } => {
             window_target.exit();
+        }
+        Event::AboutToWait => {}
+        Event::WindowEvent {
+            event: WindowEvent::RedrawRequested,
+            ..
+        } => {
+            render(message, &mut skia_renderer, &context, &font_collection, scale_factor);
+        }
+        Event::WindowEvent {
+            event: WindowEvent::Resized(..),
+            ..
+        } => {
+            skia_renderer.resize(&context);
+        }
+        Event::WindowEvent {
+            event: WindowEvent::ScaleFactorChanged { scale_factor: new_scale_factor, .. },
+            ..
+        } => {
+            scale_factor = new_scale_factor;
         }
         _ => {}
     });
@@ -38,20 +71,47 @@ fn create_window(event_loop: &EventLoop<UserEvent>) -> GlWindow {
         .with_visible(true)
         .with_decorations(true);
 
-    #[cfg(target_os = "linux")]
-    let winit_window_builder = {
-        if env::var("WAYLAND_DISPLAY").is_ok() {
-            let app_id = &cmd_line_settings.wayland_app_id;
-            WindowBuilderExtWayland::with_name(winit_window_builder, "neovide", app_id.clone())
-        } else {
-            let class = &cmd_line_settings.x11_wm_class;
-            let instance = &cmd_line_settings.x11_wm_class_instance;
-            WindowBuilderExtX11::with_name(winit_window_builder, class, instance)
-        }
-    };
-
     #[cfg(target_os = "macos")]
     let winit_window_builder = winit_window_builder.with_accepts_first_mouse(false);
 
     build_window(winit_window_builder, event_loop)
+}
+
+fn render(
+    msg: &str,
+    renderer: &mut SkiaRenderer,
+    context: &WindowedContext,
+    font_collection: &FontCollection,
+    scale: f64,
+) {
+    let canvas = renderer.canvas();
+    let text_color: Color4f = Color::from_rgb(255, 255, 255).into();
+    let background_color: Color4f = Color::from_rgb(0, 0, 0).into();
+    let font_size = scale * 12.0 * 96.0 / 72.0;
+
+    canvas.clear(background_color);
+
+    let text_paint = Paint::new(text_color, None);
+
+    let mut text_style = TextStyle::new();
+    text_style.set_font_families(&["monospace"]);
+    text_style.set_foreground_color(&text_paint);
+    text_style.set_font_size(font_size as f32);
+
+    let mut paragraph_style = ParagraphStyle::new();
+    paragraph_style.set_text_style(&text_style);
+    paragraph_style.set_max_lines(100);
+
+    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
+    paragraph_builder.push_style(&text_style);
+    paragraph_builder.add_text(msg);
+    paragraph_builder.pop();
+
+    let mut paragraph = paragraph_builder.build();
+    paragraph.layout(500.0);
+
+    paragraph.paint(canvas, Point::new(0.0, 0.0));
+    renderer.gr_context.flush_and_submit();
+    context.window().pre_present_notify();
+    context.swap_buffers().unwrap();
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -267,7 +267,6 @@ pub fn main_loop(
             window.inner_size(),
             window.outer_position().ok(),
         );
-        std::process::exit(RUNNING_TRACKER.exit_code());
     }));
 
     event_loop.run(move |e, window_target| {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,3 +1,4 @@
+mod error_window;
 mod keyboard_manager;
 mod mouse_manager;
 mod renderer;
@@ -53,6 +54,7 @@ use crate::{
     running_tracker::*,
     settings::{load_last_window_settings, save_window_size, PersistentWindowSettings, SETTINGS},
 };
+pub use error_window::show_error_window;
 pub use settings::{KeyboardSettings, WindowSettings};
 
 static ICON: &[u8] = include_bytes!("../../assets/neovide.ico");
@@ -86,15 +88,7 @@ pub fn create_window(
     event_loop: &EventLoop<UserEvent>,
     initial_window_size: &WindowSize,
 ) -> GlWindow {
-    let icon = {
-        let icon = load_from_memory(ICON).expect("Failed to parse icon data");
-        let (width, height) = icon.dimensions();
-        let mut rgba = Vec::with_capacity((width * height) as usize * 4);
-        for (_, _, pixel) in icon.pixels() {
-            rgba.extend_from_slice(&pixel.to_rgba().0);
-        }
-        Icon::from_rgba(rgba, width, height).expect("Failed to create icon object")
-    };
+    let icon = load_icon();
 
     let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
 
@@ -334,4 +328,14 @@ pub fn main_loop(
             window_target.set_control_flow(update_loop.step(&mut window_wrapper, Ok(e)).unwrap());
         }
     })
+}
+
+pub fn load_icon() -> Icon {
+    let icon = load_from_memory(ICON).expect("Failed to parse icon data");
+    let (width, height) = icon.dimensions();
+    let mut rgba = Vec::with_capacity((width * height) as usize * 4);
+    for (_, _, pixel) in icon.pixels() {
+        rgba.extend_from_slice(&pixel.to_rgba().0);
+    }
+    Icon::from_rgba(rgba, width, height).expect("Failed to create icon object")
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -276,11 +276,17 @@ pub fn main_loop(
             }
             Event::AboutToWait => {}
             _ => {
-                let _ = tx.as_ref().unwrap().send(e);
+                if let Some(tx) = tx.as_ref() {
+                    let _ = tx.send(e);
+                }
             }
         }
 
         if !RUNNING_TRACKER.is_running() {
+            window_target.set_control_flow(ControlFlow::Wait);
+            if tx.is_none() {
+                return;
+            }
             let tx = tx.take().unwrap();
             drop(tx);
             let handle = render_thread_handle.take().unwrap();

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -71,7 +71,9 @@ pub struct WinitWindowWrapper {
 impl WinitWindowWrapper {
     pub fn new(window: GlWindow, initial_window_size: WindowSize) -> Self {
         let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
-        let windowed_context = build_context(window, &cmd_line_settings);
+        let srgb = cmd_line_settings.srgb;
+        let vsync = cmd_line_settings.vsync;
+        let windowed_context = build_context(window, srgb, vsync);
         let window = windowed_context.window();
 
         let scale_factor = windowed_context.window().scale_factor();

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -10,7 +10,6 @@ use winapi::{
     },
     um::{
         libloaderapi::GetModuleFileNameA,
-        wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS},
         winnt::{KEY_WRITE, REG_OPTION_NON_VOLATILE, REG_SZ},
         winreg::{RegCloseKey, RegCreateKeyExA, RegDeleteTreeA, RegSetValueExA, HKEY_CURRENT_USER},
         winuser::SetProcessDpiAwarenessContext,
@@ -222,18 +221,5 @@ pub fn register_rightclick_file() -> bool {
 pub fn windows_fix_dpi() {
     unsafe {
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-    }
-}
-
-pub fn windows_attach_to_console() {
-    // Attach to parent console tip found here: https://github.com/rust-lang/rust/issues/67159#issuecomment-987882771
-    unsafe {
-        AttachConsole(ATTACH_PARENT_PROCESS);
-    }
-}
-
-pub fn windows_detach_from_console() {
-    unsafe {
-        FreeConsole();
     }
 }


### PR DESCRIPTION
**NOTE:** Depends on and includes https://github.com/neovide/neovide/pull/2062

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Startup errors are now properly reported. If a terminal is attached, then they are reported to the terminal and otherwise in a GUI window, which supports, resizing, scrolling and copying, much like a pager like `less`.

On Windows the subsystem is always `windows` and no console is ever attached. So all errors and help messages are reported through the GUI. This was done because `AttachConsole` does not really properly attach to the console, and it does not return to the command line until the user press enter, which is confusing.

On Linux and MacOS, a double fork is done instead of launching a completely new process, unless  `--no-fork` is specified. This happens immediately after the commandline is processed, so any commandline helps is still printed to the terminal.

## Did this PR introduce a breaking change? 
* Yes, some errors that previously were silently ignored are now reported and hard errors. This mainly concerns errors in the `ginit.vim`, which were completely silently ignored before.
* `--no-fork` have no effect on Windows anymore.
