### PR TITLE
Direct3D Rendering on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -206,9 +206,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
@@ -250,7 +250,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.55",
+ "syn 2.0.57",
  "which 4.4.2",
 ]
 
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -444,14 +444,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -630,7 +630,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -853,7 +853,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -1439,6 +1439,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shlex",
+ "simple_moving_average",
  "skia-safe",
  "spin_sleep",
  "strum",
@@ -1453,6 +1454,7 @@ dependencies = [
  "winapi",
  "winit",
  "winres",
+ "wio",
  "xdg",
 ]
 
@@ -1603,7 +1605,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1798,7 +1800,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1812,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1875,7 +1877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2060,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "ring"
@@ -2141,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -2225,14 +2227,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2270,7 +2272,7 @@ checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2293,6 +2295,15 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simple_moving_average"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd19d3808aad2604c824399fd270260d634678b010328c9d96851bb0fb63121"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "siphasher"
@@ -2327,6 +2338,8 @@ dependencies = [
  "bitflags 2.5.0",
  "lazy_static",
  "skia-bindings",
+ "winapi",
+ "wio",
 ]
 
 [[package]]
@@ -2445,7 +2458,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2476,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2513,7 +2526,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2589,9 +2602,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes 1.6.0",
@@ -2625,7 +2638,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2843,7 +2856,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
  "wasm-bindgen-shared",
 ]
 
@@ -2877,7 +2890,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3372,6 +3385,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "x11-clipboard"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,7 +3500,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rmpv = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 shlex = "1.1.0"
-skia-safe = { version = "0.68.0", features = ["gl", "textlayout"] }
+simple_moving_average = "0.1.2"
 spin_sleep = "1.1.1"
 strum = { version = "0.26.2", features = ["derive"] }
 swash = { version = "0.1.8", default-features = false }
@@ -78,7 +78,28 @@ serial_test = "3.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # NOTE: winerror is only needed because the indirect dependency parity-tokio-ipc does not set it even if it uses it
-winapi = { version = "0.3.9", features = ["winuser", "wincon", "winerror", "dwmapi", "profileapi"] }
+winapi = { version = "0.3.9", features = [
+    "d3d12",
+    "d3d12sdklayers",
+    "dwmapi",
+    "dxgi",
+    "dxgi1_2",
+    "dxgi1_3",
+    "dxgi1_4",
+    "dxgi1_6",
+    "impl-default",
+    "profileapi",
+    "synchapi",
+    "wincon",
+    "winerror",
+    "winuser",
+    ]}
+# for ComPtr
+wio = { version = "0.2.2" }
+skia-safe = { version = "0.68.0", features = ["gl", "d3d", "textlayout"] }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+skia-safe = { version = "0.68.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 icrate = { version = "0.0.4", features = [ "apple", "Foundation", "Foundation_NSThread", "AppKit", "AppKit_NSColor", "AppKit_NSEvent", "AppKit_NSView", "AppKit_NSWindow", "AppKit_NSViewController", "AppKit_NSMenu", "AppKit_NSMenuItem", "AppKit_NSOpenPanel", "AppKit_NSScreen", "Foundation_NSArray" ] }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -134,6 +134,11 @@ pub struct CmdLineSettings {
 
     #[command(flatten)]
     pub geometry: GeometryArgs,
+
+    /// Force opengl on Windows
+    #[cfg(target_os = "windows")]
+    #[arg(long = "opengl", env = "NEOVIDE_OPENGL", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
+    pub opengl: bool,
 }
 
 // geometry, size and maximized are mutually exclusive

--- a/src/profiling/d3d.rs
+++ b/src/profiling/d3d.rs
@@ -1,0 +1,517 @@
+use std::{
+    collections::VecDeque,
+    ffi::CString,
+    mem,
+    ptr::{null, null_mut},
+    slice::from_raw_parts,
+    sync::atomic::{AtomicU8, Ordering},
+};
+
+use winapi::{
+    ctypes::c_void,
+    shared::{
+        dxgiformat::DXGI_FORMAT_UNKNOWN,
+        dxgitype::DXGI_SAMPLE_DESC,
+        minwindef::BOOL,
+        ntdef::LARGE_INTEGER,
+        winerror::{FAILED, SUCCEEDED},
+    },
+    um::{
+        d3d12::{
+            ID3D12CommandAllocator, ID3D12CommandList, ID3D12CommandQueue, ID3D12Device,
+            ID3D12Fence, ID3D12GraphicsCommandList, ID3D12QueryHeap, ID3D12Resource,
+            D3D12_COMMAND_LIST_TYPE_COPY, D3D12_COMMAND_LIST_TYPE_DIRECT,
+            D3D12_CPU_PAGE_PROPERTY_UNKNOWN, D3D12_FENCE_FLAG_NONE, D3D12_HEAP_FLAG_NONE,
+            D3D12_HEAP_PROPERTIES, D3D12_HEAP_TYPE_READBACK, D3D12_MEMORY_POOL_UNKNOWN,
+            D3D12_QUERY_HEAP_DESC, D3D12_QUERY_TYPE_TIMESTAMP, D3D12_RANGE, D3D12_RESOURCE_DESC,
+            D3D12_RESOURCE_DIMENSION_BUFFER, D3D12_RESOURCE_FLAG_NONE,
+            D3D12_RESOURCE_STATE_COPY_DEST, D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+        },
+        profileapi::QueryPerformanceFrequency,
+    },
+    ENUM, STRUCT,
+};
+
+use wio::com::ComPtr;
+
+use tracy_client_sys::{
+    ___tracy_emit_gpu_calibration_serial, ___tracy_emit_gpu_context_name,
+    ___tracy_emit_gpu_new_context, ___tracy_emit_gpu_time_serial,
+    ___tracy_emit_gpu_zone_begin_serial, ___tracy_emit_gpu_zone_end_serial,
+    ___tracy_gpu_calibration_data, ___tracy_gpu_context_name_data, ___tracy_gpu_new_context_data,
+    ___tracy_gpu_time_data, ___tracy_gpu_zone_begin_data, ___tracy_gpu_zone_end_data,
+    ___tracy_source_location_data,
+};
+
+use crate::profiling::{is_connected, GpuContextType, GpuCtx};
+use crate::renderer::d3d::{call_com_fn, D3DSkiaRenderer};
+
+// The winapi crate does not expose these for some reason
+ENUM! {
+    enum D3d12ViewInstancingTier {
+    D3D12_VIEW_INSTANCING_TIER_NOT_SUPPORTED = 0,
+    D3D12_VIEW_INSTANCING_TIER_1 = 1,
+    D3D12_VIEW_INSTANCING_TIER_2 = 2,
+    D3D12_VIEW_INSTANCING_TIER_3 = 3,
+}}
+#[allow(non_camel_case_types)]
+type D3D12_VIEW_INSTANCING_TIER = D3d12ViewInstancingTier;
+
+ENUM! {
+    enum D3d12CommandListSupportFlags {
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_NONE = 0,
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_DIRECT,
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_BUNDLE,
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_COMPUTE,
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_COPY,
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_VIDEO_DECODE,
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_VIDEO_PROCESS,
+    D3D12_COMMAND_LIST_SUPPORT_FLAG_VIDEO_ENCODE,
+}}
+#[allow(non_camel_case_types)]
+type D3D12_COMMAND_LIST_SUPPORT_FLAGS = D3d12CommandListSupportFlags;
+
+STRUCT! {
+    #[allow(non_snake_case)]
+    struct D3D12_FEATURE_DATA_D3D12_OPTIONS3 {
+    CopyQueueTimestampQueriesSupported: BOOL,
+    CastingFullyTypedFormatSupported: BOOL,
+    WriteBufferImmediateSupportFlags: D3D12_COMMAND_LIST_SUPPORT_FLAGS,
+    ViewInstancingTier: D3D12_VIEW_INSTANCING_TIER,
+    BarycentricsSupported: BOOL,
+}}
+
+ENUM! {
+    enum D3d12Feature {
+    D3D12_FEATURE_D3D12_OPTIONS = 0,
+    D3D12_FEATURE_ARCHITECTURE = 1,
+    D3D12_FEATURE_FEATURE_LEVELS = 2,
+    D3D12_FEATURE_FORMAT_SUPPORT = 3,
+    D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS = 4,
+    D3D12_FEATURE_FORMAT_INFO = 5,
+    D3D12_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT = 6,
+    D3D12_FEATURE_SHADER_MODEL = 7,
+    D3D12_FEATURE_D3D12_OPTIONS1 = 8,
+    D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_SUPPORT = 10,
+    D3D12_FEATURE_ROOT_SIGNATURE = 12,
+    D3D12_FEATURE_ARCHITECTURE1 = 16,
+    D3D12_FEATURE_D3D12_OPTIONS2 = 18,
+    D3D12_FEATURE_SHADER_CACHE = 19,
+    D3D12_FEATURE_COMMAND_QUEUE_PRIORITY = 20,
+    D3D12_FEATURE_D3D12_OPTIONS3 = 21,
+    D3D12_FEATURE_EXISTING_HEAPS = 22,
+    D3D12_FEATURE_D3D12_OPTIONS4 = 23,
+    D3D12_FEATURE_SERIALIZATION = 24,
+    D3D12_FEATURE_CROSS_NODE = 25,
+    D3D12_FEATURE_D3D12_OPTIONS5 = 27,
+    D3D12_FEATURE_DISPLAYABLE,
+    D3D12_FEATURE_D3D12_OPTIONS6 = 30,
+    D3D12_FEATURE_QUERY_META_COMMAND = 31,
+    D3D12_FEATURE_D3D12_OPTIONS7 = 32,
+    D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPE_COUNT = 33,
+    D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPES = 34,
+    D3D12_FEATURE_D3D12_OPTIONS8 = 36,
+    D3D12_FEATURE_D3D12_OPTIONS9 = 37,
+    D3D12_FEATURE_D3D12_OPTIONS10,
+    D3D12_FEATURE_D3D12_OPTIONS11,
+    D3D12_FEATURE_D3D12_OPTIONS12,
+    D3D12_FEATURE_D3D12_OPTIONS13,
+}}
+
+ENUM! {enum D3d12QueryHeapType {
+  D3D12_QUERY_HEAP_TYPE_OCCLUSION = 0,
+  D3D12_QUERY_HEAP_TYPE_TIMESTAMP = 1,
+  D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS = 2,
+  D3D12_QUERY_HEAP_TYPE_SO_STATISTICS = 3,
+  D3D12_QUERY_HEAP_TYPE_VIDEO_DECODE_STATISTICS = 4,
+  D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP = 5,
+  D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS1,
+}}
+
+impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS3 {
+    fn default() -> Self {
+        unsafe { mem::zeroed() }
+    }
+}
+
+static CONTEXT_ID: AtomicU8 = AtomicU8::new(0);
+
+struct D3D12QueryPayload {
+    query_id_start: u32,
+    query_count: u32,
+}
+
+struct GpuCtxD3D {
+    id: u8,
+    _device: ComPtr<ID3D12Device>,
+    queue: ComPtr<ID3D12CommandQueue>,
+    query_heap: ComPtr<ID3D12QueryHeap>,
+    readback_buffer: ComPtr<ID3D12Resource>,
+    payload_fence: ComPtr<ID3D12Fence>,
+    command_allocator: ComPtr<ID3D12CommandAllocator>,
+    command_list: ComPtr<ID3D12GraphicsCommandList>,
+    query_limit: u32,
+    prev_calibration: u64,
+    qpc_to_ns: u64,
+    query_counter: u32,
+    prev_counter: u32,
+    payload_queue: VecDeque<D3D12QueryPayload>,
+    active_payload: usize,
+}
+
+impl GpuCtxD3D {
+    fn next_query_id(&mut self) -> u32 {
+        let query_counter = self.query_counter;
+        if self.query_counter >= self.query_limit {
+            panic!("Submitted too many GPU queries! Consider increasing MAXQUERIES.")
+        }
+        self.query_counter += 2;
+        (self.prev_counter + query_counter) % self.query_limit
+    }
+}
+
+impl GpuCtxD3D {
+    fn new_frame(&mut self) {
+        if !is_connected() {
+            return;
+        }
+        let query_counter = self.query_counter;
+        self.query_counter = 0;
+        self.payload_queue.push_back(D3D12QueryPayload {
+            query_id_start: self.prev_counter,
+            query_count: query_counter,
+        });
+
+        self.prev_counter += query_counter;
+        if self.prev_counter >= self.query_limit {
+            self.prev_counter -= self.query_limit;
+        }
+
+        self.active_payload += 1;
+        unsafe {
+            self.queue
+                .Signal(self.payload_fence.as_raw(), self.active_payload as u64);
+        }
+    }
+}
+
+fn get_performance_counter_frequency() -> u64 {
+    let mut t = LARGE_INTEGER::default();
+    unsafe {
+        QueryPerformanceFrequency(&mut t);
+        *t.QuadPart() as u64
+    }
+}
+
+const MAXQUERIES: u32 = 64 * 1024; // Queries are begin and end markers, so we can store half as many total time durations. Must be even!
+
+pub fn create_d3d_gpu_context(name: &str, renderer: &D3DSkiaRenderer) -> Box<dyn GpuCtx> {
+    let queue = renderer.command_queue.clone();
+    let device = renderer.device.clone();
+    let ctx_id = CONTEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let (gpu_ctx, gpu_timestamp, timestamp_frequency) = unsafe {
+        if queue.GetDesc().Type == D3D12_COMMAND_LIST_TYPE_COPY {
+            let mut feature_data = D3D12_FEATURE_DATA_D3D12_OPTIONS3::default();
+            let p_feature_data =
+                &mut feature_data as *mut D3D12_FEATURE_DATA_D3D12_OPTIONS3 as *mut c_void;
+            let success = SUCCEEDED(device.CheckFeatureSupport(
+                D3D12_FEATURE_D3D12_OPTIONS3,
+                p_feature_data,
+                mem::size_of_val(&feature_data) as u32,
+            ));
+            if !(success && feature_data.CopyQueueTimestampQueriesSupported != 0) {
+                panic!("Platform does not support profiling of copy queues.");
+            }
+        }
+
+        let mut timestamp_frequency = 0;
+
+        if FAILED(queue.GetTimestampFrequency(&mut timestamp_frequency)) {
+            panic!("Failed to get timestamp frequency.");
+        }
+
+        let mut cpu_timestamp = 0;
+        let mut gpu_timestamp = 0;
+
+        if FAILED(queue.GetClockCalibration(&mut gpu_timestamp, &mut cpu_timestamp)) {
+            panic!("Failed to get queue clock calibration.");
+        }
+
+        let qpc_to_ns = 1000000000 / get_performance_counter_frequency();
+
+        // Save the device cpu timestamp, not the profiler's timestamp.
+        let prev_calibration = cpu_timestamp * qpc_to_ns;
+
+        let mut heap_desc = D3D12_QUERY_HEAP_DESC {
+            Type: if queue.GetDesc().Type == D3D12_COMMAND_LIST_TYPE_COPY {
+                D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP
+            } else {
+                D3D12_QUERY_HEAP_TYPE_TIMESTAMP
+            },
+            ..Default::default()
+        };
+
+        let mut query_limit = MAXQUERIES;
+        heap_desc.Count = query_limit;
+        heap_desc.NodeMask = 0; // #TODO: Support multiple adapters.
+
+        let query_heap: ComPtr<ID3D12QueryHeap> = loop {
+            if let Ok(query_heap) =
+                call_com_fn(|query_heap, id| device.CreateQueryHeap(&heap_desc, id, query_heap))
+            {
+                break query_heap;
+            } else {
+                query_limit /= 2;
+                heap_desc.Count = query_limit;
+            }
+        };
+
+        // Create a readback buffer, which will be used as a destination for the query data.
+
+        let readback_buffer_desc = D3D12_RESOURCE_DESC {
+            Alignment: 0,
+            Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
+            Width: query_limit as u64 * mem::size_of::<u64>() as u64,
+            Height: 1,
+            DepthOrArraySize: 1,
+            Format: DXGI_FORMAT_UNKNOWN,
+            Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR, // Buffers are always row major.
+            MipLevels: 1,
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                Quality: 0,
+            },
+            Flags: D3D12_RESOURCE_FLAG_NONE,
+        };
+
+        let readback_heap_props = D3D12_HEAP_PROPERTIES {
+            Type: D3D12_HEAP_TYPE_READBACK,
+            CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+            MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
+            CreationNodeMask: 0,
+            VisibleNodeMask: 0, // TODO: Support multiple adapters.
+        };
+
+        let readback_buffer: ComPtr<ID3D12Resource> = call_com_fn(|readback_buffer, id| {
+            device.CreateCommittedResource(
+                &readback_heap_props,
+                D3D12_HEAP_FLAG_NONE,
+                &readback_buffer_desc,
+                D3D12_RESOURCE_STATE_COPY_DEST,
+                null(),
+                id,
+                readback_buffer,
+            )
+        })
+        .expect("Failed to create query readback buffer.");
+
+        let payload_fence: ComPtr<ID3D12Fence> =
+            call_com_fn(|fence, id| device.CreateFence(0, D3D12_FENCE_FLAG_NONE, id, fence))
+                .expect("Failed to create payload fence.");
+
+        let command_allocator: ComPtr<ID3D12CommandAllocator> = call_com_fn(|allocator, id| {
+            device.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, id, allocator)
+        })
+        .expect("Failed to create command allocator");
+
+        let command_list: ComPtr<ID3D12GraphicsCommandList> = call_com_fn(|command_list, id| {
+            device.CreateCommandList(
+                0,
+                D3D12_COMMAND_LIST_TYPE_DIRECT,
+                command_allocator.as_raw(),
+                null_mut(),
+                id,
+                command_list,
+            )
+        })
+        .expect("Failed to create command list");
+
+        (
+            Box::new(GpuCtxD3D {
+                id: ctx_id,
+                _device: device,
+                queue,
+                query_heap,
+                readback_buffer,
+                command_list,
+                payload_fence,
+                command_allocator,
+                query_limit,
+                prev_calibration,
+                qpc_to_ns,
+                query_counter: 0,
+                prev_counter: 0,
+                payload_queue: VecDeque::new(),
+                active_payload: 0,
+            }),
+            gpu_timestamp,
+            timestamp_frequency,
+        )
+    };
+
+    enum GpuContextFlags {
+        GpuContextCalibration = 1 << 0,
+    }
+
+    let period = 1E+09 / timestamp_frequency as f32;
+
+    let ctxt_data = ___tracy_gpu_new_context_data {
+        gpuTime: gpu_timestamp as i64,
+        period,
+        context: ctx_id,
+        flags: GpuContextFlags::GpuContextCalibration as u8,
+        type_: GpuContextType::Direct3D12 as u8,
+    };
+    let namestring = CString::new(name).unwrap();
+    let name_data = ___tracy_gpu_context_name_data {
+        context: ctx_id,
+        name: namestring.as_ptr(),
+        len: name.len() as u16,
+    };
+    unsafe {
+        ___tracy_emit_gpu_new_context(ctxt_data);
+        ___tracy_emit_gpu_context_name(name_data);
+    }
+    gpu_ctx
+}
+
+impl GpuCtx for GpuCtxD3D {
+    fn gpu_collect(&mut self) {
+        if !is_connected() {
+            self.query_counter = 0;
+            return;
+        }
+
+        // Find out what payloads are available.
+        let newest_ready_payload = unsafe { self.payload_fence.GetCompletedValue() as usize };
+        let payload_count = self.payload_queue.len() - (self.active_payload - newest_ready_payload);
+
+        if payload_count > 0 {
+            let map_range = D3D12_RANGE {
+                Begin: 0,
+                End: self.query_limit as usize * mem::size_of::<u64>(),
+            };
+
+            let mut readback_buffer_mapping = null_mut();
+            if FAILED(unsafe {
+                self.readback_buffer
+                    .Map(0, &map_range, &mut readback_buffer_mapping)
+            }) {
+                panic!("Failed to map readback buffer.");
+            }
+
+            let timestamp_data = unsafe {
+                from_raw_parts(
+                    readback_buffer_mapping as *const u64,
+                    self.query_limit as usize,
+                )
+            };
+
+            for _ in 0..payload_count {
+                if let Some(payload) = &self.payload_queue.front() {
+                    for j in 0..payload.query_count {
+                        let counter = (payload.query_id_start + j) % self.query_limit;
+                        let timestamp = timestamp_data[counter as usize];
+                        let query_id = counter;
+
+                        let time_data = ___tracy_gpu_time_data {
+                            gpuTime: timestamp as i64,
+                            queryId: query_id as u16,
+                            context: self.id,
+                        };
+                        unsafe {
+                            ___tracy_emit_gpu_time_serial(time_data);
+                        }
+                    }
+                    self.payload_queue.pop_front();
+                }
+            }
+            unsafe {
+                self.readback_buffer.Unmap(0, null());
+            }
+
+            // Recalibrate to account for drift.
+
+            let mut cpu_timestamp = 0;
+            let mut gpu_timestamp = 0;
+
+            if FAILED(unsafe {
+                self.queue
+                    .GetClockCalibration(&mut gpu_timestamp, &mut cpu_timestamp)
+            }) {
+                panic!("Failed to get queue clock calibration.");
+            }
+
+            cpu_timestamp *= self.qpc_to_ns;
+
+            let cpu_delta = cpu_timestamp as i64 - self.prev_calibration as i64;
+            if cpu_delta > 0 {
+                self.prev_calibration = cpu_timestamp;
+                let calibration_data = ___tracy_gpu_calibration_data {
+                    gpuTime: gpu_timestamp as i64,
+                    cpuDelta: cpu_delta,
+                    context: self.id,
+                };
+                unsafe {
+                    ___tracy_emit_gpu_calibration_serial(calibration_data);
+                }
+            }
+        }
+
+        self.new_frame();
+    }
+
+    fn gpu_begin(&mut self, loc_data: &___tracy_source_location_data) -> i64 {
+        let query = self.next_query_id();
+
+        let gpu_data = ___tracy_gpu_zone_begin_data {
+            srcloc: (loc_data as *const ___tracy_source_location_data) as u64,
+            queryId: query as u16,
+            context: self.id,
+        };
+        unsafe {
+            // We don't have access to the skia command list, so we need to use our own, consisting
+            // of just a single command to get the order right.
+            self.command_list
+                .EndQuery(self.query_heap.as_raw(), D3D12_QUERY_TYPE_TIMESTAMP, query);
+            self.command_list.Close();
+            let command_list = self.command_list.as_raw() as *mut ID3D12CommandList;
+            self.queue.ExecuteCommandLists(1, &command_list);
+            self.command_list
+                .Reset(self.command_allocator.as_raw(), null_mut());
+            ___tracy_emit_gpu_zone_begin_serial(gpu_data);
+        }
+        query as i64
+    }
+
+    fn gpu_end(&mut self, query_id: i64) {
+        // TODO: Should probly flush Skia here, since it uses it's own command lists
+        let end_query_id = query_id as u32 + 1;
+
+        let gpu_data = ___tracy_gpu_zone_end_data {
+            queryId: end_query_id as u16,
+            context: self.id,
+        };
+        unsafe {
+            self.command_list.EndQuery(
+                self.query_heap.as_raw(),
+                D3D12_QUERY_TYPE_TIMESTAMP,
+                end_query_id,
+            );
+            self.command_list.ResolveQueryData(
+                self.query_heap.as_raw(),
+                D3D12_QUERY_TYPE_TIMESTAMP,
+                query_id as u32,
+                2,
+                self.readback_buffer.as_raw(),
+                query_id as u64 * mem::size_of::<u64>() as u64,
+            );
+            self.command_list.Close();
+            let command_list = self.command_list.as_raw() as *mut ID3D12CommandList;
+            self.queue.ExecuteCommandLists(1, &command_list);
+            self.command_list
+                .Reset(self.command_allocator.as_raw(), null_mut());
+            ___tracy_emit_gpu_zone_end_serial(gpu_data);
+        }
+    }
+}

--- a/src/profiling/mod.rs
+++ b/src/profiling/mod.rs
@@ -3,6 +3,8 @@ mod profiling_disabled;
 #[cfg(feature = "profiling")]
 mod profiling_enabled;
 
+#[cfg(all(feature = "gpu_profiling", target_os = "windows"))]
+pub mod d3d;
 #[cfg(feature = "gpu_profiling")]
 pub mod opengl;
 

--- a/src/renderer/d3d.rs
+++ b/src/renderer/d3d.rs
@@ -60,7 +60,7 @@ use crate::{
 
 const D3D_FEATUREL_LEVEL: D3D_FEATURE_LEVEL = D3D_FEATURE_LEVEL_11_0;
 
-fn call_com_fn<T0, T1, F>(fun: F) -> Result<ComPtr<T1>, ()>
+pub fn call_com_fn<T0, T1, F>(fun: F) -> Result<ComPtr<T1>, ()>
 where
     T1: Interface,
     F: FnOnce(&mut *mut T0, REFIID) -> HRESULT,
@@ -146,7 +146,7 @@ pub struct D3DSkiaRenderer {
     swap_chain: ComPtr<IDXGISwapChain3>,
     swap_chain_desc: DXGI_SWAP_CHAIN_DESC1,
     swap_chain_waitable: HANDLE,
-    command_queue: ComPtr<ID3D12CommandQueue>,
+    pub command_queue: ComPtr<ID3D12CommandQueue>,
     buffers: Vec<ComPtr<ID3D12Resource>>,
     surfaces: Vec<Surface>,
     fence_values: Vec<u64>,
@@ -156,7 +156,7 @@ pub struct D3DSkiaRenderer {
     frame_index: usize,
     _backend_context: BackendContext,
     _adapter: ComPtr<IDXGIAdapter1>,
-    _device: ComPtr<ID3D12Device>,
+    pub device: ComPtr<ID3D12Device>,
 }
 
 impl D3DSkiaRenderer {
@@ -267,7 +267,7 @@ impl D3DSkiaRenderer {
 
         let mut ret = Self {
             _adapter: adapter,
-            _device: device,
+            device,
             command_queue,
             swap_chain,
             swap_chain_desc,
@@ -452,6 +452,11 @@ impl SkiaRenderer for D3DSkiaRenderer {
 
     fn create_vsync(&self, _proxy: EventLoopProxy<UserEvent>) -> VSync {
         unimplemented!()
+    }
+
+    #[cfg(feature = "gpu_profiling")]
+    fn tracy_create_gpu_context(&self, name: &str) -> Box<dyn GpuCtx> {
+        create_d3d_gpu_context(name, &self)
     }
 }
 

--- a/src/renderer/d3d.rs
+++ b/src/renderer/d3d.rs
@@ -138,7 +138,6 @@ fn get_hardware_adapter(factory: &ComPtr<IDXGIFactory4>) -> Result<ComPtr<IDXGIA
 }
 
 pub struct D3DSkiaRenderer {
-    window: Window,
     gr_context: DirectContext,
     swap_chain: ComPtr<IDXGISwapChain3>,
     swap_chain_desc: DXGI_SWAP_CHAIN_DESC1,
@@ -152,8 +151,9 @@ pub struct D3DSkiaRenderer {
     frame_swapped: bool,
     frame_index: usize,
     _backend_context: BackendContext,
-    _adapter: ComPtr<IDXGIAdapter1>,
     pub device: ComPtr<ID3D12Device>,
+    _adapter: ComPtr<IDXGIAdapter1>,
+    window: Window,
 }
 
 impl D3DSkiaRenderer {
@@ -454,6 +454,8 @@ impl SkiaRenderer for D3DSkiaRenderer {
 impl Drop for D3DSkiaRenderer {
     fn drop(&mut self) {
         unsafe {
+            self.gr_context.release_resources_and_abandon();
+            self.wait_for_gpu();
             CloseHandle(self.fence_event);
         }
     }

--- a/src/renderer/d3d.rs
+++ b/src/renderer/d3d.rs
@@ -1,0 +1,464 @@
+use std::ptr::{null, null_mut};
+
+use winapi::{
+    shared::{
+        dxgi::{
+            IDXGIAdapter1, DXGI_ADAPTER_DESC1, DXGI_ADAPTER_FLAG_SOFTWARE,
+            DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT, DXGI_SWAP_EFFECT_FLIP_DISCARD,
+        },
+        dxgi1_2::{DXGI_ALPHA_MODE_UNSPECIFIED, DXGI_SCALING_NONE, DXGI_SWAP_CHAIN_DESC1},
+        dxgi1_3::{CreateDXGIFactory2, DXGI_CREATE_FACTORY_DEBUG},
+        dxgi1_4::{IDXGIFactory4, IDXGISwapChain3},
+        dxgi1_6::{IDXGIFactory6, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE},
+        dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM,
+        dxgitype::{DXGI_SAMPLE_DESC, DXGI_USAGE_RENDER_TARGET_OUTPUT},
+        guiddef::REFIID,
+        windef::HWND,
+        winerror::SUCCEEDED,
+    },
+    um::{
+        d3d12::{
+            D3D12CreateDevice, D3D12GetDebugInterface, ID3D12CommandQueue, ID3D12Device,
+            ID3D12Fence, ID3D12Resource, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_QUEUE_DESC,
+            D3D12_COMMAND_QUEUE_FLAG_NONE, D3D12_FENCE_FLAG_NONE, D3D12_RESOURCE_STATE_PRESENT,
+        },
+        d3d12sdklayers::ID3D12Debug,
+        d3dcommon::{D3D_FEATURE_LEVEL, D3D_FEATURE_LEVEL_11_0},
+        handleapi::CloseHandle,
+        synchapi::{CreateEventA as CreateEvent, WaitForSingleObjectEx},
+        unknwnbase::IUnknown,
+        winbase::INFINITE,
+        winnt::{HANDLE, HRESULT},
+    },
+    Interface,
+};
+
+use wio::com::ComPtr;
+
+use skia_safe::{
+    gpu::{
+        d3d::{BackendContext, TextureResourceInfo},
+        surfaces::wrap_backend_render_target,
+        BackendRenderTarget, DirectContext, FlushInfo, Protected, SurfaceOrigin, SyncCpu,
+    },
+    surface::BackendSurfaceAccess,
+    Canvas, ColorType, Surface,
+};
+
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use winit::{event_loop::EventLoopProxy, window::Window};
+
+use super::{SkiaRenderer, VSync};
+
+#[cfg(feature = "gpu_profiling")]
+use crate::profiling::{d3d::create_d3d_gpu_context, GpuCtx};
+
+use crate::{
+    profiling::{tracy_frame, tracy_gpu_zone, tracy_zone},
+    window::UserEvent,
+};
+
+const D3D_FEATUREL_LEVEL: D3D_FEATURE_LEVEL = D3D_FEATURE_LEVEL_11_0;
+
+fn call_com_fn<T0, T1, F>(fun: F) -> Result<ComPtr<T1>, ()>
+where
+    T1: Interface,
+    F: FnOnce(&mut *mut T0, REFIID) -> HRESULT,
+{
+    let mut ptr = null_mut();
+    let res = fun(&mut ptr, &T1::uuidof());
+    if SUCCEEDED(res) {
+        Ok(unsafe { ComPtr::from_raw(ptr as *mut T1) })
+    } else {
+        Err(())
+    }
+}
+
+fn is_adapter_suitable(adapter: *mut IDXGIAdapter1) -> bool {
+    let mut desc = DXGI_ADAPTER_DESC1::default();
+    if SUCCEEDED(unsafe { (*adapter).GetDesc1(&mut desc) }) {
+        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) == DXGI_ADAPTER_FLAG_SOFTWARE {
+            // Don't select the Basic Render Driver adapter.
+            false
+        } else {
+            // Check to see whether the adapter supports Direct3D 12, but don't create the
+            // actual device yet.
+            unsafe {
+                SUCCEEDED(D3D12CreateDevice(
+                    adapter as *mut IUnknown,
+                    D3D_FEATUREL_LEVEL,
+                    &ID3D12Device::uuidof(),
+                    null_mut(),
+                ))
+            }
+        }
+    } else {
+        false
+    }
+}
+
+fn find_first_suitable(
+    enumerator: &dyn Fn(u32) -> Result<ComPtr<IDXGIAdapter1>, ()>,
+) -> Result<ComPtr<IDXGIAdapter1>, ()> {
+    let mut adapter_index = 0;
+    loop {
+        if let Ok(adapter) = enumerator(adapter_index) {
+            if is_adapter_suitable(adapter.as_raw()) {
+                break Ok(adapter);
+            }
+        } else {
+            break Err(());
+        }
+        adapter_index += 1;
+    }
+}
+
+// Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
+// If no such adapter can be found, *ppAdapter will be set to nullptr.
+fn get_hardware_adapter(factory: &ComPtr<IDXGIFactory4>) -> Result<ComPtr<IDXGIAdapter1>, ()> {
+    let adapter = if let Ok(factory6) = factory.cast::<IDXGIFactory6>() {
+        find_first_suitable(&|index: u32| -> Result<ComPtr<IDXGIAdapter1>, ()> {
+            call_com_fn(|adapter, id| unsafe {
+                factory6.EnumAdapterByGpuPreference(
+                    index,
+                    DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
+                    id,
+                    adapter,
+                )
+            })
+        })
+    } else {
+        Err(())
+    };
+
+    if adapter.is_err() {
+        find_first_suitable(&|index: u32| -> Result<ComPtr<IDXGIAdapter1>, ()> {
+            call_com_fn(|adapter, _| unsafe { factory.EnumAdapters(index, adapter) })
+        })
+    } else {
+        adapter
+    }
+}
+
+pub struct D3DSkiaRenderer {
+    window: Window,
+    gr_context: DirectContext,
+    swap_chain: ComPtr<IDXGISwapChain3>,
+    swap_chain_desc: DXGI_SWAP_CHAIN_DESC1,
+    swap_chain_waitable: HANDLE,
+    command_queue: ComPtr<ID3D12CommandQueue>,
+    buffers: Vec<ComPtr<ID3D12Resource>>,
+    surfaces: Vec<Surface>,
+    fence_values: Vec<u64>,
+    fence: ComPtr<ID3D12Fence>,
+    fence_event: HANDLE,
+    frame_swapped: bool,
+    frame_index: usize,
+    _backend_context: BackendContext,
+    _adapter: ComPtr<IDXGIAdapter1>,
+    _device: ComPtr<ID3D12Device>,
+}
+
+impl D3DSkiaRenderer {
+    pub fn new(window: Window) -> Self {
+        let mut factory_flags = 0;
+
+        let debug_controller: ComPtr<ID3D12Debug> = call_com_fn(|debug_controller, id| unsafe {
+            D3D12GetDebugInterface(id, debug_controller)
+        })
+        .expect("Failed to create Direct3D debug controller");
+        unsafe {
+            debug_controller.EnableDebugLayer();
+        }
+        // Enable additional debug layers.
+        factory_flags |= DXGI_CREATE_FACTORY_DEBUG;
+
+        let dxgi_factory: ComPtr<IDXGIFactory4> =
+            call_com_fn(|factory, id| unsafe { CreateDXGIFactory2(factory_flags, id, factory) })
+                .expect("Failed to create DXGI factory");
+        let adapter = get_hardware_adapter(&dxgi_factory)
+            .expect("Failed to find any suitable Direct3D 12 adapters");
+
+        let device: ComPtr<ID3D12Device> = call_com_fn(|device, id| unsafe {
+            D3D12CreateDevice(
+                adapter.as_raw() as *mut IUnknown,
+                D3D_FEATUREL_LEVEL,
+                id,
+                device,
+            )
+        })
+        .expect("Failed to create a Direct3D 12 device");
+
+        // Describe and create the command queue.
+        let queue_desc = D3D12_COMMAND_QUEUE_DESC {
+            Flags: D3D12_COMMAND_QUEUE_FLAG_NONE,
+            Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
+            ..Default::default()
+        };
+        let command_queue: ComPtr<ID3D12CommandQueue> =
+            call_com_fn(|queue, id| unsafe { device.CreateCommandQueue(&queue_desc, id, queue) })
+                .expect("Failed to create the Direct3D command queue");
+
+        // Describe and create the swap chain.
+        let swap_chain_desc = DXGI_SWAP_CHAIN_DESC1 {
+            Width: 0,
+            Height: 0,
+            Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+            Stereo: false.into(),
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                Quality: 0,
+            },
+            BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
+            BufferCount: 2,
+            Scaling: DXGI_SCALING_NONE,
+            SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
+            AlphaMode: DXGI_ALPHA_MODE_UNSPECIFIED,
+            Flags: DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT,
+        };
+
+        let hwnd = if let RawWindowHandle::Win32(handle) = window.raw_window_handle() {
+            handle.hwnd
+        } else {
+            panic!("Not a Win32 window");
+        };
+
+        let swap_chain: ComPtr<IDXGISwapChain3> = call_com_fn(|swap_chain, _| unsafe {
+            dxgi_factory.CreateSwapChainForHwnd(
+                command_queue.as_raw() as *mut IUnknown,
+                hwnd as HWND,
+                &swap_chain_desc,
+                null(),
+                null_mut(),
+                swap_chain,
+            )
+        })
+        .expect("Failed to create the Direct3D swap chain");
+
+        unsafe {
+            swap_chain.SetMaximumFrameLatency(1);
+        };
+
+        let swap_chain_waitable = unsafe { swap_chain.GetFrameLatencyWaitableObject() };
+        if swap_chain_waitable.is_null() {
+            panic!("Failed to get swapchain waitable object");
+        }
+
+        // use a high value to make it easier to track these in PIX
+        let fence_values = vec![10000; swap_chain_desc.BufferCount as usize];
+        let fence: ComPtr<ID3D12Fence> = call_com_fn(|fence, id| unsafe {
+            device.CreateFence(fence_values[0], D3D12_FENCE_FLAG_NONE, id, fence)
+        })
+        .expect("Failed to create fence");
+
+        let fence_event = unsafe { CreateEvent(null_mut(), false.into(), false.into(), null()) };
+        let frame_index = unsafe { swap_chain.GetCurrentBackBufferIndex() as usize };
+
+        let backend_context = BackendContext {
+            adapter: adapter.clone(),
+            device: device.clone(),
+            queue: command_queue.clone(),
+            memory_allocator: None,
+            protected_context: Protected::No,
+        };
+        let gr_context = unsafe {
+            DirectContext::new_d3d(&backend_context, None).expect("Failed to create Skia context")
+        };
+
+        let mut ret = Self {
+            _adapter: adapter,
+            _device: device,
+            command_queue,
+            swap_chain,
+            swap_chain_desc,
+            swap_chain_waitable,
+            gr_context,
+            _backend_context: backend_context,
+            buffers: Vec::new(),
+            surfaces: Vec::new(),
+            fence_values,
+            fence,
+            fence_event,
+            frame_swapped: true,
+            frame_index,
+            window,
+        };
+        ret.setup_surfaces();
+
+        ret
+    }
+
+    fn move_to_next_frame(&mut self) {
+        if self.frame_swapped {
+            tracy_gpu_zone!("move_to_next_frame");
+            unsafe {
+                let current_fence_value = self.fence_values[self.frame_index];
+
+                // Schedule a Signal command in the queue.
+                self.command_queue
+                    .Signal(self.fence.as_raw(), current_fence_value);
+
+                // Update the frame index.
+                self.frame_index = self.swap_chain.GetCurrentBackBufferIndex() as usize;
+                let old_fence_value = self.fence_values[self.frame_index];
+
+                // If the next frame is not ready to be rendered yet, wait until it is ready.
+                if self.fence.GetCompletedValue() < old_fence_value {
+                    self.fence
+                        .SetEventOnCompletion(old_fence_value, self.fence_event);
+                    WaitForSingleObjectEx(self.fence_event, INFINITE, false.into());
+                }
+
+                // Set the fence value for the next frame.
+                self.fence_values[self.frame_index] = current_fence_value + 1;
+                self.frame_swapped = false;
+            };
+        }
+    }
+
+    unsafe fn wait_for_gpu(&mut self) {
+        unsafe {
+            let current_fence_value = *self.fence_values.iter().max().unwrap();
+            // Schedule a Signal command in the queue.
+            self.command_queue
+                .Signal(self.fence.as_raw(), current_fence_value);
+
+            // Wait until the fence has been processed.
+            self.fence
+                .SetEventOnCompletion(current_fence_value, self.fence_event);
+            WaitForSingleObjectEx(self.fence_event, INFINITE, false.into());
+
+            // Increment all fence values
+            for v in &mut self.fence_values {
+                *v = current_fence_value + 1;
+            }
+        }
+    }
+
+    fn setup_surfaces(&mut self) {
+        let size = self.window.inner_size();
+        let size = (
+            size.width.try_into().expect("Could not convert width"),
+            size.height.try_into().expect("Could not convert height"),
+        );
+
+        self.buffers.clear();
+        self.surfaces.clear();
+        for i in 0..self.swap_chain_desc.BufferCount {
+            let buffer: ComPtr<ID3D12Resource> =
+                call_com_fn(|buffer, id| unsafe { self.swap_chain.GetBuffer(i, id, buffer) })
+                    .expect("Could not get swapchain buffer");
+            self.buffers.push(buffer.clone());
+
+            let info = TextureResourceInfo {
+                resource: buffer,
+                alloc: None,
+                resource_state: D3D12_RESOURCE_STATE_PRESENT,
+                format: self.swap_chain_desc.Format,
+                sample_count: self.swap_chain_desc.SampleDesc.Count,
+                level_count: 1,
+                sample_quality_pattern: 0,
+                protected: Protected::No,
+            };
+
+            let backend_render_target = BackendRenderTarget::new_d3d(size, &info);
+
+            let surface = wrap_backend_render_target(
+                &mut self.gr_context,
+                &backend_render_target,
+                SurfaceOrigin::TopLeft,
+                ColorType::RGBA8888,
+                None,
+                None,
+            )
+            .expect("Could not create backend render target");
+            self.surfaces.push(surface);
+        }
+        self.frame_index = unsafe { self.swap_chain.GetCurrentBackBufferIndex() as usize };
+    }
+}
+
+impl SkiaRenderer for D3DSkiaRenderer {
+    fn window(&self) -> &Window {
+        &self.window
+    }
+
+    fn flush(&mut self) {}
+
+    fn swap_buffers(&mut self) {
+        let info = FlushInfo::default();
+        unsafe {
+            {
+                tracy_gpu_zone!("submit surface");
+                // Switch the back buffer resource state to present For some reason the
+                // DirectContext::flush_and_submit does not do that for us automatically.
+                let buffer_index = self.swap_chain.GetCurrentBackBufferIndex() as usize;
+                self.gr_context.flush_surface_with_access(
+                    &mut self.surfaces[buffer_index],
+                    BackendSurfaceAccess::Present,
+                    &info,
+                );
+                self.gr_context.submit(Some(SyncCpu::No));
+            }
+
+            {
+                tracy_zone!("wait for vblank");
+                WaitForSingleObjectEx(self.swap_chain_waitable, 1000, true.into());
+                tracy_frame();
+            };
+
+            let res = {
+                tracy_gpu_zone!("present");
+                self.swap_chain.Present(1, 0)
+            };
+            if SUCCEEDED(res) {
+                self.frame_swapped = true;
+            }
+        }
+    }
+
+    fn canvas(&mut self) -> &Canvas {
+        // Only block the cpu when whe actually need to draw to the canvas
+        if self.frame_swapped {
+            self.move_to_next_frame();
+        }
+        self.surfaces[self.frame_index].canvas()
+    }
+
+    fn resize(&mut self) {
+        // Clean up any outstanding resources in command lists
+        self.gr_context.flush_submit_and_sync_cpu();
+
+        unsafe {
+            self.wait_for_gpu();
+        }
+
+        self.surfaces.clear();
+        self.buffers.clear();
+
+        let size = self.window.inner_size();
+
+        unsafe {
+            self.swap_chain.ResizeBuffers(
+                0,
+                size.width,
+                size.height,
+                self.swap_chain_desc.Format,
+                self.swap_chain_desc.Flags,
+            );
+        }
+        self.setup_surfaces();
+    }
+
+    fn create_vsync(&self, _proxy: EventLoopProxy<UserEvent>) -> VSync {
+        unimplemented!()
+    }
+}
+
+impl Drop for D3DSkiaRenderer {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.fence_event);
+        }
+    }
+}

--- a/src/renderer/d3d.rs
+++ b/src/renderer/d3d.rs
@@ -1,5 +1,15 @@
 use std::ptr::{null, null_mut};
 
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use skia_safe::{
+    gpu::{
+        d3d::{BackendContext, TextureResourceInfo},
+        surfaces::wrap_backend_render_target,
+        BackendRenderTarget, DirectContext, FlushInfo, Protected, SurfaceOrigin, SyncCpu,
+    },
+    surface::BackendSurfaceAccess,
+    Canvas, ColorType, Surface,
+};
 use winapi::{
     shared::{
         dxgi::{
@@ -32,27 +42,12 @@ use winapi::{
     },
     Interface,
 };
-
+use winit::{event_loop::EventLoopProxy, window::Window};
 use wio::com::ComPtr;
 
-use skia_safe::{
-    gpu::{
-        d3d::{BackendContext, TextureResourceInfo},
-        surfaces::wrap_backend_render_target,
-        BackendRenderTarget, DirectContext, FlushInfo, Protected, SurfaceOrigin, SyncCpu,
-    },
-    surface::BackendSurfaceAccess,
-    Canvas, ColorType, Surface,
-};
-
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
-use winit::{event_loop::EventLoopProxy, window::Window};
-
 use super::{vsync::VSyncWinSwapChain, SkiaRenderer, VSync};
-
 #[cfg(feature = "gpu_profiling")]
 use crate::profiling::{d3d::create_d3d_gpu_context, GpuCtx};
-
 use crate::{profiling::tracy_gpu_zone, window::UserEvent};
 
 const D3D_FEATUREL_LEVEL: D3D_FEATURE_LEVEL = D3D_FEATURE_LEVEL_11_0;

--- a/src/renderer/vsync/mod.rs
+++ b/src/renderer/vsync/mod.rs
@@ -5,6 +5,8 @@ mod vsync_macos;
 mod vsync_timer;
 #[cfg(target_os = "windows")]
 mod vsync_win_dwm;
+#[cfg(target_os = "windows")]
+mod vsync_win_swap_chain;
 
 use vsync_timer::VSyncTimer;
 
@@ -15,6 +17,8 @@ use winit::{event_loop::EventLoopProxy, window::Window};
 
 #[cfg(target_os = "windows")]
 pub use vsync_win_dwm::VSyncWinDwm;
+#[cfg(target_os = "windows")]
+pub use vsync_win_swap_chain::VSyncWinSwapChain;
 
 #[cfg(target_os = "macos")]
 pub use vsync_macos::VSyncMacos;
@@ -26,6 +30,8 @@ pub enum VSync {
     Timer(VSyncTimer),
     #[cfg(target_os = "windows")]
     WindowsDwm(VSyncWinDwm),
+    #[cfg(target_os = "windows")]
+    WindowsSwapChain(VSyncWinSwapChain),
     #[cfg(target_os = "macos")]
     Macos(VSyncMacos),
 }
@@ -48,6 +54,8 @@ impl VSync {
             VSync::Timer(vsync) => vsync.wait_for_vsync(),
             #[cfg(target_os = "windows")]
             VSync::WindowsDwm(vsync) => vsync.wait_for_vsync(),
+            #[cfg(target_os = "windows")]
+            VSync::WindowsSwapChain(vsync) => vsync.wait_for_vsync(),
             #[cfg(target_os = "macos")]
             VSync::Macos(vsync) => vsync.wait_for_vsync(),
             _ => {}
@@ -56,7 +64,10 @@ impl VSync {
 
     pub fn uses_winit_throttling(&self) -> bool {
         #[cfg(target_os = "windows")]
-        return matches!(self, VSync::WinitThrottling() | VSync::WindowsDwm(..));
+        return matches!(
+            self,
+            VSync::WinitThrottling() | VSync::WindowsDwm(..) | VSync::WindowsSwapChain(..)
+        );
 
         #[cfg(target_os = "macos")]
         return matches!(self, VSync::WinitThrottling() | VSync::Macos(..));
@@ -95,6 +106,8 @@ impl VSync {
             VSync::WinitThrottling(..) => window.request_redraw(),
             #[cfg(target_os = "windows")]
             VSync::WindowsDwm(vsync) => vsync.request_redraw(),
+            #[cfg(target_os = "windows")]
+            VSync::WindowsSwapChain(vsync) => vsync.request_redraw(),
             #[cfg(target_os = "macos")]
             VSync::Macos(vsync) => vsync.request_redraw(),
             _ => {}

--- a/src/renderer/vsync/vsync_win_swap_chain.rs
+++ b/src/renderer/vsync/vsync_win_swap_chain.rs
@@ -1,0 +1,65 @@
+use std::{
+    sync::mpsc::{channel, Sender},
+    thread::{spawn, JoinHandle},
+};
+
+use winapi::um::{synchapi::WaitForSingleObjectEx, winnt::HANDLE};
+
+use winit::event_loop::EventLoopProxy;
+
+use crate::{profiling::tracy_zone, window::UserEvent};
+
+enum Message {
+    RequestRedraw,
+    Quit,
+}
+
+struct SwapChainHandle {
+    handle: HANDLE,
+}
+
+unsafe impl Send for SwapChainHandle {}
+unsafe impl Sync for SwapChainHandle {}
+
+pub struct VSyncWinSwapChain {
+    vsync_thread: Option<JoinHandle<()>>,
+    sender: Sender<Message>,
+}
+
+impl VSyncWinSwapChain {
+    pub fn new(proxy: EventLoopProxy<UserEvent>, swap_chain_waitable: HANDLE) -> Self {
+        let handle = SwapChainHandle {
+            handle: swap_chain_waitable,
+        };
+        let (sender, receiver) = channel();
+        let vsync_thread = {
+            Some(spawn(move || {
+                let handle = handle;
+                while let Ok(Message::RequestRedraw) = receiver.recv() {
+                    tracy_zone!("wait for vblank");
+                    unsafe {
+                        WaitForSingleObjectEx(handle.handle, 1000, true.into());
+                    }
+                    let _ = proxy.send_event(UserEvent::RedrawRequested);
+                }
+            }))
+        };
+        Self {
+            vsync_thread,
+            sender,
+        }
+    }
+
+    pub fn wait_for_vsync(&mut self) {}
+
+    pub fn request_redraw(&mut self) {
+        let _ = self.sender.send(Message::RequestRedraw);
+    }
+}
+
+impl Drop for VSyncWinSwapChain {
+    fn drop(&mut self) {
+        let _ = self.sender.send(Message::Quit);
+        self.vsync_thread.take().unwrap().join().unwrap();
+    }
+}


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This switches to a Direct3D based renderer and finally makes the Windows render loop smooth with almost no frame drops, at least on my machine. 

Using Direct3D will also improve the compatibility with older hardware.

NOTE:
* You can still use the old opengl based rendering by passing the  `--opengl` option. 
* The `--no-vsync` option does not work properly at the moment
* There might be bugs when the device is lost/computer sleeps/monitor turned off
* The device selection code is somewhat naive
* The code probably needs some cleanup, and that's the biggest reason for the draft status. I will probably split this PR into two, one pure refactoring, and another one that adds the functionality.
* This also seem to reduce the stuttering in some Wayland compositors like Mutter/Gnome at the cost of a very, very slight possible additional latency after pressing a key, less than a frame
* `Asus GPU Tweak III` causes Neovide to stutter when it’s running. Not because it messes with the GPU, but because it seem to do something to the Windows messaging system, all calls, even `PeekMesage`, with should be almost instant,  take a long time to complete. In the case of `PeekMessage` sometimes a couple of ms, and several of those in a row will cause dropped frames. So, I suggest closing the program or find an alternative. Neovide is probably not the only application affected.
* The gpu profiling is almost unusably slow, and I think we would need access to the skia internal command queues to make it faster. But maybe there’s another way?

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No, it should not
