### PR TITLE
fix: Use rpc request instead of notify for quit requests

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -94,7 +94,7 @@ vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
     once = true,
     nested = true,
     callback = function()
-        rpcnotify("neovide.quit", vim.v.exiting)
+        rpcrequest("neovide.quit", vim.v.exiting)
     end
 })
 

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -62,6 +62,13 @@ impl Handler for NeovimHandler {
             }
             "neovide.set_clipboard" => set_clipboard_contents(&arguments[0])
                 .map_err(|_| Value::from("cannot set clipboard contents")),
+            "neovide.quit" => {
+                let error_code = arguments[0]
+                    .as_i64()
+                    .expect("Could not parse error code from neovim");
+                RUNNING_TRACKER.quit_with_code(error_code as i32, "Quit from neovim");
+                Ok(Value::Nil)
+            }
             _ => Ok(Value::from("rpcrequest not handled")),
         }
     }
@@ -91,12 +98,6 @@ impl Handler for NeovimHandler {
             }
             "option_changed" => {
                 SETTINGS.handle_option_changed_notification(arguments, &self.proxy.lock().unwrap());
-            }
-            "neovide.quit" => {
-                let error_code = arguments[0]
-                    .as_i64()
-                    .expect("Could not parse error code from neovim");
-                RUNNING_TRACKER.quit_with_code(error_code as i32, "Quit from neovim");
             }
             #[cfg(windows)]
             "neovide.register_right_click" => {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Send the quit request using rpc requests instead of notify, so that Neovim waits until Neovide has processed the possible return value until it quits.

Sometimes, without this wait the return code is never received by Neovide before Neovim has quit and it's too late, so the wrong return code is returned.

NOTE: To quit with a return code use [:quit](https://neovim.io/doc/user/quickfix.html#%3Acquit)

## Did this PR introduce a breaking change? 
- No
