### PR TITLE
fix: prevent empty window title

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -81,8 +81,11 @@ impl Editor {
     pub fn handle_editor_command(&mut self, command: EditorCommand) {
         match command {
             EditorCommand::NeovimRedrawEvent(event) => match event {
-                RedrawEvent::SetTitle { title } => {
+                RedrawEvent::SetTitle { mut title } => {
                     tracy_zone!("EditorSetTitle");
+                    if title.is_empty() {
+                        title = "Neovide".to_string()
+                    }
                     EVENT_AGGREGATOR.send(WindowCommand::TitleChanged(title));
                 }
                 RedrawEvent::ModeInfoSet { cursor_modes } => {


### PR DESCRIPTION
If Neovim attempts to send an empty window title, it is now set to
Neovide instead, rather than the empty string.

This improves two user scenarios:

- Users who utilize assistive technologies will now always observe a
  window title by default.
- Users of window managers that rely on window titles will have improved
  integration.

The precipitating use case was using Komorebi, a tiling window manager
for Windows. Komorebi uses an empty window title as a strong signal that
the software is a hidden window, as this is a common convention on the
platform.

Updates https://github.com/neovide/neovide/issues/1553