### PR TITLE
Add support for variable font weights

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -277,6 +277,7 @@ impl Editor {
             EditorCommand::RedrawScreen => {
                 tracy_zone!("EditorRedrawScreen");
                 self.redraw_screen();
+                self.draw_command_batcher.send_batch();
             }
         };
     }

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     bridge::EditorMode,
     editor::{Cursor, CursorShape},
     profiling::tracy_zone,
-    renderer::animation_utils::*,
+    renderer::{animation_utils::*, RendererSettings},
     renderer::{GridRenderer, RenderedWindow},
     settings::{ParseFromValue, SETTINGS},
     window::UserEvent,
@@ -317,7 +317,11 @@ impl CursorRenderer {
         let bold = style.as_ref().map(|x| x.bold).unwrap_or(false);
         let italic = style.as_ref().map(|x| x.italic).unwrap_or(false);
 
-        let blobs = &grid_renderer.shaper.shape_cached(character, bold, italic);
+        let blobs = &grid_renderer.shaper.shape_cached(
+            character,
+            bold.then_some(SETTINGS.get::<RendererSettings>().bold_weight),
+            italic,
+        );
 
         for blob in blobs.iter() {
             canvas.draw_text_blob(

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -62,12 +62,11 @@ impl FontOptions {
             } else if part.starts_with(FONT_WIDTH_PREFIX) && part.len() > 1 {
                 font_options.allow_float_size |= part[1..].contains(ALLOW_FLOAT_SIZE_OPT);
                 font_options.width = parse_pixels(part).map_err(|_| INVALID_WIDTH_ERR)?;
-            } else if part.starts_with(FONT_WEIGHT_PREFIX) {
-                if part.len() == 1 {
+            } else if let Some(weight) = part.strip_prefix(FONT_WEIGHT_PREFIX) {
+                if weight.is_empty() {
                     font_options.weight = SETTINGS.get::<RendererSettings>().bold_weight;
                 } else {
-                    font_options.weight =
-                        part[1..].parse::<u32>().map_err(|_| INVALID_WEIGHT_ERR)?;
+                    font_options.weight = weight.parse::<u32>().map_err(|_| INVALID_WEIGHT_ERR)?;
                 }
             } else if part == FONT_ITALIC_OPT {
                 font_options.italic = true;

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -196,7 +196,8 @@ impl GridRenderer {
         paint.set_anti_alias(false);
         paint.set_blend_mode(BlendMode::SrcOver);
 
-        if SETTINGS.get::<RendererSettings>().debug_renderer {
+        let settings = SETTINGS.get::<RendererSettings>();
+        if settings.debug_renderer {
             let random_hsv: HSV = (rand::random::<f32>() * 360.0, 1.0, 1.0).into();
             let random_color = random_hsv.to_color(255);
             paint.set_color(random_color);
@@ -215,7 +216,11 @@ impl GridRenderer {
         if !trimmed.is_empty() {
             for blob in self
                 .shaper
-                .shape_cached(trimmed.to_string(), style.bold, style.italic)
+                .shape_cached(
+                    trimmed.to_string(),
+                    style.bold.then_some(settings.bold_weight),
+                    style.italic,
+                )
                 .iter()
             {
                 tracy_zone!("draw_text_blob");


### PR DESCRIPTION
Adds the option to add a number after b to represent the configured font weight. (We should decide if we would prefer to change to w instead of b for this. I went with b as it was part of what we already had)
Add an option to configure what weight bold should be

![be7ab14a-0cb2-4714-aa3f-90c211d56651](https://github.com/neovide/neovide/assets/3323631/573e03a5-0189-4d63-b696-ab99da0ea12b)

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
