### PR TITLE
fix: fix hang on neovim exit

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -12,10 +12,7 @@ use log::{error, info};
 use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
 use rmpv::Utf8String;
 use std::{io::Error, ops::Add, sync::Arc};
-use tokio::{
-    runtime::{Builder, Runtime},
-    task::JoinHandle,
-};
+use tokio::runtime::{Builder, Runtime};
 use winit::event_loop::EventLoopProxy;
 
 use crate::{
@@ -34,14 +31,8 @@ pub use ui_commands::{send_ui, start_ui_command_handler, ParallelCommand, Serial
 const INTRO_MESSAGE_LUA: &str = include_str!("../../lua/intro.lua");
 const NEOVIM_REQUIRED_VERSION: &str = "0.9.2";
 
-enum RuntimeState {
-    Idle,
-    Attached(JoinHandle<()>),
-}
-
 pub struct NeovimRuntime {
-    runtime: Runtime,
-    state: RuntimeState,
+    runtime: Option<Runtime>,
 }
 
 fn neovim_instance() -> Result<NeovimInstance> {
@@ -158,8 +149,7 @@ impl NeovimRuntime {
         let runtime = Builder::new_multi_thread().enable_all().build()?;
 
         Ok(Self {
-            runtime,
-            state: RuntimeState::Idle,
+            runtime: Some(runtime),
         })
     }
 
@@ -168,20 +158,16 @@ impl NeovimRuntime {
         event_loop_proxy: EventLoopProxy<UserEvent>,
         grid_size: Option<Dimensions>,
     ) -> Result<()> {
-        assert!(matches!(self.state, RuntimeState::Idle));
         let handler = start_editor(event_loop_proxy);
-        let session = self.runtime.block_on(launch(handler, grid_size))?;
-        self.state = RuntimeState::Attached(self.runtime.spawn(run(session)));
+        let runtime = self.runtime.as_ref().unwrap();
+        let session = runtime.block_on(launch(handler, grid_size))?;
+        runtime.spawn(run(session));
         Ok(())
     }
 }
 
 impl Drop for NeovimRuntime {
     fn drop(&mut self) {
-        if let RuntimeState::Attached(join_handle) =
-            std::mem::replace(&mut self.state, RuntimeState::Idle)
-        {
-            let _ = self.runtime.block_on(join_handle);
-        }
+        self.runtime.take().unwrap().shutdown_background();
     }
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

This is basically #2130 again. I wanted a cleaner fix, but a lot of the async and threading stuff will need to be reworked. In the mean time there have been enough reports of hangs to justify a quick fix so it's usable.

I tried a couple of things that worked for me before, but an added complication now is the task spawning in `start_ui_command_handler`. If those are stuck in a `recv()`, they just won't exit.

I'm thinking instead of `RUNNING_TRACKER` we need to use cancellation tokens or something tokio can select on so we can break out of futures that will never return. Checking `RUNNING_TRACKER.is_running()` does nothing when stuck in an await, and we shouldn't rely on channels dropping at the end of a scope to break out of these loops, because that drop can possibly not happen if stuck in another await. That is exactly what's happening here.

After working on this for a bit I also realized that no timeout is really needed, because tokio doesn't kill the child process when the runtime shuts down. Not unless we call `kill_on_drop()`, which we don't. This change just lets neovide exit instead of waiting forever in stuck awaits.
