### PR TITLE
docs: fix show_border cutting into transparent

### DIFF
--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -203,7 +203,7 @@ vim.g.neovide_window_blurred = true
 
 Setting `g:neovide_window_blurred` toggles the window blur state.
 
-The blurred level respects the `g:neovide_transparency`  value between 0.0 and 1.0.
+The blurred level respects the `g:neovide_transparency` value between 0.0 and 1.0.
 
 #### Floating Blur Amount
 
@@ -269,6 +269,11 @@ Lua:
 vim.g.neovide_transparency = 0.8
 ```
 
+![Transparency](assets/Transparency.png)
+
+Setting `g:neovide_transparency` to a value between 0.0 and 1.0 will set the opacity of the window
+to that value.
+
 #### Show Border (Currently macOS only)
 
 VimScript:
@@ -286,11 +291,6 @@ vim.g.neovide_show_border = true
 Draw a grey border around opaque windows only.
 
 Default: `false`
-
-![Transparency](assets/Transparency.png)
-
-Setting `g:neovide_transparency` to a value between 0.0 and 1.0 will set the opacity of the window
-to that value.
 
 #### Scroll Animation Length
 


### PR DESCRIPTION
After my previous PR has been merged and the docs updated I noticed that I accidentally sliced into the documentation of `g:neovide_transparency`, cutting between the description and a screenshot. This PR fixes it. 😅

## What kind of change does this PR introduce?
- Fix
- Documentation

## Did this PR introduce a breaking change? 
- No
