### PR TITLE
fix: Don't poll the event loop on Wayland to reduce the power usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,9 +2849,9 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcbdba03a3cfc5f757469fd5b6d795fc461484c97e47e94b0fc7db93261d9c5"
+checksum = "3db0b1cc1bb12a70457300d9affc07acb587390d971a796dac2f4d9bca8df776"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,13 @@ default = []
 embed-fonts = []
 profiling = ["dep:tracy-client-sys"]
 gpu_profiling = ["profiling"]
+# Corresponds to https://github.com/nagisa/rust_tracy_client/blob/main/FEATURES.mkd
+tracy-fibers = ["tracy-client-sys?/fibers"]
+tracy-system-tracing = ["tracy-client-sys?/system-tracing"]
+tracy-context-switch-tracing = ["tracy-client-sys?/context-switch-tracing"]
+tracy-sampling = ["tracy-client-sys?/sampling"]
+tracy-code-transfer = ["tracy-client-sys?/code-transfer"]
+tracy-callstack-inlines = ["tracy-client-sys?/callstack-inlines"]
 
 [dependencies]
 anyhow = { version = "1.0.75", features = ["backtrace"] }
@@ -58,7 +65,7 @@ time = "0.3.9"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 toml = "0.7.3"
-tracy-client-sys = { version = "0.19.0", optional = true }
+tracy-client-sys = { version = "0.22.0", optional = true, default-features = false, features = ["broadcast", "delayed-init", "enable", "manual-lifetime"] }
 unicode-segmentation = "1.9.0"
 which = "4.2.5"
 winit = { version = "=0.29.4", features = ["serde"] }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -245,7 +245,7 @@ pub fn main_loop(
                 break;
             }
 
-            let (wait_duration, _) = update_loop.get_event_wait_time();
+            let (wait_duration, _) = update_loop.get_event_wait_time(&window_wrapper.vsync);
             let event = rx
                 .recv_timeout(wait_duration)
                 .map_err(|e| matches!(e, RecvTimeoutError::Disconnected));


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
When the winit vsync is used, the event loop should never be polled, otherwise the CPU usage is just wasted. Winit will send the redraw request and wake the loop up when it's time to render anyway.

All other ways of doing vsync, just blocks inside the loop itself, so polling should be used there.

This also updates the tracy profiler to the latest version.

## Did this PR introduce a breaking change? 
- No
