### PR TITLE
chore!: Update the macOS CI to use macOS 12 instead of 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macOS-11, ubuntu-latest]
+        os: [windows-latest, macOS-12, ubuntu-latest]
         toolchain: [stable, nightly]
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         # NOTE: Should use the oldest available Ubuntu release, for maximum compatibility
-        os: [windows-latest, macOS-11, ubuntu-20.04]
+        os: [windows-latest, macOS-12, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Updates the CI images to macOS 12. MacOS 12 - Big Sur is no longer supported according to https://en.wikipedia.org/wiki/MacOS. I don't see anything in the Rust release notes or in the Gitlab CI release notes about macOS 11 being unsupported though.

But in any case this seem to fix the CI problems we have compiling the `aarch64-apple-darwin` image, which broke after this was released https://github.com/actions/runner-images/releases/tag/macOS-11%2F20231030.1 and can be seen here https://github.com/neovide/neovide/actions/runs/6768373367/job/18392914175?pr=2106 for example. This has been verified on my fork https://github.com/fredizzimo/neovide/actions/runs/6773128253/job/18407618899.

## Did this PR introduce a breaking change? 
This possibly breaks Neovide on macOS 11 and earlier.
