### PR TITLE
Fix remember window size

### DIFF
--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -40,19 +40,37 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
         Some(ref ident) => {
             let vim_setting_name = format!("{prefix}{ident}");
 
-            let location = match option(field) {
-                Ok(option) => match option {
-                    Some(option_name) => quote! {{ crate::settings::SettingLocation::NeovimOption(#option_name.to_owned()) }},
-                    None => quote! {{ crate::settings::SettingLocation::NeovideGlobal(#vim_setting_name.to_owned()) }},
-                },
+            let option_name = match option(field) {
+                Ok(option_name) => option_name,
                 Err(error) => {
                     return error.to_compile_error();
                 }
             };
 
+            let location = match &option_name {
+                Some(option_name) => quote! {{ crate::settings::SettingLocation::NeovimOption(#option_name.to_owned()) }},
+                None => quote! {{ crate::settings::SettingLocation::NeovideGlobal(#vim_setting_name.to_owned()) }},
+            };
+
             let field_ident = field.ident.as_ref().unwrap();
             let case_name = field_ident.to_string().to_case(Case::Pascal);
             let case_ident = Ident::new(&case_name, field_ident.span());
+
+            // Only create a reader function for global neovide variables
+            let reader = if option_name.is_none() {
+                quote! {
+                    fn reader(settings: &crate::settings::Settings) -> Option<rmpv::Value> {
+                        let s = settings.get::<#name>();
+                        Some(s.#ident.into())
+                    }
+                }
+            } else {
+                quote! {
+                    fn reader(_settings: &crate::settings::Settings) -> Option<rmpv::Value> {
+                        None
+                    }
+                }
+            };
 
             quote! {{
                 fn update(settings: &crate::settings::Settings, value: rmpv::Value) {
@@ -64,9 +82,12 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
                     );
                 }
 
+                #reader
+
                 settings.set_setting_handlers(
                     #location,
                     update,
+                    reader,
                 );
             }}
         }

--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -73,13 +73,15 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
             };
 
             quote! {{
-                fn update(settings: &crate::settings::Settings, value: rmpv::Value) {
+                fn update(settings: &crate::settings::Settings, value: rmpv::Value, send_changed_event: bool) {
                     let mut s = settings.get::<#name>();
                     s.#ident.parse_from_value(value);
                     settings.set(&s);
-                    crate::event_aggregator::EVENT_AGGREGATOR.send(
-                        #event_name::#case_ident(s.#ident.clone()),
-                    );
+                    if send_changed_event {
+                        crate::event_aggregator::EVENT_AGGREGATOR.send(
+                            #event_name::#case_ident(s.#ident.clone()),
+                        );
+                    }
                 }
 
                 #reader

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -117,7 +117,6 @@ async fn launch(grid_size: Option<Dimensions>) -> Result<NeovimSession> {
 
     start_ui_command_handler(Arc::clone(&session.neovim));
     SETTINGS.read_initial_values(&session.neovim).await?;
-    SETTINGS.setup_changed_listeners(&session.neovim).await?;
 
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);


### PR DESCRIPTION
The new option observation starts sending notifications earlier than the previous solution. So we need to ignore the columns and lines change notifications until the ui has finished initializing or we don't properly set the window size

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
