### PR TITLE
chore: remove swash's scale and render features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,8 +2461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9af636fb90d39858650cae1088a37e2862dab4e874a0bb49d6dfb5b2dacf0e24"
 dependencies = [
  "read-fonts",
- "yazi",
- "zeno",
 ]
 
 [[package]]
@@ -3462,18 +3460,6 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
-
-[[package]]
-name = "yazi"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
-
-[[package]]
-name = "zeno"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ shlex = "1.1.0"
 skia-safe = { version = "0.68.0", features = ["gl", "textlayout"] }
 spin_sleep = "1.1.1"
 strum = { version = "0.26.2", features = ["derive"] }
-swash = "0.1.8"
+swash = { version = "0.1.8", default-features = false }
 time = { version = "0.3.34", features = ["macros", "formatting"] }
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }


### PR DESCRIPTION
These features relate to glyph rasterization. They are unused since Neovide uses Skia for text rendering. This removes several dependencies.

## What kind of change does this PR introduce?
- Other

## Did this PR introduce a breaking change?
- No