### PR TITLE
Clarity on the 'frame' attribute

### DIFF
--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -29,7 +29,7 @@ maximized = false
 srgb = false
 idle = true
 neovim-bin = "/usr/bin/nvim" # in reality found dynamically on $PATH if unset
-frame = "full"
+frame = "Full" # Full, Transparent, Buttonless, None -- case sensitive
 ```
 
 See [Command Line Reference](command-line-reference.md) for details on what those settings do.


### PR DESCRIPTION
It states 'full' but must be 'Full'. All values are case sensitive and must start with a capital letter.

## What kind of change does this PR introduce?
- Fix
- Documentation

## Did this PR introduce a breaking change? 
- No
