### PR TITLE
style: fix typos

### DIFF
--- a/lua/intro.lua
+++ b/lua/intro.lua
@@ -130,7 +130,7 @@ local function get_intro_lines()
 
     -- Show the sponsor and register message one out of four times, the Uganda
     -- message two out of four times.
-    -- Use Vim rather tha lua  for rand to avoid polluting the random seed
+    -- Use Vim rather than lua for rand to avoid polluting the random seed
     local seed = vim.fn.srand()
     local help_type = (vim.fn.rand(seed) % 4) + 1
     if help_type <= 2 then

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -202,14 +202,14 @@ impl RenderedWindow {
             self.position_t = (self.position_t + dt / settings.position_animation_length).min(1.0);
         }
 
-        let prev_positon = self.grid_current_position;
+        let prev_position = self.grid_current_position;
         self.grid_current_position = ease_point(
             ease_out_expo,
             self.grid_start_position,
             self.get_target_position(outer_size, padding_as_grid),
             self.position_t,
         );
-        animating |= self.grid_current_position != prev_positon;
+        animating |= self.grid_current_position != prev_position;
 
         animating |= self
             .scroll_animation
@@ -333,7 +333,7 @@ impl RenderedWindow {
                 Color::from_argb((0.03 * 255.) as u8, 0, 0, 0),
                 Color::from_argb((0.35 * 255.) as u8, 0, 0, 0),
                 // Directional Light flag is necessary to make the shadow render consistently
-                // across varius sizes of floating windows. It effects how the light direction is
+                // across various sizes of floating windows. It effects how the light direction is
                 // processed.
                 Some(ShadowFlags::DIRECTIONAL_LIGHT),
             );

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -186,7 +186,7 @@ impl KeyboardManager {
 
     pub fn format_modifier_string(&self, text: &str, is_special: bool) -> String {
         // Shift should always be sent together with special keys (Enter, Space, F keys and so on).
-        // And as a special case togeter with CTRL and standard a-z characters.
+        // And as a special case together with CTRL and standard a-z characters.
         // In all other cases the resulting character is enough.
         // Note that, in Neovim <C-a> and <C-A> are the same, but <C-S-A> is different.
         // Actually, <C-S-a> is the same as <C-S-A>, since Neovim converts all shifted

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -63,7 +63,7 @@ const DEFAULT_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
     width: 500,
     height: 500,
 };
-const MIN_PERSISTEN_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
+const MIN_PERSISTENT_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
     width: 300,
     height: 150,
 };
@@ -233,7 +233,7 @@ pub fn determine_window_size(window_settings: Option<&PersistentWindowSettings>)
                 WindowSize::Size(
                     Size::clamp(
                         size,
-                        MIN_PERSISTEN_WINDOW_SIZE.into(),
+                        MIN_PERSISTENT_WINDOW_SIZE.into(),
                         MAX_PERSISTENT_WINDOW_SIZE.into(),
                         scale,
                     )

--- a/website/docs/maintainer-cookbook.md
+++ b/website/docs/maintainer-cookbook.md
@@ -103,7 +103,7 @@ Now here's where the order becomes important:
       (where `$tag` is the tag name)
 
 5. Run `cargo build` and make sure it succeeds, **remember to `git add
-  Cargo.lock` to make sure releases stay reproducable
+  Cargo.lock` to make sure releases stay reproducible
   ([#1628](https://github.com/neovide/neovide/issues/1628),
   [#1482](https://github.com/neovide/neovide/issues/1482))**
 6. Create a commit called `Bump version to $tag`


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

Done with `typos --exclude src/bridge/ui_commands.rs -w` and fixing the remaining printed ambiguous ones manually.

`ui_commands.rs` had a false positive in the vim options.

## What kind of change does this PR introduce?
- Codestyle

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
