### PR TITLE
fix: Scrolling of windows with winbar or native borders

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -97,3 +97,25 @@ vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
         rpcnotify("neovide.quit", vim.v.exiting)
     end
 })
+
+local function unlink_highlight(name)
+    local highlight = vim.api.nvim_get_hl(0, {name=name, link=false})
+    vim.api.nvim_set_hl(0, name, highlight)
+end
+
+-- Neovim only reports the final highlight group in the ext_hlstate information
+-- So we need to unlink all the groups when the color scheme is changed
+-- This is quite hacky, so let the user disable it.
+vim.api.nvim_create_autocmd({ "ColorScheme" }, {
+    pattern = "*",
+    nested = false,
+    callback = function()
+        if vim.g.neovide_unlink_border_highlights then
+            unlink_highlight("FloatTitle")
+            unlink_highlight("FloatFooter")
+            unlink_highlight("FloatBorder")
+            unlink_highlight("WinBar")
+            unlink_highlight("WinBarNC")
+        end
+    end
+})

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -9,7 +9,9 @@ use rmpv::Value;
 use skia_safe::Color4f;
 use strum::AsRefStr;
 
-use crate::editor::{Colors, CursorMode, CursorShape, Style, UnderlineStyle};
+use crate::editor::{
+    Colors, CursorMode, CursorShape, HighlightInfo, HighlightKind, Style, UnderlineStyle,
+};
 
 #[derive(Clone, Debug)]
 pub enum ParseError {
@@ -476,7 +478,7 @@ fn parse_default_colors(default_colors_arguments: Vec<Value>) -> Result<RedrawEv
     })
 }
 
-fn parse_style(style_map: Value) -> Result<Style> {
+fn parse_style(style_map: Value, info_array: Value) -> Result<Style> {
     let attributes = parse_map(style_map)?;
 
     let mut style = Style::new(Colors::new(None, None, None));
@@ -524,13 +526,75 @@ fn parse_style(style_map: Value) -> Result<Style> {
         }
     }
 
+    style.infos = parse_array(info_array)?
+        .into_iter()
+        .map(parse_highlight_info)
+        .collect::<Result<Vec<_>>>()?;
+
     Ok(style)
 }
 
-fn parse_hl_attr_define(hl_attr_define_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let [id, attributes, _terminal_attributes, _info] = extract_values(hl_attr_define_arguments)?;
+fn parse_highlight_info(info_map: Value) -> Result<HighlightInfo> {
+    let attributes = parse_map(info_map)?;
 
-    let style = parse_style(attributes)?;
+    let mut kind = None;
+    let mut ui_name = None;
+    let mut hi_name = None;
+    let mut id = None;
+
+    for attribute in attributes {
+        if let (Value::String(name), value) = attribute {
+            match (name.as_str().unwrap(), value) {
+                ("kind", value) => {
+                    let kind_str = parse_string(value)?;
+                    match kind_str.as_str() {
+                        "ui" => kind = Some(HighlightKind::Ui),
+                        "syntax" => kind = Some(HighlightKind::Syntax),
+                        "terminal" => kind = Some(HighlightKind::Terminal),
+                        _ => return Err(ParseError::Format("Invalid highlight kind".to_string())),
+                    }
+                }
+                ("ui_name", value) => ui_name = Some(parse_string(value)?),
+                ("hi_name", value) => hi_name = Some(parse_string(value)?),
+                ("id", value) => id = Some(parse_u64(value)?),
+                _ => debug!("Ignored highlight info attribute: {}", name),
+            }
+        } else {
+            return Err(ParseError::Format(
+                "Invalid highlight info format".to_string(),
+            ));
+        }
+    }
+    let kind = kind.ok_or(ParseError::Format(
+        "kind field not found in highlight info".to_string(),
+    ))?;
+    let ui_name = if kind == HighlightKind::Ui {
+        ui_name.ok_or(ParseError::Format(
+            "ui_name field not found in highlight info".to_string(),
+        ))?
+    } else {
+        String::default()
+    };
+    let hi_name = hi_name
+        .ok_or(ParseError::Format(
+            "hi_name field not found in highlight info".to_string(),
+        ))?
+        .to_string();
+    let id = id.ok_or(ParseError::Format(
+        "id field not found in highlight info".to_string(),
+    ))?;
+    Ok(HighlightInfo {
+        kind,
+        ui_name,
+        hi_name,
+        id,
+    })
+}
+
+fn parse_hl_attr_define(hl_attr_define_arguments: Vec<Value>) -> Result<RedrawEvent> {
+    let [id, attributes, _terminal_attributes, infos] = extract_values(hl_attr_define_arguments)?;
+
+    let style = parse_style(attributes, infos)?;
     Ok(RedrawEvent::HighlightAttributesDefine {
         id: parse_u64(id)?,
         style,

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -550,7 +550,8 @@ fn parse_highlight_info(info_map: Value) -> Result<HighlightInfo> {
                     match kind_str.as_str() {
                         "ui" => kind = Some(HighlightKind::Ui),
                         "syntax" => kind = Some(HighlightKind::Syntax),
-                        "terminal" => kind = Some(HighlightKind::Terminal),
+                        // The documentation says terminal but Neovim 0.9.4 sends term...
+                        "terminal" | "term" => kind = Some(HighlightKind::Terminal),
                         _ => return Err(ParseError::Format("Invalid highlight kind".to_string())),
                     }
                 }
@@ -575,11 +576,8 @@ fn parse_highlight_info(info_map: Value) -> Result<HighlightInfo> {
     } else {
         String::default()
     };
-    let hi_name = hi_name
-        .ok_or(ParseError::Format(
-            "hi_name field not found in highlight info".to_string(),
-        ))?
-        .to_string();
+    // hi_name can actually be absent for terminal, even though the documentation indicates otherwise
+    let hi_name = hi_name.unwrap_or_default();
     let id = id.ok_or(ParseError::Format(
         "id field not found in highlight info".to_string(),
     ))?;

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -123,6 +123,7 @@ async fn launch(handler: NeovimHandler, grid_size: Option<Dimensions>) -> Result
 
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
+    options.set_hlstate_external(true);
     options.set_multigrid_external(!settings.no_multi_grid);
     options.set_rgb(true);
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 
 pub use cursor::{Cursor, CursorMode, CursorShape};
 pub use draw_command_batcher::DrawCommandBatcher;
-pub use style::{Colors, Style, UnderlineStyle};
+pub use style::{Colors, HighlightInfo, HighlightKind, Style, UnderlineStyle};
 pub use window::*;
 
 const MODE_CMDLINE: u64 = 4;

--- a/src/editor/style.rs
+++ b/src/editor/style.rs
@@ -31,6 +31,23 @@ pub struct Style {
     pub blend: u8,
     #[new(default)]
     pub underline: Option<UnderlineStyle>,
+    #[new(default)]
+    pub infos: Vec<HighlightInfo>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum HighlightKind {
+    Ui,
+    Syntax,
+    Terminal,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HighlightInfo {
+    pub kind: HighlightKind,
+    pub ui_name: String,
+    pub hi_name: String,
+    pub id: u64,
 }
 
 impl Style {

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -258,12 +258,17 @@ impl CursorRenderer {
             let mut grid_y = cursor_grid_y as f32 + window.grid_current_position.y
                 - window.scroll_animation.position;
 
+            let top_border = (window.top_border.len() as u64) as f32;
+            let bottom_border = (window.bottom_border.len() as u64) as f32;
+
             // Prevent the cursor from targeting a position outside its current window. Since only
             // the vertical direction is effected by scrolling, we only have to clamp the vertical
             // grid position.
-            grid_y = grid_y
-                .max(window.grid_current_position.y)
-                .min(window.grid_current_position.y + window.grid_size.height as f32 - 1.0);
+            grid_y = grid_y.max(window.grid_current_position.y + top_border).min(
+                window.grid_current_position.y + window.grid_size.height as f32
+                    - 1.0
+                    - bottom_border,
+            );
 
             self.destination = (grid_x * font_width as f32, grid_y * font_height as f32).into();
         } else {

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -510,6 +510,8 @@ impl RenderedWindow {
                 line_fragments,
             } => {
                 tracy_zone!("draw_line_cmd", 0);
+                // At the moment we only consider top and bottom borders, and winbar is also one type of border
+                // So, lines with purly border highlight groups are considered borders.
                 let is_border = line_fragments
                     .iter()
                     .map(|fragment| {

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -237,7 +237,7 @@ impl RenderedWindow {
         let line_height = font_dimensions.height as f32;
         let mut has_transparency = false;
 
-        let lines: Vec<(Matrix, &Rc<RefCell<Line>>)> = if self.grid_size.height > 0 {
+        let lines: Vec<(Matrix, &Rc<RefCell<Line>>)> = if !self.scrollback_lines.is_empty() {
             (0..self.grid_size.height as isize + 1)
                 .filter_map(|i| {
                     self.scrollback_lines[scroll_offset_lines + i]
@@ -261,27 +261,24 @@ impl RenderedWindow {
             Vec::new()
         };
 
-        let border_lines: Vec<(Matrix, &Rc<RefCell<Line>>)> = if self.grid_size.height > 0 {
-            self.top_border
-                .clone()
-                .chain(self.bottom_border.clone())
-                .filter_map(|i| {
-                    self.actual_lines[i]
-                        .as_ref()
-                        .and_then(|line| line.borrow().is_border.then_some((i, line)))
-                })
-                .map(|(i, line)| {
-                    let mut matrix = Matrix::new_identity();
-                    matrix.set_translate((
-                        pixel_region.left(),
-                        pixel_region.top() + (i * font_dimensions.height as isize) as f32,
-                    ));
-                    (matrix, line)
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let border_lines: Vec<(Matrix, &Rc<RefCell<Line>>)> = self
+            .top_border
+            .clone()
+            .chain(self.bottom_border.clone())
+            .filter_map(|i| {
+                self.actual_lines[i]
+                    .as_ref()
+                    .and_then(|line| line.borrow().is_border.then_some((i, line)))
+            })
+            .map(|(i, line)| {
+                let mut matrix = Matrix::new_identity();
+                matrix.set_translate((
+                    pixel_region.left(),
+                    pixel_region.top() + (i * font_dimensions.height as isize) as f32,
+                ));
+                (matrix, line)
+            })
+            .collect();
 
         let inner_region = Rect::from_xywh(
             pixel_region.x(),

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -82,8 +82,8 @@ pub struct RenderedWindow {
     scrollback_lines: RingBuffer<Option<Arc<Mutex<Line>>>>,
     actual_lines: RingBuffer<Option<Arc<Mutex<Line>>>>,
     scroll_delta: isize,
-    top_border: Range<isize>,
-    bottom_border: Range<isize>,
+    pub top_border: Range<isize>,
+    pub bottom_border: Range<isize>,
 
     grid_start_position: Point,
     pub grid_current_position: Point,

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -261,7 +261,7 @@ impl RenderedWindow {
             Vec::new()
         };
 
-        let border_lines: Vec<(Matrix, &Rc<RefCell<Line>>)> = self
+        let border_lines: Vec<_> = self
             .top_border
             .clone()
             .chain(self.bottom_border.clone())

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -23,6 +23,7 @@ pub struct WindowSettings {
     pub theme: String,
     pub input_macos_alt_is_meta: bool,
     pub input_ime: bool,
+    pub unlink_border_highlights: bool,
 
     #[option = "mousemoveevent"]
     pub mouse_move_event: bool,
@@ -59,6 +60,7 @@ impl Default for WindowSettings {
             mouse_move_event: false,
             observed_lines: None,
             observed_columns: None,
+            unlink_border_highlights: true,
         }
     }
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -317,7 +317,7 @@ Lua:
 vim.g.neovide_underline_stroke_scale = 1.0
 ```
 
-**Unrelease yet.**
+**Unreleased yet.**
 
 Setting `g:neovide_underline_stroke_scale` to a floating point will increase or decrease the stroke
 width of the underlines (including undercurl, underdash, etc.). If the scaled stroke width is less
@@ -345,6 +345,29 @@ vim.g.neovide_theme = 'auto'
 Set the [`background`](https://neovim.io/doc/user/options.html#'background') option when Neovide
 starts. Possible values: _light_, _dark_, _auto_. On systems that support it, _auto_ will mirror the
 system theme, and will update `background` when the system theme changes.
+
+#### Fix border and winbar scrolling glitches
+
+VimScript:
+
+```vim
+let g:neovide_unlink_border_highlights = v:true
+```
+
+Lua:
+
+```lua
+vim.g.neovide_unlink_border_highlights = true
+```
+
+**Unreleased yet.**
+
+Neovide uses some highlight groups for detecting the border of the windows, when scrolling. This
+detection is not perfect due to some limitations of Neovim, it only returns the final highlight
+groups for linked highlights. This option unlinks those highlight groups after the color scheme is
+loaded to make Neovide detect them properly.
+
+If this causes other problems, you can set this option to false.
 
 ### Functionality
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This fixes the scrolling of windows with winbar or native borders by only scrolling the inner region. 

The solution is quite hacky, see the new `neovide_unlink_border_highlights` option for example. But I think this is the best we can do with the current version of Neovim.

I also changed `Arc<Mutex<Line>>`  `<RC<RefCell<Line>>` because it's never accessed concurrently.

* Fixes https://github.com/neovide/neovide/issues/1550
* Fixes https://github.com/neovide/neovide/issues/1446

**NOTE:** This probably needs a bit more testing before merging.

## Did this PR introduce a breaking change? 
- No
