### PR TITLE
fix: Handle some more numpad keys

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -95,7 +95,23 @@ impl KeyboardManager {
             KeyCode::NumpadSubtract => Some("kMinus"),
             KeyCode::NumpadAdd => Some("kPlus"),
             KeyCode::NumpadEnter => Some("kEnter"),
-            KeyCode::NumpadDecimal => Some("kDel"),
+            KeyCode::NumpadEqual => Some("kEqual"),
+            KeyCode::NumpadComma => match key_event.logical_key.as_ref() {
+                Key::Character(",") => Some("kComma"),
+                Key::Character(".") => Some("kPoint"),
+                _ => None,
+            },
+            KeyCode::NumpadDecimal => {
+                if is_numlock_key {
+                    match key_event.logical_key.as_ref() {
+                        Key::Character(",") => Some("kComma"),
+                        Key::Character(".") => Some("kPoint"),
+                        _ => None,
+                    }
+                } else {
+                    Some("kDel")
+                }
+            }
             KeyCode::Numpad9 => {
                 KeyboardManager::handle_numpad_numkey(is_numlock_key, "k9", "kPageUp")
             }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix. Some numpad keys are not mapped to the correct neovim key. With this patch, neovide honors numlock for [`NumpadDecimal`], and sets the correct neovim keycode for [`NumpadComma`] and [`NumpadEqual`].

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No. 

[`NumpadComma`]: https://docs.rs/winit/0.29.10/winit/keyboard/enum.KeyCode.html#variant.NumpadComma
[`NumpadDecimal`]: https://docs.rs/winit/0.29.10/winit/keyboard/enum.KeyCode.html#variant.NumpadDecimal
[`NumpadEqual`]: https://docs.rs/winit/0.29.10/winit/keyboard/enum.KeyCode.html#variant.NumpadEqual

This is a follow up of #2032

See also [neovim docs][0].

Please note that I don't have a numpad with `<kEqual>` and `<kComma>` keys, I could only test kPoint (which is currently incorrectly handled as `<kDel>` even with numlock on).

[0]: https://github.com/neovim/neovim/blob/1bf645918e94e7e8f770592484164f1ee303f24e/runtime/doc/intro.txt#L377-L379
