### PR TITLE
Observe mousemoveevent option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "copypasta"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1495,7 @@ dependencies = [
 name = "neovide-derive"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
  "quote",
  "syn 1.0.109",
 ]

--- a/neovide-derive/Cargo.toml
+++ b/neovide-derive/Cargo.toml
@@ -15,3 +15,4 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 quote = "1.0"
+convert_case = "0.6.0"

--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -1,6 +1,12 @@
+//! Derive macro for setting groups.
+//!
+//! This macro will generate a `SettingGroup` implementation for the struct it is applied to.
+//! It will also generate an enum with the name `{StructName}Changed` that contains a variant for
+//! each field in the struct. The enum will be used to send events when a setting is changed.
+
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
-use quote::{quote, format_ident};
+use quote::{format_ident, quote};
 use syn::{
     parse_macro_input, Attribute, Data, DataStruct, DeriveInput, Error, Field, Ident, Lit, Meta,
 };

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -78,23 +78,16 @@ impl Handler for NeovimHandler {
                 }
             }
             "setting_changed" => {
-                SETTINGS.handle_changed_notification(arguments);
+                SETTINGS.handle_setting_changed_notification(arguments);
+            }
+            "option_changed" => {
+                SETTINGS.handle_option_changed_notification(arguments);
             }
             "neovide.quit" => {
                 let error_code = arguments[0]
                     .as_i64()
                     .expect("Could not parse error code from neovim");
                 RUNNING_TRACKER.quit_with_code(error_code as i32, "Quit from neovim");
-            }
-            "neovide.columns" => {
-                if let Some(columns) = arguments[0].as_u64() {
-                    EVENT_AGGREGATOR.send(WindowCommand::Columns(columns));
-                }
-            }
-            "neovide.lines" => {
-                if let Some(lines) = arguments[0].as_u64() {
-                    EVENT_AGGREGATOR.send(WindowCommand::Lines(lines));
-                }
             }
             #[cfg(windows)]
             "neovide.register_right_click" => {

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -99,9 +99,9 @@ impl NeovimInstance {
                 } else {
                     format!("\\\\.\\pipe\\{}", address)
                 };
-                return Ok(Self::split(
+                Ok(Self::split(
                     tokio::net::windows::named_pipe::ClientOptions::new().open(address)?,
-                ));
+                ))
             }
 
             #[cfg(not(any(unix, windows)))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,9 +174,9 @@ fn setup() -> Result<(WindowSize, NeovimRuntime)> {
 
     trace!("Neovide version: {}", crate_version!());
 
-    WindowSettings::register();
-    RendererSettings::register();
-    CursorSettings::register();
+    SETTINGS.register::<WindowSettings>();
+    SETTINGS.register::<RendererSettings>();
+    SETTINGS.register::<CursorSettings>();
     let window_size = determine_window_size();
     let grid_size = match window_size {
         WindowSize::Grid(grid_size) => Some(grid_size),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,7 @@ use error_handling::{handle_startup_errors, NeovideExitCode};
 use renderer::{cursor_renderer::CursorSettings, RendererSettings};
 use settings::SETTINGS;
 use window::{
-    create_event_loop, create_window, determine_window_size, main_loop, KeyboardSettings,
-    WindowSettings, WindowSize,
+    create_event_loop, create_window, determine_window_size, main_loop, WindowSettings, WindowSize,
 };
 
 pub use channel_utils::*;
@@ -178,7 +177,6 @@ fn setup() -> Result<(WindowSize, NeovimRuntime)> {
     WindowSettings::register();
     RendererSettings::register();
     CursorSettings::register();
-    KeyboardSettings::register();
     let window_size = determine_window_size();
     let grid_size = match window_size {
         WindowSize::Grid(grid_size) => Some(grid_size),

--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -28,21 +28,21 @@ pub trait CursorVfx {
     );
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum HighlightMode {
     SonicBoom,
     Ripple,
     Wireframe,
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TrailMode {
     Railgun,
     Torpedo,
     PixieDust,
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VfxMode {
     Highlight(HighlightMode),
     Trail(TrailMode),

--- a/src/settings/from_value.rs
+++ b/src/settings/from_value.rs
@@ -3,7 +3,6 @@ use log::error;
 
 // Trait to allow for conversion from rmpv::Value to any other data type.
 // Note: Feel free to implement this trait for custom types in each subsystem.
-// The reverse conversion (MyType->Value) can be performed by implementing `From<MyType> for Value`
 pub trait ParseFromValue {
     fn parse_from_value(&mut self, value: Value);
 }
@@ -71,6 +70,19 @@ impl ParseFromValue for bool {
             *self = value.as_u64().unwrap() != 0;
         } else {
             error!("Setting expected a bool or 0/1, but received {:?}", value);
+        }
+    }
+}
+
+impl<T: ParseFromValue + Default> ParseFromValue for Option<T> {
+    fn parse_from_value(&mut self, value: Value) {
+        match self.as_mut() {
+            Some(inner) => inner.parse_from_value(value),
+            None => {
+                let mut inner = T::default();
+                inner.parse_from_value(value);
+                *self = Some(inner);
+            }
         }
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -200,6 +200,7 @@ mod tests {
             create_nvim_command,
             session::{NeovimInstance, NeovimSession},
         },
+        cmd_line::CmdLineSettings,
         error_handling::ResultPanicExplanation,
     };
 
@@ -312,6 +313,10 @@ mod tests {
 
         let settings = Settings::new();
         settings.register::<TestSettings>();
+
+        //create_nvim_command tries to read from CmdLineSettings.neovim_args
+        //TODO: this sets a static variable. Can this have side effects on other tests?
+        SETTINGS.set::<CmdLineSettings>(&CmdLineSettings::default());
 
         let command =
             create_nvim_command().unwrap_or_explained_panic("Could not create nvim command");

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -100,7 +100,7 @@ impl Settings {
                     let variable_name = format!("neovide_{name}");
                     match nvim.get_var(&variable_name).await {
                         Ok(value) => {
-                            self.listeners.read().get(&location).unwrap()(&self, value);
+                            self.listeners.read().get(&location).unwrap()(self, value);
                         }
                         Err(error) => {
                             trace!("Initial value load failed for {}: {}", name, error);
@@ -109,7 +109,7 @@ impl Settings {
                 }
                 SettingLocation::NeovimOption(name) => match nvim.get_option(name).await {
                     Ok(value) => {
-                        self.listeners.read().get(&location).unwrap()(&self, value);
+                        self.listeners.read().get(&location).unwrap()(self, value);
                     }
                     Err(error) => {
                         trace!("Initial value load failed for {}: {}", name, error);
@@ -168,7 +168,7 @@ impl Settings {
         self.listeners
             .read()
             .get(&SettingLocation::NeovideGlobal(name))
-            .unwrap()(&self, value);
+            .unwrap()(self, value);
     }
 
     pub fn handle_option_changed_notification(&self, arguments: Vec<Value>) {
@@ -181,7 +181,7 @@ impl Settings {
         self.listeners
             .read()
             .get(&SettingLocation::NeovimOption(name))
-            .unwrap()(&self, value);
+            .unwrap()(self, value);
     }
 
     pub fn register<T: SettingGroup>(&self) {

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use crate::window::UserEvent;
 #[cfg(target_os = "macos")]
-use crate::{settings::SETTINGS, window::KeyboardSettings};
+use crate::{settings::SETTINGS, window::WindowSettings};
 #[allow(unused_imports)]
 use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 use winit::{
@@ -221,8 +221,8 @@ fn use_alt() -> bool {
 // and does not operate the same as other systems.
 #[cfg(target_os = "macos")]
 fn use_alt() -> bool {
-    let settings = SETTINGS.get::<KeyboardSettings>();
-    settings.macos_alt_is_meta
+    let settings = SETTINGS.get::<WindowSettings>();
+    settings.input_macos_alt_is_meta
 }
 
 fn get_special_key(key_event: &KeyEvent) -> Option<&str> {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -55,7 +55,7 @@ use crate::{
     settings::{load_last_window_settings, save_window_size, PersistentWindowSettings, SETTINGS},
 };
 pub use error_window::show_error_window;
-pub use settings::WindowSettings;
+pub use settings::{WindowSettings, WindowSettingsChanged};
 
 static ICON: &[u8] = include_bytes!("../../assets/neovide.ico");
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -55,7 +55,7 @@ use crate::{
     settings::{load_last_window_settings, save_window_size, PersistentWindowSettings, SETTINGS},
 };
 pub use error_window::show_error_window;
-pub use settings::{KeyboardSettings, WindowSettings};
+pub use settings::WindowSettings;
 
 static ICON: &[u8] = include_bytes!("../../assets/neovide.ico");
 
@@ -69,8 +69,6 @@ pub enum WindowCommand {
     TitleChanged(String),
     SetMouseEnabled(bool),
     ListAvailableFonts,
-    Columns(u64),
-    Lines(u64),
     FocusWindow,
     Minimize,
 }

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -184,7 +184,7 @@ impl MouseManager {
                 // otherwise, update the window_id_under_mouse to match the one selected
                 self.window_details_under_mouse = Some(relevant_window_details.clone());
 
-                if has_moved {
+                if has_moved && SETTINGS.get::<WindowSettings>().mouse_move_event {
                     // Send a mouse move command
                     EVENT_AGGREGATOR.send(UiCommand::Serial(SerialCommand::MouseButton {
                         button: "move".into(),

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -21,6 +21,15 @@ pub struct WindowSettings {
     pub padding_right: u32,
     pub padding_bottom: u32,
     pub theme: String,
+    pub input_macos_alt_is_meta: bool,
+    pub input_ime: bool,
+
+    #[option = "mousemoveevent"]
+    pub mouse_move_event: bool,
+    #[option = "lines"]
+    pub observed_lines: Option<u64>,
+    #[option = "columns"]
+    pub observed_columns: Option<u64>,
 }
 
 impl Default for WindowSettings {
@@ -45,23 +54,11 @@ impl Default for WindowSettings {
             padding_right: 0,
             padding_bottom: 0,
             theme: "".to_string(),
-        }
-    }
-}
-
-#[derive(Clone, SettingGroup)]
-#[setting_prefix = "input"]
-pub struct KeyboardSettings {
-    pub macos_alt_is_meta: bool,
-    pub ime: bool,
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for KeyboardSettings {
-    fn default() -> Self {
-        Self {
-            macos_alt_is_meta: false,
-            ime: true,
+            input_macos_alt_is_meta: false,
+            input_ime: false,
+            mouse_move_event: false,
+            observed_lines: None,
+            observed_columns: None,
         }
     }
 }

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -153,7 +153,7 @@ impl UpdateLoop {
             _ => {}
         }
         window_wrapper.handle_window_commands();
-        window_wrapper.synchronize_settings();
+        window_wrapper.handle_window_setting_change_events();
 
         if let Ok(event) = event {
             self.should_render |= window_wrapper.handle_event(event);

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -153,7 +153,7 @@ impl UpdateLoop {
             _ => {}
         }
         window_wrapper.handle_window_commands();
-        window_wrapper.handle_window_setting_change_events();
+        window_wrapper.handle_window_settings_changed_events();
 
         if let Ok(event) = event {
             self.should_render |= window_wrapper.handle_event(event);

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -1,6 +1,5 @@
 use super::{
-    KeyboardManager, KeyboardSettings, MouseManager, SkiaRenderer, UserEvent, WindowCommand,
-    WindowSettings,
+    KeyboardManager, MouseManager, SkiaRenderer, UserEvent, WindowCommand, WindowSettings,
 };
 
 use crate::{
@@ -11,7 +10,7 @@ use crate::{
     profiling::{emit_frame_mark, tracy_gpu_collect, tracy_gpu_zone, tracy_zone},
     renderer::{build_context, GlWindow, Renderer, VSync, WindowedContext},
     running_tracker::RUNNING_TRACKER,
-    settings::{DEFAULT_GRID_SIZE, MIN_GRID_SIZE, SETTINGS},
+    settings::{SettingChanged, DEFAULT_GRID_SIZE, MIN_GRID_SIZE, SETTINGS},
     window::WindowSize,
     CmdLineSettings,
 };
@@ -59,6 +58,7 @@ pub struct WinitWindowWrapper {
     saved_inner_size: PhysicalSize<u32>,
     saved_grid_size: Option<Dimensions>,
     window_command_receiver: UnboundedReceiver<WindowCommand>,
+    window_setting_changed_receiver: UnboundedReceiver<SettingChanged<WindowSettings>>,
     ime_enabled: bool,
     ime_position: PhysicalPosition<i32>,
     requested_columns: Option<u64>,
@@ -83,17 +83,16 @@ impl WinitWindowWrapper {
 
         let skia_renderer = SkiaRenderer::new(&windowed_context);
 
-        let window_command_receiver = EVENT_AGGREGATOR.register_event::<WindowCommand>();
-
         log::info!(
             "window created (scale_factor: {:.4}, font_dimensions: {:?})",
             scale_factor,
             renderer.grid_renderer.font_dimensions,
         );
 
-        let ime_enabled = { SETTINGS.get::<KeyboardSettings>().ime };
+        let settings = SETTINGS.get::<WindowSettings>();
+        let ime_enabled = settings.input_ime;
 
-        match SETTINGS.get::<WindowSettings>().theme.as_str() {
+        match settings.theme.as_str() {
             "light" => set_background("light"),
             "dark" => set_background("dark"),
             "auto" => match window.theme() {
@@ -115,7 +114,8 @@ impl WinitWindowWrapper {
             font_changed_last_frame: false,
             saved_inner_size,
             saved_grid_size: None,
-            window_command_receiver,
+            window_command_receiver: EVENT_AGGREGATOR.register_event(),
+            window_setting_changed_receiver: EVENT_AGGREGATOR.register_event(),
             ime_enabled,
             ime_position: PhysicalPosition::new(-1, -1),
             requested_columns: None,
@@ -158,20 +158,6 @@ impl WinitWindowWrapper {
         self.windowed_context.window().set_ime_allowed(ime_enabled);
     }
 
-    pub fn synchronize_settings(&mut self) {
-        let fullscreen = { SETTINGS.get::<WindowSettings>().fullscreen };
-
-        if self.fullscreen != fullscreen {
-            self.toggle_fullscreen();
-        }
-
-        let ime_enabled = { SETTINGS.get::<KeyboardSettings>().ime };
-
-        if self.ime_enabled != ime_enabled {
-            self.set_ime(ime_enabled);
-        }
-    }
-
     #[allow(clippy::needless_collect)]
     pub fn handle_window_commands(&mut self) {
         tracy_zone!("handle_window_commands", 0);
@@ -182,20 +168,35 @@ impl WinitWindowWrapper {
                     self.mouse_manager.enabled = mouse_enabled
                 }
                 WindowCommand::ListAvailableFonts => self.send_font_names(),
-                WindowCommand::Columns(columns) => {
-                    log::info!("Requested columns {columns}");
-                    self.requested_columns = Some(columns);
-                }
-                WindowCommand::Lines(lines) => {
-                    log::info!("Requested lines {lines}");
-                    self.requested_lines = Some(lines);
-                }
                 WindowCommand::FocusWindow => {
                     self.windowed_context.window().focus_window();
                 }
                 WindowCommand::Minimize => {
                     self.minimize_window();
                     self.is_minimized = true;
+                }
+            }
+        }
+    }
+
+    pub fn handle_window_setting_change_events(&mut self) {
+        while let Ok(setting_changed) = self.window_setting_changed_receiver.try_recv() {
+            if setting_changed.field == "observed_columns"
+                || setting_changed.field == "observed_lines"
+            {
+                log::info!("Observed columns/lines changed");
+                let settings = SETTINGS.get::<WindowSettings>();
+                self.requested_lines = settings.observed_lines;
+                self.requested_columns = settings.observed_columns;
+            } else if setting_changed.field == "fullscreen" {
+                let settings = SETTINGS.get::<WindowSettings>();
+                if self.fullscreen != settings.fullscreen {
+                    self.toggle_fullscreen();
+                }
+            } else if setting_changed.field == "input_ime" {
+                let settings = SETTINGS.get::<WindowSettings>();
+                if self.ime_enabled != settings.input_ime {
+                    self.set_ime(settings.input_ime);
                 }
             }
         }


### PR DESCRIPTION
Tracks the mousemoveevent option so that we dont send mouse move events when we shouldn't.
To do this I updated our settings infrastructure to allow option settings. This is done by adding an `option` attribute to the field that should be backed by an option instead of a global variable. For now all options require a name as they are normally named by neovim and have strange conventions.

While I was in these systems I also added a Changed event which is raised whenever a field on a setting object is updated. This allowed me to remove our current option observation code in favor of tracking updated events.

@fredizzimo to do this I recombined the keyboard settings and window settings structs so that they could both be handled in one location. I believe you introduced that change (maybe) so lmk if you think that will cause problems. Another possible solution for this might be to allow our event system to have multiple subscribers. I didn't go this route because thats a larger change that I didn't want to sneak in here. But I could be convinced if somebody feels strongly.

Fixes https://github.com/neovide/neovide/issues/1838

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- Yes
Global variable Neovide settings are no longer set in nvim on startup.

This feature was a bit odd from the start as I don't really see the use case beyond maybe giving auto completes for variables on startup? I removed it because option values are best implemented via an Option type. Since we don't own the Option or Value types, I couldn't implement From for Option<f64> which I needed for lines and columns. I could see a usecase for bidirectional settings in the future, but this initial setting seems of limited value. However on the off chance somebody depends on it, I'm capturing the change here.