### PR TITLE
feat: add option to disable window transparency

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -78,6 +78,10 @@ pub struct CmdLineSettings {
     #[arg(long = "no-idle", env = "NEOVIDE_IDLE", action = ArgAction::SetFalse, value_parser = FalseyValueParser::new())]
     pub idle: bool,
 
+    /// Disable transparent backgrounds. If enabled, ignores the `neovide_transparency` vim global
+    #[arg(long = "no-transparency", env = "NEOVIDE_NO_TRANSPARENCY", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
+    pub no_transparency: bool,
+
     /// Disable opening multiple files supplied in tabs (they're still buffers)
     #[arg(long = "no-tabs")]
     pub no_tabs: bool,

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub frame: Option<Frame>,
     pub theme: Option<String>,
     pub font: Option<FontSettings>,
+    pub no_transparency: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -100,6 +101,9 @@ impl Config {
         }
         if let Some(theme) = &self.theme {
             env::set_var("NEOVIDE_THEME", theme);
+        }
+        if let Some(no_transparency) = &self.no_transparency {
+            env::set_var("NEOVIDE_NO_TRANSPARENCY", no_transparency.to_string());
         }
     }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -137,7 +137,7 @@ pub fn create_event_loop() -> EventLoop<UserEvent> {
 #[cfg(target_os = "macos")]
 pub fn set_window_blurred(window: &Window, opacity: f32) {
     let window_blurred = SETTINGS.get::<WindowSettings>().window_blurred;
-    let opaque = opacity >= 1.0;
+    let opaque = opacity >= 1.0 || SETTINGS.get::<CmdLineSettings>().no_transparency;
 
     window.set_blur(window_blurred && !opaque);
 }
@@ -149,7 +149,7 @@ pub fn invalidate_shadow(window: &Window) {
     use cocoa::base::YES;
 
     let window_transparency = &SETTINGS.get::<WindowSettings>().transparency;
-    let opaque = *window_transparency >= 1.0;
+    let opaque = *window_transparency >= 1.0 || SETTINGS.get::<CmdLineSettings>().no_transparency;
 
     let raw_window = match window.raw_window_handle() {
         #[cfg(target_os = "macos")]
@@ -187,6 +187,8 @@ pub fn create_window(
         _ => DEFAULT_WINDOW_SIZE,
     };
 
+    let transparent = !cmd_line_settings.no_transparency;
+
     let winit_window_builder = WindowBuilder::new()
         .with_title("Neovide")
         .with_window_icon(Some(icon))
@@ -194,7 +196,7 @@ pub fn create_window(
         // Unfortunately we can't maximize here, because winit shows the window momentarily causing
         // flickering
         .with_maximized(false)
-        .with_transparent(SETTINGS.get::<WindowSettings>().transparency < 1.0)
+        .with_transparent(transparent)
         .with_visible(false);
 
     let frame_decoration = cmd_line_settings.frame;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -194,7 +194,7 @@ pub fn create_window(
         // Unfortunately we can't maximize here, because winit shows the window momentarily causing
         // flickering
         .with_maximized(false)
-        .with_transparent(true)
+        .with_transparent(SETTINGS.get::<WindowSettings>().transparency < 1.0)
         .with_visible(false);
 
     let frame_decoration = cmd_line_settings.frame;
@@ -212,7 +212,6 @@ pub fn create_window(
         Frame::Full => winit_window_builder,
         Frame::None => winit_window_builder.with_decorations(false),
         Frame::Buttonless => winit_window_builder
-            .with_transparent(true)
             .with_title_hidden(title_hidden)
             .with_titlebar_buttons_hidden(true)
             .with_titlebar_transparent(true)

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -8,6 +8,7 @@ use crate::windows_utils::{register_right_click, unregister_right_click};
 use crate::{
     bridge::{send_ui, ParallelCommand, SerialCommand},
     dimensions::Dimensions,
+    error_msg,
     profiling::{tracy_frame, tracy_gpu_collect, tracy_gpu_zone, tracy_plot, tracy_zone},
     renderer::{build_context, DrawCommand, GlWindow, Renderer, VSync, WindowedContext},
     running_tracker::RUNNING_TRACKER,
@@ -238,6 +239,12 @@ impl WinitWindowWrapper {
             #[cfg(target_os = "macos")]
             WindowSettingsChanged::Transparency(opacity) => {
                 log::info!("transparency changed to {}", opacity);
+                if opacity < 1.0 && SETTINGS.get::<CmdLineSettings>().no_transparency {
+                    error_msg!(
+                        "Transparency is disabled because the `no-transparency` option is set."
+                    );
+                    return;
+                }
                 invalidate_shadow(self.windowed_context.window());
                 set_window_blurred(self.windowed_context.window(), opacity);
             }

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -166,6 +166,19 @@ buffers.
 Note: Even if files are opened in tabs, they're buffers anyways. It's just about them being visible
 or not.
 
+### No Transparency
+
+```sh
+--no-transparency or $NEOVIDE_NO_TRANSPARENCY
+```
+
+By default, Neovide creates a transparent window, even if `g:neovide_transparency` is set to `1` (opaque),
+to allow changing the transparency without having to restart Neovide.
+
+When this option is set, Neovide creates an opaque window and `g:neovide_transparency` is disabled.
+
+On macOS this slightly changes the appearance of the window.
+
 ### No VSync
 
 ```sh

--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -34,6 +34,7 @@ idle = true
 neovim-bin = "/usr/bin/nvim" # in reality found dynamically on $PATH if unset
 frame = "full"
 title-hidden = true
+no-transparency = false
 ```
 
 Settings from environment variables can be found in [Command Line Reference](command-line-reference.md),


### PR DESCRIPTION
Single line change that sets the window transparency based on the user configured transparency, instead of always setting it to true.

(Also removes a redundant `with_transparent` call)

On macOS this slightly changes the window's appearance for opaque backgrounds.

<img width="1512" alt="Comparison between Neovide, Kitty and this Pull Request on macOS" src="https://github.com/neovide/neovide/assets/13782948/b70d419d-5791-4d75-a4ba-d60750224ed1">

(The lack of the borders around the window is something that always has bothered me when using Neovide, because almost all macOS windows have it)

### What kind of change does this PR introduce?
- Feature

### Did this PR introduce a breaking change? 
- No
