### PR TITLE
fix!: Ignore window size when minimized

### DIFF
--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -70,7 +70,7 @@ pub fn save_window_size(window_wrapper: &WinitWindowWrapper) {
     let window = window_wrapper.windowed_context.window();
     // Don't save the window size when the window is minimized, since the size can be 0
     // Note wayland can't determine this
-    if matches!(window.is_minimized(), Some(true)) {
+    if window.is_minimized() == Some(true) {
         return;
     }
     let maximized = window.is_maximized();

--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 
-use crate::{dimensions::Dimensions, settings::SETTINGS, window::WindowSettings};
+use crate::{
+    dimensions::Dimensions, settings::SETTINGS, window::WindowSettings, window::WinitWindowWrapper,
+};
 
 const SETTINGS_FILE: &str = "neovide-settings.json";
 
@@ -64,12 +66,17 @@ pub fn load_last_window_settings() -> Result<PersistentWindowSettings, String> {
     Ok(loaded_settings)
 }
 
-pub fn save_window_size(
-    maximized: bool,
-    pixel_size: PhysicalSize<u32>,
-    grid_size: Dimensions,
-    position: Option<PhysicalPosition<i32>>,
-) {
+pub fn save_window_size(window_wrapper: &WinitWindowWrapper) {
+    let window = window_wrapper.windowed_context.window();
+    // Don't save the window size when the window is minimized, since the size can be 0
+    // Note wayland can't determine this
+    if matches!(window.is_minimized(), Some(true)) {
+        return;
+    }
+    let maximized = window.is_maximized();
+    let pixel_size = window.inner_size();
+    let grid_size = window_wrapper.get_grid_size();
+    let position = window.outer_position().ok();
     let window_settings = SETTINGS.get::<WindowSettings>();
 
     let settings = PersistentSettings {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -13,7 +13,7 @@ mod draw_background;
 use std::env;
 
 use winit::{
-    dpi::PhysicalSize,
+    dpi::{PhysicalSize, Size},
     error::EventLoopError,
     event::Event,
     event_loop::{EventLoop, EventLoopBuilder},
@@ -62,6 +62,14 @@ static ICON: &[u8] = include_bytes!("../../assets/neovide.ico");
 const DEFAULT_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
     width: 500,
     height: 500,
+};
+const MIN_PERSISTEN_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
+    width: 300,
+    height: 150,
+};
+const MAX_PERSISTENT_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
+    width: 8192,
+    height: 8192,
 };
 
 #[derive(Clone, Debug)]
@@ -219,7 +227,19 @@ pub fn determine_window_size(window_settings: Option<&PersistentWindowSettings>)
             Some(PersistentWindowSettings::Windowed {
                 pixel_size: Some(pixel_size),
                 ..
-            }) => WindowSize::Size(*pixel_size),
+            }) => {
+                let size = Size::new(*pixel_size);
+                let scale = 1.0;
+                WindowSize::Size(
+                    Size::clamp(
+                        size,
+                        MIN_PERSISTEN_WINDOW_SIZE.into(),
+                        MAX_PERSISTENT_WINDOW_SIZE.into(),
+                        scale,
+                    )
+                    .to_physical(scale),
+                )
+            }
             _ => WindowSize::Size(DEFAULT_WINDOW_SIZE),
         },
     }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -44,7 +44,6 @@ use keyboard_manager::KeyboardManager;
 use mouse_manager::MouseManager;
 use renderer::SkiaRenderer;
 use update_loop::UpdateLoop;
-use window_wrapper::WinitWindowWrapper;
 
 use crate::{
     cmd_line::{CmdLineSettings, GeometryArgs},
@@ -56,6 +55,7 @@ use crate::{
 };
 pub use error_window::show_error_window;
 pub use settings::{WindowSettings, WindowSettingsChanged};
+pub use window_wrapper::WinitWindowWrapper;
 
 static ICON: &[u8] = include_bytes!("../../assets/neovide.ico");
 
@@ -275,13 +275,7 @@ pub fn main_loop(
             }
         }
 
-        let window = window_wrapper.windowed_context.window();
-        save_window_size(
-            window.is_maximized(),
-            window.inner_size(),
-            window_wrapper.get_grid_size(),
-            window.outer_position().ok(),
-        );
+        save_window_size(&window_wrapper);
     });
 
     let result = event_loop.run(|e, window_target| {
@@ -331,13 +325,7 @@ pub fn main_loop(
         }
 
         if !RUNNING_TRACKER.is_running() {
-            let window = window_wrapper.windowed_context.window();
-            save_window_size(
-                window.is_maximized(),
-                window.inner_size(),
-                window_wrapper.get_grid_size(),
-                window.outer_position().ok(),
-            );
+            save_window_size(&window_wrapper);
             window_target.exit();
         } else {
             window_target.set_control_flow(update_loop.step(&mut window_wrapper, Ok(e)).unwrap());

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -414,7 +414,7 @@ impl WinitWindowWrapper {
 
             // Make the window Visible only after the size is adjusted
             self.windowed_context.window().set_visible(true);
-        } else if !matches!(self.windowed_context.window().is_minimized(), Some(true)) {
+        } else if self.windowed_context.window().is_minimized() != Some(true) {
             // NOTE: Only actually resize the grid when the window is not minimized
             // Some platforms return a zero size when that is the case, so we should not try to resize to that.
             let new_size = self.windowed_context.window().inner_size();

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -414,7 +414,9 @@ impl WinitWindowWrapper {
 
             // Make the window Visible only after the size is adjusted
             self.windowed_context.window().set_visible(true);
-        } else {
+        } else if !matches!(self.windowed_context.window().is_minimized(), Some(true)) {
+            // NOTE: Only actually resize the grid when the window is not minimized
+            // Some platforms return a zero size when that is the case, so we should not try to resize to that.
             let new_size = self.windowed_context.window().inner_size();
             if self.saved_inner_size != new_size || self.font_changed_last_frame || padding_changed
             {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Some platforms report a zero window size when minimized, so ignore that when saving the window size and resizing the Neovide grid.

Also enforce a minimum and maximum window size when restoring a saved size. This ensures that a window with a zero size is not displayed.

Fixes
* https://github.com/neovide/neovide/issues/2015

Fixes partially:
* https://github.com/neovide/neovide/issues/2141

It also fixes the annoying issue that the window layout changes when the window is minimized and then restored again.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, windows sizes less than 300x150 or bigger than 8192x8192 can't be saved.

