### PR TITLE
fix: Maximize window on creation on linux

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -142,8 +142,15 @@ pub fn create_window(
         Some(PersistentWindowSettings::Windowed { position, .. }) => Some(position),
         _ => None,
     };
+    #[cfg(target_os = "linux")]
+    let maximized = matches!(window_settings, Some(PersistentWindowSettings::Maximized))
+        || cmd_line_settings.geometry.maximized;
+    // Unfortunately we can't maximize here, because winit shows the window momentarily causing
+    // flickering
+    #[cfg(not(target_os = "linux"))]
+    let maximized = false;
 
-    log::trace!("Settings initial_window_size {:?}", initial_window_size);
+    log::trace!("Settings initial_window_size {initial_window_size:?} maximized {maximized:?}");
 
     // NOTE: For Geometry, the window is resized when it's shown based on the font and other
     // settings.
@@ -156,9 +163,7 @@ pub fn create_window(
         .with_title("Neovide")
         .with_window_icon(Some(icon))
         .with_inner_size(inner_size)
-        // Unfortunately we can't maximize here, because winit shows the window momentarily causing
-        // flickering
-        .with_maximized(false)
+        .with_maximized(maximized)
         .with_transparent(true)
         .with_visible(false);
 


### PR DESCRIPTION
The code notes a flickering issue when creating the window in a maximized state, but I haven't been able to reproduce this flicking on any Linux environment. I tested GNOME, KDE, and sway, and none of them exhibited any flickering. I therefore changed the behavior so that the window is maximized on creation in accordance with persistent window settings or config file/command.

This also resolves the mild annoyance of the window existing in a blank, non-maximized state for a short while before initialization is finished, since [set_visible](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.set_visible) has no effect on Wayland

TODO: More X11 testing

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
