### PR TITLE
refactor: fix compilation warnings

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -18,7 +18,6 @@ use crate::{
 
 pub use cursor::{Cursor, CursorMode, CursorShape};
 pub use draw_command_batcher::DrawCommandBatcher;
-pub use grid::CharacterGrid;
 pub use style::{Colors, Style, UnderlineStyle};
 pub use window::*;
 

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -130,7 +130,7 @@ pub enum FontEdging {
 }
 
 impl FontEdging {
-    const INVALID_ERR: &str = "Invalid edging";
+    const INVALID_ERR: &'static str = "Invalid edging";
     pub fn parse(value: &str) -> Result<Self, &str> {
         match value {
             "antialias" => Ok(Self::AntiAlias),
@@ -151,7 +151,7 @@ pub enum FontHinting {
 }
 
 impl FontHinting {
-    const INVALID_ERR: &str = "Invalid hinting";
+    const INVALID_ERR: &'static str = "Invalid hinting";
     pub fn parse(value: &str) -> Result<Self, &str> {
         match value {
             "full" => Ok(Self::Full),

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -21,7 +21,7 @@ pub use window_size::{
 };
 
 mod config;
-pub use config::{config_path, Config};
+pub use config::Config;
 
 lazy_static! {
     pub static ref SETTINGS: Settings = Settings::new();

--- a/src/window/renderer.rs
+++ b/src/window/renderer.rs
@@ -20,11 +20,8 @@ fn create_surface(
     let size = windowed_context.get_render_target_size();
     let backend_render_target = make_gl(
         size.into(),
-        Some(pixel_format.num_samples() as usize),
-        pixel_format
-            .stencil_size()
-            .try_into()
-            .expect("Could not convert stencil"),
+        Some(pixel_format.num_samples().into()),
+        pixel_format.stencil_size().into(),
         fb_info,
     );
     windowed_context.resize(


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Other

## Did this PR introduce a breaking change? 
- No

This just fixes some warnings when compiling on nightly and running cargo clippy. No functionality has been changed.