### PR TITLE
fix: When counting leading spaces for space skip optimization count codepoints

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -386,7 +386,7 @@ impl CachingShaper {
 
         let mut resulting_blobs = Vec::new();
 
-        trace!("Shaping text: {}", text);
+        trace!("Shaping text: {:?}", text);
 
         for (cluster_group, font_pair) in self.build_clusters(&text, style) {
             let features = self.get_font_features(

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -215,7 +215,8 @@ impl GridRenderer {
         // There's a lot of overhead for empty blobs in Skia, for some reason they never hit the
         // cache, so trim all the spaces
         let trimmed = text.trim_start();
-        let leading_spaces = text.len() - trimmed.len();
+        let leading_space_bytes = text.len() - trimmed.len();
+        let leading_spaces = text[..leading_space_bytes].chars().count();
         let trimmed = trimmed.trim_end();
         let x_adjustment = leading_spaces as u64 * self.font_dimensions.width;
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No (I assume change in 5be2acec746309c0b6be4cd61312b9503c39baa5 does not count as breaking)


Result from running `cargo +stable-x86_64-pc-windows-msvc run -- --grid '1x25' --log -- -u NONE -i NONE -N --cmd 'set fillchars=eob:\  cmdheight=0 nolist noshowcmd laststatus=0' --cmd "call setline(1, map(range(0x09, 0x0D) + [0x20, 0x85, 0xA0, 0x1680] + range(0x2000, 0x200A) + [0x2028, 0x2029, 0x202F, 0x205F, 0x3000], 'printf(''%s%04x'', nr2char(v:val), v:val)'))" --cmd 'autocmd FocusGained * redraw! | sleep 1'` with this branch:

![image](https://github.com/neovide/neovide/assets/32704105/2906cc6e-b256-4951-8e24-5a52b97394fc)

Result from running the same command, but with `cargo +stable-x86_64-pc-windows-msvc run --` replaced with `neovide` to get neovide 0.12.1 from scoop:

![image](https://github.com/neovide/neovide/assets/32704105/f5b5bd2c-193e-4d08-a44c-9146b8c20987)
