### PR TITLE
fix: Reset the cached font info after the fudge factor is updated

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -171,9 +171,10 @@ impl CachingShaper {
             self.fudge_factor = font_width.round() / font_width;
             debug!("Fudge factor: {:.2}", self.fudge_factor);
             font_size = self.current_size();
+            self.font_info = None;
+            self.font_loader = FontLoader::new(font_size);
             debug!("Fudged font size: {:.2}px", font_size);
             debug!("Fudged font width: {:.2}px", self.info().1);
-            self.font_loader = FontLoader::new(font_size);
         }
         self.blob_cache.clear();
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The old `font_info` was used after the new font size had been calculated using the fudge factor. In practice I never saw problems due to this, since the grid sizes were also rounded the same way. But it was still incorrect, and there could very well be some font sizes that were rendered wrong, with either one pixel to wide or narrow grid size.

## Did this PR introduce a breaking change? 
- No
