### PR TITLE
 Add underline scale factor config

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -257,18 +257,10 @@ impl GridRenderer {
         let mut underline_paint = Paint::default();
         underline_paint.set_anti_alias(false);
         underline_paint.set_blend_mode(BlendMode::SrcOver);
-        let auto_scaling = SETTINGS
-            .get::<RendererSettings>()
-            .underline_automatic_scaling;
-        // Arbitrary value under which we simply round the line thickness to 1. Anything else
-        // results in ugly aliasing artifacts.
-        let stroke_width = if self.shaper.current_size() < 15. || !auto_scaling {
-            underline_paint.set_anti_alias(false);
-            1.0
-        } else {
-            underline_paint.set_anti_alias(true);
-            self.shaper.current_size() / 10.
-        };
+        let underline_stroke_scale = SETTINGS.get::<RendererSettings>().underline_stroke_scale;
+        // If the stroke width is less than one, clamp it to one otherwise we get nasty aliasing
+        // issues
+        let stroke_width = (self.shaper.current_size() * underline_stroke_scale / 10.).max(1.);
 
         underline_paint
             .set_color(style.special(&self.default_style.colors).to_color())

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -51,7 +51,7 @@ pub struct RendererSettings {
     light_radius: f32,
     debug_renderer: bool,
     profiler: bool,
-    underline_automatic_scaling: bool,
+    underline_stroke_scale: f32,
 }
 
 impl Default for RendererSettings {
@@ -69,7 +69,7 @@ impl Default for RendererSettings {
             light_radius: 5.,
             debug_renderer: false,
             profiler: false,
-            underline_automatic_scaling: false,
+            underline_stroke_scale: 1.,
         }
     }
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -308,23 +308,23 @@ mouse makes it visible again.
 VimScript:
 
 ```vim
-let g:neovide_underline_automatic_scaling = v:false
+let g:neovide_underline_stroke_scale = 1.0
 ```
 
 Lua:
 
 ```lua
-vim.g.neovide_underline_automatic_scaling = false
+vim.g.neovide_underline_stroke_scale = 1.0
 ```
 
-**Available since 0.10.**
+**Unrelease yet.**
 
-Setting `g:neovide_underline_automatic_scaling` to a boolean value determines whether automatic
-scaling of text underlines (including undercurl, underdash, etc.) is enabled. Noticeable for font
-sizes above 15.
+Setting `g:neovide_underline_stroke_scale` to a floating point will increase or decrease the stroke
+width of the underlines (including undercurl, underdash, etc.). If the scaled stroke width is less
+than 1, it is clamped to 1 to prevent strange aliasing.
 
-**Note**: This is currently glitchy, and leads to some underlines being clipped by the line of text
-below.
+**Note**: This is currently glitchy if the scale is too large, and leads to some underlines being 
+clipped by the line of text below.
 
 #### Theme
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -323,7 +323,7 @@ Setting `g:neovide_underline_stroke_scale` to a floating point will increase or 
 width of the underlines (including undercurl, underdash, etc.). If the scaled stroke width is less
 than 1, it is clamped to 1 to prevent strange aliasing.
 
-**Note**: This is currently glitchy if the scale is too large, and leads to some underlines being 
+**Note**: This is currently glitchy if the scale is too large, and leads to some underlines being
 clipped by the line of text below.
 
 #### Theme


### PR DESCRIPTION
Make automatic underline scaling the default and change the existing configuration to be a scale factor as per user request

Implements https://github.com/neovide/neovide/issues/1976

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- Yes

Removed old underline_automatic_scaling config as it seems to work great and I haven't seen any requests for how to enable it. The scale factor feels like a better user facing config.
The new system also slightly adjusts where the aliasing starts so that its a clamp instead of an arbitrary cutoff
