### PR TITLE
fix: loading of fonts with OpenType font variations

### DIFF
--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -32,6 +32,9 @@ impl FontPair {
 
         let typeface = skia_font.typeface().unwrap();
         let (font_data, index) = typeface.to_font_data().unwrap();
+        // Only the lower 16 bits are part of the index, the rest indicates named instances. But we
+        // don't care about those here, since we are just loading the font, so ignore them
+        let index = index & 0xFFFF;
         let swash_font = SwashFont::from_data(font_data, index)?;
 
         Some(Self {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* fixes https://github.com/neovide/neovide/issues/2352

Only the lower 16 bits of the index returned by Skia are part of the actual font index that should be loaded.

## Did this PR introduce a breaking change? 
- No
