### PR TITLE
Update nvim-rs, remove superflous arc-wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "nvim-rs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9156b04d79079937abae1eb912669c48c360fb5d86138052a9bbae9c5220a71e"
+checksum = "45fcd98ddbb0c866684dacec0d99a7c623c1784b0facfd44cfee17cc79aa81b2"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -1770,6 +1770,7 @@ dependencies = [
  "rmpv",
  "tokio",
  "tokio-util",
+ "winapi",
 ]
 
 [[package]]
@@ -2775,9 +2776,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log = "0.4.16"
 lru = "0.7.5"
 neovide-derive = { path = "neovide-derive", version = "0.1.0" }
 num = "0.4.1"
-nvim-rs = { version = "0.6.0", features = ["use_tokio"] }
+nvim-rs = { version = "0.7.0", features = ["use_tokio"] }
 parking_lot = "0.12.0"
 rand = "0.8.5"
 raw-window-handle = "0.5.0"

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use log::{error, info};
 use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
 use rmpv::Utf8String;
-use std::{io::Error, ops::Add, sync::Arc};
+use std::{io::Error, ops::Add};
 use tokio::runtime::{Builder, Runtime};
 use winit::event_loop::EventLoopProxy;
 
@@ -109,7 +109,7 @@ async fn launch(handler: NeovimHandler, grid_size: Option<Dimensions>) -> Result
     let should_handle_clipboard = settings.wsl || settings.server.is_some();
     setup_neovide_specific_state(&session.neovim, should_handle_clipboard).await?;
 
-    start_ui_command_handler(Arc::clone(&session.neovim));
+    start_ui_command_handler(session.neovim.clone());
     SETTINGS.read_initial_values(&session.neovim).await?;
 
     let mut options = UiAttachOptions::new();

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -37,7 +37,7 @@ impl NeovimSession {
         let io_handle = spawn(io);
 
         Ok(Self {
-            neovim: neovim,
+            neovim,
             io_handle,
         })
     }

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -4,7 +4,6 @@
 use std::{
     io::{Error, ErrorKind, Result},
     process::Stdio,
-    sync::Arc,
 };
 
 use nvim_rs::{error::LoopError, neovim::Neovim, Handler};
@@ -23,7 +22,7 @@ type BoxedReader = Box<dyn AsyncRead + Send + Unpin + 'static>;
 type BoxedWriter = Box<dyn AsyncWrite + Send + Unpin + 'static>;
 
 pub struct NeovimSession {
-    pub neovim: Arc<Neovim<NeovimWriter>>,
+    pub neovim: Neovim<NeovimWriter>,
     pub io_handle: JoinHandle<std::result::Result<(), Box<LoopError>>>,
 }
 
@@ -38,7 +37,7 @@ impl NeovimSession {
         let io_handle = spawn(io);
 
         Ok(Self {
-            neovim: Arc::new(neovim),
+            neovim: neovim,
             io_handle,
         })
     }

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -36,10 +36,7 @@ impl NeovimSession {
             Neovim::<NeovimWriter>::new(reader.compat(), Box::new(writer.compat_write()), handler);
         let io_handle = spawn(io);
 
-        Ok(Self {
-            neovim,
-            io_handle,
-        })
+        Ok(Self { neovim, io_handle })
     }
 }
 

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -1,4 +1,4 @@
-use std::sync::{Mutex};
+use std::sync::Mutex;
 
 use log::trace;
 

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Mutex};
 
 use log::trace;
 
@@ -340,7 +340,7 @@ lazy_static! {
     static ref UI_CHANNELS: UIChannels = UIChannels::new();
 }
 
-pub fn start_ui_command_handler(nvim: Arc<Neovim<NeovimWriter>>) {
+pub fn start_ui_command_handler(nvim: Neovim<NeovimWriter>) {
     let (serial_tx, mut serial_rx) = unbounded_channel::<SerialCommand>();
     let ui_command_nvim = nvim.clone();
     tokio::spawn(async move {


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Codestyle
- Other

## Did this PR introduce a breaking change? 

- No

Updated `nvim-rs` to the latest release. I noticed you're wrapping the `Neovim` instance in `Arc`. That's not really necessary, since `nvim-rs` does `Arc`-wrapping for all components anyways.

There might be performance implications - this removes an indirection, but cloning the `Neovim` instance now needs to bump 3 counters instead of one. My assumption would be that this is a win, but there aren't any benchmarks in place to decide this.Your choice :)