### PR TITLE
fix: bug of restoring window position on macos.

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -245,6 +245,11 @@ pub fn create_window(
     let gl_window = build_window(winit_window_builder, event_loop);
     let window = &gl_window.window;
 
+    #[cfg(target_os = "macos")]
+    if let Some(previous_position) = previous_position {
+        window.set_outer_position(previous_position);
+    }
+
     // Check that window is visible in some monitor, and reposition it if not.
     window.current_monitor().and_then(|current_monitor| {
         let monitor_position = current_monitor.position();


### PR DESCRIPTION
Fix #2303 

According to winit docs at https://docs.rs/winit/latest/winit/window/struct.WindowBuilder.html#method.with_position, `with_position` sets the position of top left corner of **content** rect instead of **window** rect on macOS, so a `set_outer_position` call is needed.


