### PR TITLE
fix: Change the order of vsync wait and swap buffers to reduce latency

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -325,13 +325,13 @@ impl WinitWindowWrapper {
             self.skia_renderer.gr_context.flush_and_submit();
         }
         {
-            tracy_gpu_zone!("wait for vsync");
-            self.vsync.wait_for_vsync();
-        }
-        {
             tracy_gpu_zone!("swap buffers");
             self.windowed_context.window().pre_present_notify();
             self.windowed_context.swap_buffers().unwrap();
+        }
+        {
+            tracy_gpu_zone!("wait for vsync");
+            self.vsync.wait_for_vsync();
         }
         emit_frame_mark();
         tracy_gpu_collect();


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This changes the order of waiting for vsync and swapping the buffers. This reduces the input latency since reading the inputs and the swap happens during the same vsync interval, rather than different ones.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No