### PR TITLE
feat: Smoother render loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,9 +173,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "as-raw-xcb-connection"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5f312b0a56c5cdf967c0aeb67f6289603354951683bc97ddc595ab974ba9aa"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "async-trait"
@@ -1088,11 +1097,11 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1344,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
+checksum = "39a69c7c189ae418f83003da62820aca28d15a07725ce51fb924999335d622ff"
 dependencies = [
  "libc",
 ]
@@ -1459,6 +1468,7 @@ name = "neovide"
 version = "0.11.2"
 dependencies = [
  "anyhow",
+ "approx",
  "async-trait",
  "backtrace",
  "clap",
@@ -2298,7 +2308,7 @@ checksum = "1729a30a469de249c6effc17ec8d039b0aa29b3af79b819b7f51cb6ab8046a90"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2 0.9.0",
+ "memmap2 0.9.2",
  "smithay-client-toolkit 0.18.0",
  "tiny-skia",
 ]
@@ -2478,7 +2488,7 @@ dependencies = [
  "cursor-icon",
  "libc",
  "log",
- "memmap2 0.9.0",
+ "memmap2 0.9.2",
  "rustix",
  "thiserror",
  "wayland-backend 0.3.2",
@@ -2621,18 +2631,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3549,7 +3559,7 @@ dependencies = [
  "js-sys",
  "libc",
  "log",
- "memmap2 0.9.0",
+ "memmap2 0.9.2",
  "ndk",
  "ndk-sys",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,13 +71,14 @@ winit = { version = "=0.29.4", features = ["serde"] }
 xdg = "2.4.1"
 
 [dev-dependencies]
+approx = "0.5.1"
 mockall = "0.11.0"
 scoped-env = "2.1.0"
 serial_test = "2.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # NOTE: winerror is only needed because the indirect dependency parity-tokio-ipc does not set it even if it uses it
-winapi = { version = "0.3.9", features = ["winuser", "wincon", "winerror", "dwmapi"] }
+winapi = { version = "0.3.9", features = ["winuser", "wincon", "winerror", "dwmapi", "profileapi"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,7 @@ fn setup(proxy: EventLoopProxy<UserEvent>) -> Result<(WindowSize, NeovimRuntime)
     cmd_line::handle_command_line_arguments(args().collect())?;
     #[cfg(not(target_os = "windows"))]
     maybe_disown();
+
     startup_profiler();
 
     #[cfg(not(test))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,10 @@
 #[macro_use]
 extern crate neovide_derive;
 
+#[cfg(test)]
+#[macro_use]
+extern crate approx;
+
 #[macro_use]
 extern crate clap;
 

--- a/src/renderer/vsync/mod.rs
+++ b/src/renderer/vsync/mod.rs
@@ -109,9 +109,14 @@ impl VSync {
         }
     }
 
-    pub fn request_redraw(&self, context: &WindowedContext) {
-        if let VSync::WinitThrottling(..) = self {
-            context.window().request_redraw();
+    pub fn request_redraw(&mut self, context: &WindowedContext) {
+        match self {
+            VSync::WinitThrottling(..) => context.window().request_redraw(),
+            #[cfg(target_os = "windows")]
+            VSync::Windows(vsync) => vsync.request_redraw(),
+            #[cfg(target_os = "macos")]
+            VSync::Macos(vsync) => vsync.request_redraw(),
+            _ => {}
         }
     }
 }

--- a/src/renderer/vsync/mod.rs
+++ b/src/renderer/vsync/mod.rs
@@ -55,7 +55,7 @@ impl VSync {
 
             #[cfg(target_os = "macos")]
             {
-                VSync::Macos(VSyncMacos::new(context))
+                VSync::Macos(VSyncMacos::new(context, proxy))
             }
         } else {
             VSync::Timer(VSyncTimer::new())
@@ -77,7 +77,10 @@ impl VSync {
         #[cfg(target_os = "windows")]
         return matches!(self, VSync::WinitThrottling() | VSync::Windows(..));
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(target_os = "macos")]
+        return matches!(self, VSync::WinitThrottling() | VSync::Macos(..));
+
+        #[cfg(target_os = "linux")]
         return matches!(self, VSync::WinitThrottling());
     }
 

--- a/src/renderer/vsync/vsync_macos.rs
+++ b/src/renderer/vsync/vsync_macos.rs
@@ -1,60 +1,52 @@
-use std::sync::{Arc, Condvar, Mutex};
-
 use log::{error, trace, warn};
 
-use crate::renderer::WindowedContext;
+use winit::event_loop::EventLoopProxy;
+
+use crate::{renderer::WindowedContext, window::UserEvent};
 
 use super::macos_display_link::{
     core_video, get_display_id_of_window, MacosDisplayLink, MacosDisplayLinkCallbackArgs,
 };
 
 struct VSyncMacosDisplayLinkUserData {
-    vsync_count: Arc<(Mutex<usize>, Condvar)>,
+    proxy: EventLoopProxy<UserEvent>,
 }
 
 fn vsync_macos_display_link_callback(
     _args: &mut MacosDisplayLinkCallbackArgs,
     user_data: &mut VSyncMacosDisplayLinkUserData,
 ) {
-    let (lock, cvar) = &*user_data.vsync_count;
-    let mut count = lock.lock().unwrap();
-    *count += 1;
-    cvar.notify_one();
+    let _ = user_data.proxy.send_event(UserEvent::RedrawRequested);
 }
 
 pub struct VSyncMacos {
     old_display: core_video::CGDirectDisplayID,
     display_link: Option<MacosDisplayLink<VSyncMacosDisplayLinkUserData>>,
-    vsync_count: Arc<(Mutex<usize>, Condvar)>,
-    last_vsync: usize,
+    proxy: EventLoopProxy<UserEvent>,
 }
 
 impl VSyncMacos {
-    pub fn new(context: &WindowedContext) -> Self {
+    pub fn new(context: &WindowedContext, proxy: EventLoopProxy<UserEvent>) -> VSyncMacos {
         let mut vsync = VSyncMacos {
             old_display: 0,
             display_link: None,
-            vsync_count: Arc::new((Mutex::new(0), Condvar::new())),
-            last_vsync: 0,
+            proxy,
         };
 
-        vsync.display_link = vsync.create_display_link(context);
+        vsync.create_display_link(context);
 
         vsync
     }
 
-    fn create_display_link(
-        self: &mut Self,
-        context: &WindowedContext,
-    ) -> Option<MacosDisplayLink<VSyncMacosDisplayLinkUserData>> {
+    fn create_display_link(&mut self, context: &WindowedContext) {
         self.old_display = get_display_id_of_window(context.window());
 
-        let vsync_count = self.vsync_count.clone();
-
-        match MacosDisplayLink::new_from_display(
+        let display_link = match MacosDisplayLink::new_from_display(
             self.old_display,
             vsync_macos_display_link_callback,
-            VSyncMacosDisplayLinkUserData { vsync_count },
+            VSyncMacosDisplayLinkUserData {
+                proxy: self.proxy.clone(),
+            },
         ) {
             Ok(display_link) => {
                 trace!("Succeeded to create display link.");
@@ -77,22 +69,17 @@ impl VSyncMacos {
                 error!("Failed to create display link, CVReturn code: {}.", code);
                 None
             }
-        }
+        };
+        self.display_link = display_link;
     }
 
-    pub fn wait_for_vsync(&mut self) {
-        let (lock, cvar) = &*self.vsync_count;
-        let count = cvar
-            .wait_while(lock.lock().unwrap(), |count| *count < self.last_vsync + 1)
-            .unwrap();
-        self.last_vsync = *count;
-    }
+    pub fn wait_for_vsync(&mut self) {}
 
     pub fn update(&mut self, context: &WindowedContext) {
         let new_display = get_display_id_of_window(context.window());
         if new_display != self.old_display {
             trace!("Window moved to a new screen, try to re-create the display link.");
-            self.display_link = self.create_display_link(context);
+            self.create_display_link(context);
         }
     }
 }

--- a/src/renderer/vsync/vsync_win.rs
+++ b/src/renderer/vsync/vsync_win.rs
@@ -4,15 +4,43 @@ use std::{
         Arc,
     },
     thread::{spawn, JoinHandle},
+    time::Duration,
 };
-use winapi::um::dwmapi::DwmFlush;
+use winapi::{
+    shared::ntdef::LARGE_INTEGER,
+    um::dwmapi::{DwmGetCompositionTimingInfo, DWM_TIMING_INFO},
+    um::profileapi::{QueryPerformanceCounter, QueryPerformanceFrequency},
+};
+
 use winit::event_loop::EventLoopProxy;
 
-use crate::{profiling::tracy_zone, window::UserEvent};
+use spin_sleep::SpinSleeper;
+
+use crate::{
+    profiling::{tracy_plot, tracy_zone},
+    window::UserEvent,
+};
 
 pub struct VSyncWin {
     should_exit: Arc<AtomicBool>,
     vsync_thread: Option<JoinHandle<()>>,
+}
+
+/// Calculates the time until the vblank, taking into account that the vblank is cyclic, so this
+/// always finds the next vblank forward
+fn time_until_vblank_forward(delay: f64, period: f64) -> f64 {
+    delay.rem_euclid(period)
+}
+
+/// Calculates the time to wait to hit the vblank + offset given a period Note always tries to wait
+/// as close to 1 frame as possible, so the actual wait time lies between
+/// 0.5 * offset and 1.5 * offset
+fn vblank_wait_time(delay: f64, period: f64, offset: f64) -> f64 {
+    let time_until_vblank = time_until_vblank_forward(delay + offset, period);
+    if time_until_vblank < 0.5 * period {
+        return time_until_vblank + period;
+    }
+    time_until_vblank
 }
 
 impl VSyncWin {
@@ -22,19 +50,45 @@ impl VSyncWin {
         let should_exit = Arc::new(AtomicBool::new(false));
 
         // When using OpenGL on Windows in windowed mode, swap_buffers does not seem to be
-        // synchronized with the Desktop Window Manager. So work around that by waiting until the
-        // DWM is flushed before swapping the buffers. Using a separate thread simplifies things,
-        // since it avoids race conditions when the starting the wait just before the next flush is
-        // starting to happen.
+        // synchronized with the Desktop Window Manager. So work around that by manually waiting
+        // for the middle of the vblank. Experimentally that seems to be optimal with the least
+        // amount of stutter.
         let vsync_thread = {
             let should_exit = should_exit.clone();
             Some(spawn(move || {
+                let performance_frequency = unsafe {
+                    let mut performance_frequency: LARGE_INTEGER = std::mem::zeroed();
+                    QueryPerformanceFrequency(&mut performance_frequency as *mut LARGE_INTEGER);
+                    *performance_frequency.QuadPart() as f64
+                };
+                let sleeper = SpinSleeper::default();
                 while !should_exit.load(Ordering::SeqCst) {
-                    unsafe {
-                        tracy_zone!("VSyncThread");
-                        DwmFlush();
-                        let _ = proxy.send_event(UserEvent::RedrawRequested);
-                    }
+                    tracy_zone!("VSyncThread");
+                    let (_vblank_delay, _sleep_time) = unsafe {
+                        let mut timing_info: DWM_TIMING_INFO = std::mem::zeroed();
+                        timing_info.cbSize = std::mem::size_of::<DWM_TIMING_INFO>() as u32;
+                        DwmGetCompositionTimingInfo(
+                            std::ptr::null_mut(),
+                            &mut timing_info as *mut DWM_TIMING_INFO,
+                        );
+                        let mut time_now: LARGE_INTEGER = std::mem::zeroed();
+                        QueryPerformanceCounter(&mut time_now as *mut LARGE_INTEGER);
+                        let time_now = *time_now.QuadPart() as f64;
+                        let vblank_delay =
+                            (timing_info.qpcVBlank as f64 - time_now) / performance_frequency;
+                        let period = ((timing_info.qpcRefreshPeriod as f64)
+                            / performance_frequency)
+                            .max(0.001);
+
+                        // Target the middle of the vblank, which gives maximum time for both us and the compositor
+                        let sleep_time = vblank_wait_time(vblank_delay, period, 0.5 * period);
+                        sleeper.sleep(Duration::from_secs_f64(sleep_time));
+
+                        (vblank_delay, sleep_time)
+                    };
+                    tracy_plot!("Vblank_delay", _vblank_delay);
+                    tracy_plot!("sleep_time", _sleep_time);
+                    let _ = proxy.send_event(UserEvent::RedrawRequested);
                 }
             }))
         };
@@ -52,5 +106,61 @@ impl Drop for VSyncWin {
     fn drop(&mut self) {
         self.should_exit.store(true, Ordering::SeqCst);
         self.vsync_thread.take().unwrap().join().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_time_until_vblank_forward() {
+        assert_abs_diff_eq!(time_until_vblank_forward(0.3, 1.0), 0.3);
+        assert_abs_diff_eq!(time_until_vblank_forward(0.9, 1.0), 0.9);
+        assert_abs_diff_eq!(time_until_vblank_forward(1.0, 1.0), 0.0);
+        assert_abs_diff_eq!(time_until_vblank_forward(1.1, 1.0), 0.1);
+        assert_abs_diff_eq!(time_until_vblank_forward(-0.2, 1.0), 0.8);
+        assert_abs_diff_eq!(time_until_vblank_forward(-1.0, 1.0), 0.0);
+        assert_abs_diff_eq!(time_until_vblank_forward(0.001, 1.0 / 120.0), 0.001);
+        assert_abs_diff_eq!(
+            time_until_vblank_forward(0.009, 1.0 / 120.0),
+            0.009 - 1.0 / 120.0
+        );
+        assert_abs_diff_eq!(time_until_vblank_forward(0.006739, 1.0 / 144.0), 0.006739);
+    }
+
+    #[test]
+    fn test_vblank_wait_time() {
+        assert_abs_diff_eq!(vblank_wait_time(0.3, 1.0, 0.0), 1.3);
+        assert_abs_diff_eq!(vblank_wait_time(0.9, 1.0, 0.0), 0.9);
+        assert_abs_diff_eq!(vblank_wait_time(1.0, 1.0, 0.0), 1.0);
+        assert_abs_diff_eq!(vblank_wait_time(1.1, 1.0, 0.0), 1.1);
+        assert_abs_diff_eq!(vblank_wait_time(2.1, 1.0, 0.0), 1.1);
+        assert_abs_diff_eq!(vblank_wait_time(-0.2, 1.0, 0.0), 0.8);
+        assert_abs_diff_eq!(vblank_wait_time(-1.0, 1.0, 0.0), 1.0);
+        assert_abs_diff_eq!(vblank_wait_time(-1.4, 1.0, 0.0), 0.6);
+        assert_abs_diff_eq!(
+            vblank_wait_time(0.001, 1.0 / 120.0, 0.0),
+            1.0 / 120.0 + 0.001
+        );
+        assert_abs_diff_eq!(vblank_wait_time(0.009, 1.0 / 120.0, 0.0), 0.009);
+        assert_abs_diff_eq!(vblank_wait_time(0.006739, 1.0 / 144.0, 0.0), 0.006739);
+    }
+
+    #[test]
+    fn test_vblank_wait_time_with_half_offset() {
+        assert_abs_diff_eq!(vblank_wait_time(0.3, 1.0, 0.5), 0.8);
+        assert_abs_diff_eq!(vblank_wait_time(0.9, 1.0, 0.5), 1.4);
+        assert_abs_diff_eq!(vblank_wait_time(1.0, 1.0, 0.5), 0.5);
+        assert_abs_diff_eq!(vblank_wait_time(1.1, 1.0, 0.5), 0.6);
+        assert_abs_diff_eq!(vblank_wait_time(2.1, 1.0, 0.5), 0.6);
+        assert_abs_diff_eq!(vblank_wait_time(-0.2, 1.0, 0.5), 1.3);
+        assert_abs_diff_eq!(vblank_wait_time(-1.0, 1.0, 0.5), 0.5);
+        assert_abs_diff_eq!(vblank_wait_time(-1.4, 1.0, 0.5), 1.1);
+        assert_abs_diff_eq!(vblank_wait_time(0.001, 1.0 / 120.0, 0.004), 0.005);
+        assert_abs_diff_eq!(
+            vblank_wait_time(0.009, 1.0 / 120.0, 0.004),
+            0.013 - 1.0 / 120.0
+        );
     }
 }

--- a/src/renderer/vsync/vsync_win.rs
+++ b/src/renderer/vsync/vsync_win.rs
@@ -33,9 +33,10 @@ fn time_until_vblank_forward(delay: f64, period: f64) -> f64 {
     delay.rem_euclid(period)
 }
 
-/// Calculates the time to wait to hit the vblank + offset given a period Note always tries to wait
-/// as close to 1 frame as possible, so the actual wait time lies between
-/// 0.5 * offset and 1.5 * offset
+/// Calculates the time to wait to hit the vblank + offset given a period
+///
+/// Note: always tries to wait as close to 1 frame as possible, so the actual wait time lies
+/// between 0.5 * offset and 1.5 * offset
 fn vblank_wait_time(delay: f64, period: f64, offset: f64) -> f64 {
     let time_until_vblank = time_until_vblank_forward(delay + offset, period);
     if time_until_vblank < 0.5 * period {

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -225,7 +225,7 @@ impl UpdateLoop {
                         self.animate(window_wrapper);
                         // There's really no point in trying to render if the frame is skipped
                         // (most likely due to the compositor being busy). The animated frame will
-                        // be rendered at an approprate time anyway.
+                        // be rendered at an appropriate time anyway.
                         if !skipped_frame {
                             // Always draw immediately for reduced latency if we have been idling
                             if self.num_consecutive_rendered > 0

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -251,10 +251,8 @@ impl UpdateLoop {
                 ..
             })
             | Ok(Event::UserEvent(UserEvent::RedrawRequested)) => {
-                if self.pending_render {
-                    tracy_zone!("render (redraw requested)");
-                    self.render(window_wrapper);
-                }
+                tracy_zone!("render (redraw requested)");
+                self.render(window_wrapper);
             }
             _ => {}
         }

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -1,4 +1,3 @@
-use simple_moving_average::{NoSumSMA, SMA};
 use std::time::{Duration, Instant};
 
 use winit::{
@@ -75,7 +74,6 @@ pub struct UpdateLoop {
     idle: bool,
     previous_frame_start: Instant,
     last_dt: f32,
-    frame_dt_avg: NoSumSMA<f64, f64, 10>,
     should_render: ShouldRender,
     num_consecutive_rendered: u32,
     focused: FocusedState,
@@ -91,7 +89,6 @@ impl UpdateLoop {
 
         let previous_frame_start = Instant::now();
         let last_dt = 0.0;
-        let frame_dt_avg = NoSumSMA::new();
         let should_render = ShouldRender::Immediately;
         let num_consecutive_rendered = 0;
         let focused = FocusedState::Focused;
@@ -104,7 +101,6 @@ impl UpdateLoop {
             idle,
             previous_frame_start,
             last_dt,
-            frame_dt_avg,
             should_render,
             num_consecutive_rendered,
             focused,
@@ -175,11 +171,6 @@ impl UpdateLoop {
     pub fn render(&mut self, window_wrapper: &mut WinitWindowWrapper) {
         self.pending_render = false;
         window_wrapper.draw_frame(self.last_dt);
-
-        if self.num_consecutive_rendered > 2 {
-            self.frame_dt_avg
-                .add_sample(self.previous_frame_start.elapsed().as_secs_f64());
-        }
 
         if let FocusedState::UnfocusedNotDrawn = self.focused {
             self.focused = FocusedState::Unfocused;

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -118,11 +118,7 @@ impl UpdateLoop {
         .max(1.0);
 
         let expected_frame_duration = Duration::from_secs_f32(1.0 / refresh_rate);
-        if self.should_render == ShouldRender::Immediately
-            && (!vsync.uses_winit_throttling() || self.num_consecutive_rendered == 1)
-        {
-            // Only poll when using native vsync
-            // NOTE: Also after the first frame after an idle period has been rendered
+        if self.should_render == ShouldRender::Immediately && !self.pending_render {
             (Duration::from_nanos(0), Instant::now())
         } else {
             let mut deadline = self.previous_frame_start + expected_frame_duration;

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -251,8 +251,10 @@ impl UpdateLoop {
                 ..
             })
             | Ok(Event::UserEvent(UserEvent::RedrawRequested)) => {
-                tracy_zone!("render (redraw requested)");
-                self.render(window_wrapper);
+                if self.pending_render {
+                    tracy_zone!("render (redraw requested)");
+                    self.render(window_wrapper);
+                }
             }
             _ => {}
         }

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -231,7 +231,9 @@ impl UpdateLoop {
                             if self.num_consecutive_rendered > 0
                                 && window_wrapper.vsync.uses_winit_throttling()
                             {
-                                window_wrapper.windowed_context.window().request_redraw();
+                                window_wrapper
+                                    .vsync
+                                    .request_redraw(&window_wrapper.windowed_context);
                                 self.pending_render = true;
                             } else {
                                 self.render(window_wrapper);
@@ -247,7 +249,8 @@ impl UpdateLoop {
             Ok(Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..
-            }) => {
+            })
+            | Ok(Event::UserEvent(UserEvent::RedrawRequested)) => {
                 tracy_zone!("render (redraw requested)");
                 self.render(window_wrapper);
             }

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -139,14 +139,10 @@ impl UpdateLoop {
     }
 
     pub fn animate(&mut self, window_wrapper: &mut WinitWindowWrapper) {
-        let dt = if self.frame_dt_avg.get_num_samples() > 0 {
-            self.frame_dt_avg.get_average() as f32
-        } else {
-            // Assume default rate when we don't have an average yet
-            MAX_ANIMATION_DT
-        }
-        // We don't really want to support less than 10 FPS
-        .min(0.1);
+        let dt = window_wrapper
+            .vsync
+            .get_refresh_rate(&window_wrapper.windowed_context);
+
         tracy_plot!("Average dt", dt.into());
         let num_steps = (dt / MAX_ANIMATION_DT).ceil();
         let step = dt / num_steps;

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -347,7 +347,6 @@ impl WinitWindowWrapper {
 
     pub fn draw_frame(&mut self, dt: f32) {
         tracy_zone!("draw_frame");
-        self.renderer.prepare_lines();
         self.renderer.draw_frame(self.skia_renderer.canvas(), dt);
         {
             tracy_gpu_zone!("skia flush");
@@ -375,6 +374,7 @@ impl WinitWindowWrapper {
             dt,
         );
         tracy_plot!("animate_frame", res as u8 as f64);
+        self.renderer.prepare_lines();
         #[allow(clippy::let_and_return)]
         res
     }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -21,6 +21,7 @@ use skia_safe::{scalar, Rect};
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize, Position},
     event::{Event, WindowEvent},
+    event_loop::EventLoopProxy,
     window::{Fullscreen, Theme},
 };
 
@@ -68,7 +69,11 @@ pub struct WinitWindowWrapper {
 }
 
 impl WinitWindowWrapper {
-    pub fn new(window: GlWindow, initial_window_size: WindowSize) -> Self {
+    pub fn new(
+        window: GlWindow,
+        initial_window_size: WindowSize,
+        proxy: EventLoopProxy<UserEvent>,
+    ) -> Self {
         let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
         let srgb = cmd_line_settings.srgb;
         let vsync_enabled = cmd_line_settings.vsync;
@@ -101,7 +106,7 @@ impl WinitWindowWrapper {
             _ => {}
         }
 
-        let vsync = VSync::new(vsync_enabled, &windowed_context);
+        let vsync = VSync::new(vsync_enabled, &windowed_context, proxy);
 
         let mut wrapper = WinitWindowWrapper {
             windowed_context,


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This makes rendering a little bit smoother, at least on some platforms, and also cleans up and unifies some code.

* Remove some redundant polling for new events after the first frame is rendered
* Do the animation and shaping as early as possible in the frame, which leaves just rendering to the end. This makes the rendering part much more predictable, which plays nicer with how some Wayland compositors are made. For example on Gnome many frames were too late because of the unpredictability. 
* Got rid of the manual dt calculation, and tries to use the monitor refresh rate instead, with a fallback to `neovide_refresh_rate`. 
* The frames are generated using a real-time clock and the frame rate calculated above, duplicating frames when rendering too fast. But that duplication does not matter since the frames would not be visible without enabling tearing anyway. And when the vsync is disabled, the configured refresh rate is used as the base, so it does not matter in that case either.
* If frames are skipped by the compositor, the animation step is still done, which reduces the visual artefacts. This actually happens maybe once every 10 second on the gnome system I was mostly profiling on.
* The Windows and macOS vsync implementation has been simplified and emulates the the native winit vsync support, which also unifies the rest of the code. But the timer based fallback and X11 opengl based vsync still uses the old system, with the latter almost impossible to port.
* The render thread is removed on Windows. Winit has done some optimisations and the event loop is just a tiny bit on the slower side now. Furthermore, both the vsync and the event driven update loop relies on it being fast. This also simplifies the code, and removes one of the platform specific code paths.
* On Windows the frames start rendering in the middle of the Vsync interval. According to my tests this is as smooth as I think we can get on OpenGL, we need to switch to D3D and waitable swap chains to do better. Maybe it's placebo, but it's still clearly better IMO, but not as smooth as on Wayland for example.

NOTE: This is functionality complete and can be tested, but depends on, so it's best to not review before that is merged. That's also why it's marked as a draft.
* https://github.com/neovide/neovide/pull/2186

I have also not tested this properly on all platforms, I have only really done testing on Wayland and Windows. So we need testing on macOS and X11 before merging this. I have also only tested the very latest commit on a remote desktop connection to Windows.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
