### PR TITLE
feat: persist grid size along with window size

### DIFF
--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -30,6 +30,8 @@ pub enum PersistentWindowSettings {
         position: PhysicalPosition<i32>,
         #[serde(default)]
         pixel_size: Option<PhysicalSize<u32>>,
+        #[serde(default)]
+        grid_size: Option<Dimensions>,
     },
 }
 
@@ -73,7 +75,8 @@ pub fn load_last_window_settings() -> Result<PersistentWindowSettings, String> {
 
 pub fn save_window_size(
     maximized: bool,
-    size: PhysicalSize<u32>,
+    pixel_size: PhysicalSize<u32>,
+    grid_size: Dimensions,
     position: Option<PhysicalPosition<i32>>,
 ) {
     let window_settings = SETTINGS.get::<WindowSettings>();
@@ -83,7 +86,8 @@ pub fn save_window_size(
             PersistentWindowSettings::Maximized
         } else {
             PersistentWindowSettings::Windowed {
-                pixel_size: { window_settings.remember_window_size.then_some(size) },
+                pixel_size: { window_settings.remember_window_size.then_some(pixel_size) },
+                grid_size: { window_settings.remember_window_size.then_some(grid_size) },
                 position: {
                     window_settings
                         .remember_window_position

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -325,6 +325,7 @@ pub fn main_loop(
             save_window_size(
                 window.is_maximized(),
                 window.inner_size(),
+                window_wrapper.get_grid_size(),
                 window.outer_position().ok(),
             );
             window_target.exit();

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -197,9 +197,8 @@ pub enum WindowSize {
     NeovimGrid, // The geometry is read from init.vim/lua
 }
 
-pub fn determine_window_size() -> WindowSize {
+pub fn determine_window_size(window_settings: Option<&PersistentWindowSettings>) -> WindowSize {
     let cmd_line = SETTINGS.get::<CmdLineSettings>();
-    let window_settings = load_last_window_settings().ok();
 
     match cmd_line.geometry {
         GeometryArgs {
@@ -221,7 +220,7 @@ pub fn determine_window_size() -> WindowSize {
             Some(PersistentWindowSettings::Windowed {
                 pixel_size: Some(pixel_size),
                 ..
-            }) => WindowSize::Size(pixel_size),
+            }) => WindowSize::Size(*pixel_size),
             _ => WindowSize::Size(DEFAULT_WINDOW_SIZE),
         },
     }
@@ -264,6 +263,7 @@ pub fn main_loop(
         save_window_size(
             window.is_maximized(),
             window.inner_size(),
+            window_wrapper.get_grid_size(),
             window.outer_position().ok(),
         );
     }));

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -423,6 +423,10 @@ impl WinitWindowWrapper {
         should_render
     }
 
+    pub fn get_grid_size(&self) -> Dimensions {
+        self.renderer.get_grid_size()
+    }
+
     fn update_window_size_from_grid(&mut self, window_padding: &WindowPadding) {
         let window = self.windowed_context.window();
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

When neovide starts up, it uses a default grid size unless the grid size has explicitly been provided. This is problematic when relying on neovide to remember the last window size, because the grid size will be out of sync with the physical window size. The UI will initially be rendered at the wrong size, which not only doesn't look great, but exposes some other issues like the noice mini view not handling resizes properly. So if a noice mini view is rendered immediately upon startup, and neovide resizes the grid, the mini view will stay in place until it times out and disappears. In my case it stays in the middle of the screen until the 5 second timeout passes, which is quite annoying.

I thought about playing with not making the window visible until the first resize had been handled, but that wouldn't solve the problem of plugins not handling resizes properly, and it would also slow down the time until window is first shown. It didn't seem worth going down that path.

I decided to not introduce another setting flag since I think it makes sense to save the physical window size and the grid size together. The saved grid size would be incorrect if the font dimensions change between neovide launches, but most people probably won't change to very different font dimensions between launches. Even if that happens, the saved grid size will probably be more reasonable than the default, and if it's not it will be resized immediately if needed, so it's no worse than the current situation.