### PR TITLE
fix: #2234 by adding !self.scrollback_lines.is_empty() check

### DIFF
--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -748,12 +748,14 @@ impl RenderedWindow {
             line.is_valid = true;
         };
 
-        for line in self
-            .scrollback_lines
-            .iter_range_mut(scroll_offset_lines..scroll_offset_lines + height + 1)
-            .flatten()
-        {
-            prepare_line(line)
+        if !self.scrollback_lines.is_empty() {
+            for line in self
+                .scrollback_lines
+                .iter_range_mut(scroll_offset_lines..scroll_offset_lines + height + 1)
+                .flatten()
+            {
+                prepare_line(line)
+            }
         }
 
         for line in self


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

Fixes https://github.com/neovide/neovide/issues/2234 as per suggestion by [fredizzimo](https://github.com/fredizzimo).

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
