### PR TITLE
Report error when setting a wrong guifont value

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -59,6 +59,13 @@ pub async fn show_intro_message(
     nvim.exec_lua(INTRO_MESSAGE_LUA, args).await
 }
 
+pub async fn show_error_message(
+    nvim: &Neovim<NeovimWriter>,
+    message: &String,
+) -> Result<(), Box<CallError>> {
+    nvim.command(&format!("echomsg \"{message:?}\"")).await
+}
+
 #[tokio::main]
 async fn start_neovim_runtime(instance: NeovimInstance) {
     let handler = NeovimHandler::new();

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -6,8 +6,9 @@ pub mod session;
 mod setup;
 mod ui_commands;
 
-use std::{process::exit, sync::Arc, thread};
+use std::{process::exit, sync::Arc, thread, ops::Add};
 
+use itertools::Itertools;
 use log::{error, info};
 use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
 
@@ -61,9 +62,22 @@ pub async fn show_intro_message(
 
 pub async fn show_error_message(
     nvim: &Neovim<NeovimWriter>,
-    message: &String,
+    lines: &[String],
 ) -> Result<(), Box<CallError>> {
-    nvim.err_writeln(message).await
+    nvim.echo(
+        lines
+            .iter()
+            .map(|l| {
+                Value::Array(vec![
+                    Value::String(l.clone().add("\n").into()),
+                    Value::String("ErrorMsg".into()),
+                ])
+            })
+            .collect_vec(),
+        true,
+        vec![],
+    )
+    .await
 }
 
 #[tokio::main]

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -63,7 +63,7 @@ pub async fn show_error_message(
     nvim: &Neovim<NeovimWriter>,
     message: &String,
 ) -> Result<(), Box<CallError>> {
-    nvim.command(&format!("echomsg \"{message:?}\"")).await
+    nvim.err_writeln(message).await
 }
 
 #[tokio::main]

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -6,11 +6,12 @@ pub mod session;
 mod setup;
 mod ui_commands;
 
-use std::{process::exit, sync::Arc, thread, ops::Add};
+use std::{ops::Add, process::exit, sync::Arc, thread};
 
 use itertools::Itertools;
 use log::{error, info};
 use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
+use rmpv::Utf8String;
 
 use crate::{
     cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation, running_tracker::*,
@@ -64,20 +65,24 @@ pub async fn show_error_message(
     nvim: &Neovim<NeovimWriter>,
     lines: &[String],
 ) -> Result<(), Box<CallError>> {
-    nvim.echo(
-        lines
-            .iter()
-            .map(|l| {
-                Value::Array(vec![
-                    Value::String(l.clone().add("\n").into()),
-                    Value::String("ErrorMsg".into()),
-                ])
-            })
-            .collect_vec(),
-        true,
-        vec![],
-    )
-    .await
+    let error_msg_highlight: Utf8String = "ErrorMsg".into();
+    let mut prepared_lines = lines
+        .iter()
+        .map(|l| {
+            Value::Array(vec![
+                Value::String(l.clone().add("\n").into()),
+                Value::String(error_msg_highlight.clone()),
+            ])
+        })
+        .collect_vec();
+    prepared_lines.insert(
+        0,
+        Value::Array(vec![
+            Value::String("Error: ".into()),
+            Value::String(error_msg_highlight.clone()),
+        ]),
+    );
+    nvim.echo(prepared_lines, true, vec![]).await
 }
 
 #[tokio::main]

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -128,7 +128,7 @@ pub enum ParallelCommand {
         message: Vec<String>,
     },
     ShowError {
-        message: String,
+        lines: Vec<String>,
     },
 }
 
@@ -243,8 +243,12 @@ impl ParallelCommand {
             ParallelCommand::ShowIntro { message } => {
                 show_intro_message(nvim, &message).await.ok();
             }
-            ParallelCommand::ShowError { message } => {
-                show_error_message(nvim, &message).await.ok();
+            ParallelCommand::ShowError { lines } => {
+                // nvim.err_write(&message).await.ok();
+                // NOTE: https://github.com/neovim/neovim/issues/5067
+                // nvim_err_write[ln] is broken for multiline messages
+                // We should go back to it whenever that bug gets fixed.
+                show_error_message(nvim, &lines).await.ok();
             }
         }
     }

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -12,7 +12,7 @@ use crate::windows_utils::{
     register_rightclick_directory, register_rightclick_file, unregister_rightclick,
 };
 
-use super::show_intro_message;
+use super::{show_error_message, show_intro_message};
 use crate::{
     bridge::NeovimWriter, event_aggregator::EVENT_AGGREGATOR, running_tracker::RUNNING_TRACKER,
 };
@@ -127,6 +127,9 @@ pub enum ParallelCommand {
     ShowIntro {
         message: Vec<String>,
     },
+    ShowError {
+        message: String,
+    },
 }
 
 impl ParallelCommand {
@@ -239,6 +242,9 @@ impl ParallelCommand {
             }
             ParallelCommand::ShowIntro { message } => {
                 show_intro_message(nvim, &message).await.ok();
+            }
+            ParallelCommand::ShowError { message } => {
+                show_error_message(nvim, &message).await.ok();
             }
         }
     }

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -5,6 +5,18 @@ fn show_error(explanation: &str) -> ! {
     panic!("{}", explanation.to_string());
 }
 
+/// Formats, logs and displays the given message.
+#[macro_export]
+macro_rules! error_msg {
+    ($($arg:tt)+) => {
+        let msg = format!($($arg)+);
+        log::error!("{}", msg);
+        EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::ShowError {
+            lines: msg.split('\n').map(|s| s.to_string()).collect_vec(),
+        }));
+    }
+}
+
 pub trait ResultPanicExplanation<T, E: ToString> {
     fn unwrap_or_explained_panic(self, explanation: &str) -> T;
 }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -106,7 +106,10 @@ impl CachingShaper {
         if !failed_fonts.is_empty() {
             let msg = vec![
                 format!("Font can't be updated to: {}", guifont_setting),
-                format!("Following fonts couldn't be loaded: {:?}", failed_fonts),
+                format!(
+                    "Following fonts couldn't be loaded: {}",
+                    failed_fonts.iter().join(", ")
+                ),
             ];
             msg.iter().for_each(|m| error!("{}", m));
             EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::ShowError {

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -16,8 +16,11 @@ use swash::{
 };
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::profiling::tracy_zone;
-use crate::renderer::fonts::{font_loader::*, font_options::*};
+use crate::{bridge::ParallelCommand, profiling::tracy_zone, EVENT_AGGREGATOR};
+use crate::{
+    bridge::UiCommand,
+    renderer::fonts::{font_loader::*, font_options::*},
+};
 
 #[derive(new, Clone, Hash, PartialEq, Eq, Debug)]
 struct ShapeKey {
@@ -96,7 +99,11 @@ impl CachingShaper {
             self.options = options;
             self.reset_font_loader();
         } else {
-            error!("Font can't be updated to: {}", guifont_setting);
+            let msg = format!("Font can't be updated to:: {}", guifont_setting);
+            error!("{}", msg);
+            EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::ShowError {
+                message: msg,
+            }));
         }
     }
 

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -99,7 +99,7 @@ impl CachingShaper {
             self.options = options;
             self.reset_font_loader();
         } else {
-            let msg = format!("Font can't be updated to:: {}", guifont_setting);
+            let msg = format!("Font can't be updated to: {}", guifont_setting);
             error!("{}", msg);
             EVENT_AGGREGATOR.send(UiCommand::Parallel(ParallelCommand::ShowError {
                 message: msg,

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -1,6 +1,16 @@
+use std::num::ParseFloatError;
+
 use itertools::Itertools;
 
 const DEFAULT_FONT_SIZE: f32 = 14.0;
+const FONT_OPTS_SEPARATOR: char = ':';
+const FONT_LIST_SEPARATOR: char = ',';
+const FONT_HINTING_PREFIX: &str = "#h-";
+const FONT_EDGING_PREFIX: &str = "#e-";
+const FONT_HEIGHT_PREFIX: char = 'h';
+const FONT_WIDTH_PREFIX: char = 'w';
+const FONT_BOLD_OPT: &str = "b";
+const FONT_ITALIC_OPT: &str = "i";
 
 #[derive(Clone, Debug)]
 pub struct FontOptions {
@@ -15,17 +25,19 @@ pub struct FontOptions {
 }
 
 impl FontOptions {
-    pub fn parse(guifont_setting: &str) -> FontOptions {
+    pub fn parse(guifont_setting: &str) -> Result<FontOptions, &str> {
         let mut font_options = FontOptions::default();
 
-        let mut parts = guifont_setting.split(':').filter(|part| !part.is_empty());
+        let mut parts = guifont_setting
+            .split(FONT_OPTS_SEPARATOR)
+            .filter(|part| !part.is_empty());
 
         if let Some(parts) = parts.next() {
-            let parsed_font_list: Vec<String> = parts
-                .split(',')
+            let parsed_font_list = parts
+                .split(FONT_LIST_SEPARATOR)
                 .filter(|fallback| !fallback.is_empty())
                 .map(parse_font_name)
-                .collect();
+                .collect_vec();
 
             if !parsed_font_list.is_empty() {
                 font_options.font_list = parsed_font_list;
@@ -33,29 +45,23 @@ impl FontOptions {
         }
 
         for part in parts {
-            if let Some(hinting_string) = part.strip_prefix("#h-") {
-                font_options.hinting = FontHinting::parse(hinting_string);
-            } else if let Some(edging_string) = part.strip_prefix("#e-") {
-                font_options.edging = FontEdging::parse(edging_string);
-            } else if part.starts_with('h') && part.len() > 1 {
-                if part.contains('.') {
-                    font_options.allow_float_size = true;
-                }
-                if let Ok(parsed_size) = part[1..].parse::<f32>() {
-                    font_options.size = points_to_pixels(parsed_size);
-                }
-            } else if part.starts_with('w') && part.len() > 1 {
-                if let Ok(parsed_size) = part[1..].parse::<f32>() {
-                    font_options.width = points_to_pixels(parsed_size);
-                }
-            } else if part == "b" {
+            if let Some(hinting_string) = part.strip_prefix(FONT_HINTING_PREFIX) {
+                font_options.hinting = FontHinting::parse(hinting_string)?;
+            } else if let Some(edging_string) = part.strip_prefix(FONT_EDGING_PREFIX) {
+                font_options.edging = FontEdging::parse(edging_string)?;
+            } else if part.starts_with(FONT_HEIGHT_PREFIX) && part.len() > 1 {
+                font_options.allow_float_size = part[1..].contains('.');
+                font_options.size = parse_pixels(part).map_err(|_| "Invalid size")?;
+            } else if part.starts_with(FONT_WIDTH_PREFIX) && part.len() > 1 {
+                font_options.width = parse_pixels(part).map_err(|_| "Invalid width")?;
+            } else if part == FONT_BOLD_OPT {
                 font_options.bold = true;
-            } else if part == "i" {
+            } else if part == FONT_ITALIC_OPT {
                 font_options.italic = true;
             }
         }
 
-        font_options
+        Ok(font_options)
     }
 
     pub fn primary_font(&self) -> Option<String> {
@@ -89,6 +95,10 @@ impl PartialEq for FontOptions {
     }
 }
 
+fn parse_pixels(part: &str) -> Result<f32, ParseFloatError> {
+    Ok(points_to_pixels(part[1..].parse::<f32>()?))
+}
+
 fn parse_font_name(font_name: impl AsRef<str>) -> String {
     let parsed_font_name = font_name
         .as_ref()
@@ -115,11 +125,12 @@ pub enum FontEdging {
 }
 
 impl FontEdging {
-    pub fn parse(value: &str) -> Self {
+    pub fn parse(value: &str) -> Result<Self, &str> {
         match value {
-            "antialias" => FontEdging::AntiAlias,
-            "subpixelantialias" => FontEdging::SubpixelAntiAlias,
-            _ => FontEdging::Alias,
+            "antialias" => Ok(FontEdging::AntiAlias),
+            "subpixelantialias" => Ok(FontEdging::SubpixelAntiAlias),
+            "alias" => Ok(FontEdging::Alias),
+            _ => Err("Invalid edging"),
         }
     }
 }
@@ -134,12 +145,13 @@ pub enum FontHinting {
 }
 
 impl FontHinting {
-    pub fn parse(value: &str) -> Self {
+    pub fn parse(value: &str) -> Result<Self, &str> {
         match value {
-            "full" => FontHinting::Full,
-            "normal" => FontHinting::Normal,
-            "slight" => FontHinting::Slight,
-            _ => FontHinting::None,
+            "full" => Ok(FontHinting::Full),
+            "normal" => Ok(FontHinting::Normal),
+            "slight" => Ok(FontHinting::Slight),
+            "none" => Ok(FontHinting::None),
+            _ => Err("Invalid hinting"),
         }
     }
 }
@@ -172,7 +184,7 @@ mod tests {
     #[test]
     fn test_parse_one_font_from_guifont_setting() {
         let guifont_setting = "Fira Code Mono";
-        let font_options = FontOptions::parse(guifont_setting);
+        let font_options = FontOptions::parse(guifont_setting).unwrap();
 
         assert_eq!(
             font_options.font_list.len(),
@@ -186,7 +198,7 @@ mod tests {
     #[test]
     fn test_parse_many_fonts_from_guifont_setting() {
         let guifont_setting = "Fira Code Mono,Console";
-        let font_options = FontOptions::parse(guifont_setting);
+        let font_options = FontOptions::parse(guifont_setting).unwrap();
 
         assert_eq!(
             font_options.font_list.len(),
@@ -200,7 +212,7 @@ mod tests {
     #[test]
     fn test_parse_edging_from_guifont_setting() {
         let guifont_setting = "Fira Code Mono:#e-subpixelantialias";
-        let font_options = FontOptions::parse(guifont_setting);
+        let font_options = FontOptions::parse(guifont_setting).unwrap();
 
         assert_eq!(
             font_options.edging,
@@ -214,7 +226,7 @@ mod tests {
     #[test]
     fn test_parse_hinting_from_guifont_setting() {
         let guifont_setting = "Fira Code Mono:#h-slight";
-        let font_options = FontOptions::parse(guifont_setting);
+        let font_options = FontOptions::parse(guifont_setting).unwrap();
 
         assert_eq!(
             font_options.hinting,
@@ -227,7 +239,7 @@ mod tests {
     #[test]
     fn test_parse_font_size_float_from_guifont_setting() {
         let guifont_setting = "Fira Code Mono:h15.5";
-        let font_options = FontOptions::parse(guifont_setting);
+        let font_options = FontOptions::parse(guifont_setting).unwrap();
 
         let font_size_pixels = points_to_pixels(15.5);
         assert_eq!(
@@ -241,7 +253,7 @@ mod tests {
     #[allow(clippy::bool_assert_comparison)]
     fn test_parse_all_params_together_from_guifont_setting() {
         let guifont_setting = "Fira Code Mono:h15:b:i:#h-slight:#e-alias";
-        let font_options = FontOptions::parse(guifont_setting);
+        let font_options = FontOptions::parse(guifont_setting).unwrap();
 
         let font_size_pixels = points_to_pixels(15.0);
         assert_eq!(


### PR DESCRIPTION
## What kind of change does this PR introduce?

It addresses #2077 by fist implementing a new parallel `UiCommand`, `ShowError { message: String }` which gets translated to neovim's [`echomsg`](https://neovim.io/doc/user/eval.html#%3Aechom), and then using it in tandem with `log::error!` in `CachingShaper::update_font` (when `self.font_loader.get_or_load` fails).

## Did this PR introduce a breaking change? 
- Yes
  - Invalid [`guifont`](https://neovim.io/doc/user/options.html#'guifont') values will now error out instead of silently being accepted. To pick no hinting or aliased edging, you should now use `#h-none` and `#e-alias`, respectively.
    - *Actually, just checked the docs, and they already specified those options, even though the code didn't check for them specifically, they were just being handled on the wildcard match. Still this is a breaking change because of the new errors.*


Closes #2077 