### PR TITLE
feat(macos): display border for opaque backgrounds

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -9,9 +9,6 @@ mod window_wrapper;
 #[cfg(target_os = "macos")]
 mod macos;
 
-#[cfg(target_os = "macos")]
-use cocoa::base::id;
-
 #[cfg(target_os = "linux")]
 use std::env;
 
@@ -28,12 +25,6 @@ use winit::window::Window;
 
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowBuilderExtMacOS;
-
-#[cfg(target_os = "macos")]
-use objc::{msg_send, sel, sel_impl};
-
-#[cfg(target_os = "macos")]
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
 #[cfg(target_os = "linux")]
 use winit::platform::wayland::WindowBuilderExtWayland;
@@ -140,27 +131,6 @@ pub fn set_window_blurred(window: &Window, opacity: f32) {
     let opaque = opacity >= 1.0;
 
     window.set_blur(window_blurred && !opaque);
-}
-
-/// Force macOS to clear shadow of transparent windows.
-#[cfg(target_os = "macos")]
-pub fn invalidate_shadow(window: &Window) {
-    use cocoa::base::NO;
-    use cocoa::base::YES;
-
-    let window_transparency = &SETTINGS.get::<WindowSettings>().transparency;
-    let opaque = *window_transparency >= 1.0;
-
-    let raw_window = match window.raw_window_handle() {
-        #[cfg(target_os = "macos")]
-        RawWindowHandle::AppKit(handle) => handle.ns_window as id,
-        _ => return,
-    };
-
-    let value = if opaque { YES } else { NO };
-    unsafe {
-        let _: id = msg_send![raw_window, setHasShadow: value];
-    }
 }
 
 pub fn create_window(
@@ -276,9 +246,6 @@ pub fn create_window(
 
     #[cfg(target_os = "macos")]
     set_window_blurred(window, SETTINGS.get::<WindowSettings>().transparency);
-
-    #[cfg(target_os = "macos")]
-    invalidate_shadow(window);
 
     gl_window
 }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 #[cfg(target_os = "macos")]
-use crate::window::{invalidate_shadow, set_window_blurred};
+use crate::window::set_window_blurred;
 
 #[cfg(target_os = "macos")]
 use super::macos::MacosWindowFeature;
@@ -236,10 +236,11 @@ impl WinitWindowWrapper {
                 }
             }
             #[cfg(target_os = "macos")]
-            WindowSettingsChanged::Transparency(opacity) => {
-                log::info!("transparency changed to {}", opacity);
-                invalidate_shadow(self.windowed_context.window());
-                set_window_blurred(self.windowed_context.window(), opacity);
+            WindowSettingsChanged::Transparency(transparency) => {
+                log::info!("transparency changed to {}", transparency);
+                let window = self.windowed_context.window();
+                self.macos_feature.update_transparency(transparency);
+                set_window_blurred(window, transparency);
             }
             #[cfg(target_os = "macos")]
             WindowSettingsChanged::WindowBlurred(window_blurred) => {


### PR DESCRIPTION
Reworked solution initially done in #2343. (See details there)

* moves the macOS specific shadow invalidation to the `macos` module
* additionally set background color and opaqueness of the window
* renames it to `update_transparency` to better reflect what it does
* use `icrate` instead of `cocoa` for AppKit bindings in line with winit (which uses icrate internally) and #2168

## What kind of change does this PR introduce?
- Feature
- Refactor

## Did this PR introduce a breaking change? 
- No
