### PR TITLE
fix: fix console window not hidden for Windows shell command

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -1,4 +1,6 @@
+#[cfg(windows)]
 use std::os::windows::process::CommandExt;
+
 use std::{
     env,
     process::{Command as StdCommand, Stdio},
@@ -65,6 +67,7 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> StdCommand {
 
         result
     } else {
+        // On Linux and non-WSL Windows, just run the command directly
         let mut result = StdCommand::new(command);
         result.args(args);
 


### PR DESCRIPTION

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

Added a missing CREATE_NO_WINDOW when spawning a new shell command on Windows. Without this flag, a console window would temporarily appear and disappear while starting Neovide. Although it only appeared briefly, it could also steal focus from the Neovide window. I also standardized on just one way to set this flag during process creation, since there were multiple different styles within just a couple of lines of each other.