### PR TITLE
Mention winget as an installation option

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -19,6 +19,13 @@ The binaries are to be found on
 
 ## Windows
 
+### WinGet
+Neovide is available on [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/).
+It can be installed from the command line:
+```sh
+winget install Neovide.Neovide
+```
+
 ### Scoop
 
 [Scoop](https://scoop.sh/) has Neovide in the `extras` bucket. Ensure you have the `extras` bucket,


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Documentation

## Did this PR introduce a breaking change? 
- No

## Details
WinGet has an up to date installer for Neovide and WinGet is the only package manager to come preinstalled on Windows (for some newer versions at least). This change updates the website documentation to list that as an installation option.