### PR TITLE
feat: Add colored output to `--help`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tracy-callstack-inlines = ["tracy-client-sys?/callstack-inlines"]
 anyhow = { version = "1.0.75", features = ["backtrace"] }
 async-trait = "0.1.53"
 backtrace = "0.3.67"
-clap = { version = "4.3.19", features = ["cargo", "derive", "env"] }
+clap = { version = "4.4.18", features = ["cargo", "derive", "env", "color"] }
 copypasta = "0.8.1"
 csscolorparser = "0.6.2"
 derive-new = "0.5.9"

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -3,15 +3,26 @@ use std::{iter, mem};
 use crate::{dimensions::Dimensions, frame::Frame, settings::*};
 
 use anyhow::Result;
-use clap::{builder::FalseyValueParser, ArgAction, Parser};
+use clap::{
+    builder::{styling, FalseyValueParser, Styles},
+    ArgAction, Parser,
+};
 
 #[cfg(target_os = "windows")]
 pub const SRGB_DEFAULT: &str = "1";
 #[cfg(not(target_os = "windows"))]
 pub const SRGB_DEFAULT: &str = "0";
 
+fn get_styles() -> Styles {
+    styling::Styles::styled()
+        .header(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
+        .usage(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
+        .literal(styling::AnsiColor::Blue.on_default() | styling::Effects::BOLD)
+        .placeholder(styling::AnsiColor::Cyan.on_default())
+}
+
 #[derive(Clone, Debug, Parser)]
-#[command(version, about, long_about = None)]
+#[command(version, about, long_about = None, styles = get_styles())]
 pub struct CmdLineSettings {
     /// Files to open (plainly appended to NeoVim args)
     #[arg(


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

----------

Today i was building neovide, and instead of `cargo r -- --help`, i typed `cargo r --help`. And cargo help is colored!

I immediately wanted to have the same colored help in neovide. So, i added it!

They're using `cyan` for command names, and i've used defaults from clap docs, because in our case cyan looks not so fitting.

Take a look!

![image](https://github.com/neovide/neovide/assets/301015/d09224cc-e983-4791-9cfb-e69c50f5b7aa)

-------

One thing to be aware of - i expected `Cargo.lock` to be updated, after changing `Cargo.toml`, but it was not updated. Is there something else i need to do to update it?