### PR TITLE
feat: drop multiple files and folders

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -257,7 +257,7 @@ impl ParallelCommand {
             ParallelCommand::FileDrop(path) => nvim
                 .cmd(
                     vec![
-                        ("cmd".into(), "edit".into()),
+                        ("cmd".into(), "tabnew".into()),
                         ("magic".into(), vec![("file".into(), false.into())].into()),
                         ("args".into(), vec![Value::from(path)].into()),
                     ],


### PR DESCRIPTION
- dropped event now supports multiple paths including folders only;
- change file opening behavior from `edit` to `tabnew` in parallelcommand::filedrop;

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?

- Feature

## Did this PR introduce a breaking change? 
- No
