### PR TITLE
Handle new viewport margins event

### DIFF
--- a/src/bridge/api_info.rs
+++ b/src/bridge/api_info.rs
@@ -141,7 +141,6 @@ pub struct ApiInformation {
     pub channel: u64,
     pub version: ApiVersion,
     pub functions: HashSet<ApiFunction>,
-    pub ui_events: HashSet<ApiFunction>,
     pub ui_options: Vec<String>,
     // types and error_error types are not implemented
 }
@@ -278,7 +277,6 @@ pub fn parse_api_info(value: &[Value]) -> std::result::Result<ApiInformation, Ap
 
     let mut version = None;
     let mut functions = None;
-    let mut ui_events = None;
     let mut ui_options = None;
 
     for (k, v) in metadata {
@@ -286,7 +284,6 @@ pub fn parse_api_info(value: &[Value]) -> std::result::Result<ApiInformation, Ap
         match k.as_str() {
             Some("version") => version = Some(parse_version(v)?),
             Some("functions") => functions = Some(parse_functions(v)?),
-            Some("ui_events") => ui_events = Some(parse_functions(v)?),
             Some("ui_options") => ui_options = Some(parse_string_vec(v)?),
             _ => {}
         }
@@ -296,7 +293,6 @@ pub fn parse_api_info(value: &[Value]) -> std::result::Result<ApiInformation, Ap
         channel,
         version: version.ok_or("version field is misssing")?,
         functions: functions.ok_or("functions field is missing")?,
-        ui_events: ui_events.ok_or("ui_events field is missing")?,
         ui_options: ui_options.ok_or("ui_options field is missing")?,
     })
 }

--- a/src/bridge/api_info.rs
+++ b/src/bridge/api_info.rs
@@ -1,0 +1,290 @@
+use std::{collections::HashSet, fmt, hash::Hash};
+
+use itertools::Itertools;
+use rmpv::{Utf8StringRef, Value, ValueRef};
+
+#[derive(Debug, Clone)]
+pub struct ApiInfoParseError(String);
+
+impl std::error::Error for ApiInfoParseError {}
+
+impl fmt::Display for ApiInfoParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'a> From<ValueRef<'a>> for ApiInfoParseError {
+    fn from(value: ValueRef) -> Self {
+        Self(format!("{}", value))
+    }
+}
+
+impl From<&str> for ApiInfoParseError {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+#[derive(Debug)]
+pub struct ApiVersion {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+    pub prerelease: bool,
+    pub api_level: u64,
+    pub api_compatible: u64,
+    pub api_prerelease: bool,
+}
+
+#[derive(Debug)]
+pub struct ApiFunction {
+    pub name: String,
+    pub parameters: Vec<ApiParameter>,
+    pub return_type: Option<ApiParameterType>,
+    pub method: Option<bool>,
+    pub since: u64,
+    pub deprecated_since: Option<u64>,
+}
+
+impl Hash for ApiFunction {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state)
+    }
+}
+
+impl PartialEq for ApiFunction {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for ApiFunction {}
+
+#[derive(Debug)]
+pub enum ApiParameterType {
+    Nil,
+    Boolean,
+    Integer,
+    Float,
+    String,
+    Array,
+    Dictionary,
+    Object,
+    Buffer,
+    Window,
+    Tabpage,
+    ArrayOf(Box<ApiParameterType>),
+    SizedArrayOf(Box<ApiParameterType>, usize),
+    LuaRef,
+    Void,
+    Unknown(String),
+}
+
+impl ApiParameterType {
+    fn new(value: Option<&str>) -> Self {
+        match value {
+            Some("Nil") => ApiParameterType::Nil,
+            Some("Boolean") => ApiParameterType::Boolean,
+            Some("Integer") => ApiParameterType::Integer,
+            Some("Float") => ApiParameterType::Float,
+            Some("String") => ApiParameterType::String,
+            Some("Array") => ApiParameterType::Array,
+            Some("Dictionary") => ApiParameterType::Dictionary,
+            Some("Object") => ApiParameterType::Object,
+            Some("Buffer") => ApiParameterType::Buffer,
+            Some("Window") => ApiParameterType::Window,
+            Some("Tabpage") => ApiParameterType::Tabpage,
+            Some("LuaRef") => ApiParameterType::LuaRef,
+            Some("void") => ApiParameterType::Void,
+            Some(unknown) => {
+                if let Some(array_of) = unknown.strip_prefix("ArrayOf(") {
+                    let array_of = array_of.strip_suffix(')').unwrap();
+                    let mut parts = array_of.split(',');
+                    if let Some(name) = parts.next() {
+                        let name = Box::new(Self::new(Some(name.trim())));
+                        if let Some(s) = parts.next() {
+                            let size = s.trim().parse::<usize>().unwrap_or(0);
+                            return ApiParameterType::SizedArrayOf(name, size);
+                        } else {
+                            return ApiParameterType::ArrayOf(name);
+                        }
+                    }
+                }
+                ApiParameterType::Unknown(unknown.to_owned())
+            }
+            None => ApiParameterType::Unknown("".to_owned()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ApiParameter {
+    pub name: String,
+    pub parameter_type: ApiParameterType,
+}
+
+#[derive(Debug)]
+pub struct ApiInformation {
+    pub channel: u64,
+    pub version: ApiVersion,
+    pub functions: HashSet<ApiFunction>,
+    pub ui_events: HashSet<ApiFunction>,
+    pub ui_options: Vec<String>,
+    // types and error_error types are not implemented
+}
+
+fn parse_version(value: ValueRef) -> std::result::Result<ApiVersion, ApiInfoParseError> {
+    let mut major = None;
+    let mut minor = None;
+    let mut patch = None;
+    let mut prerelease = None;
+    let mut api_level = None;
+    let mut api_compatible = None;
+    let mut api_prerelase = None;
+
+    let version: Vec<(ValueRef, ValueRef)> = value.try_into()?;
+    for (k, v) in version {
+        let k: Utf8StringRef = k.try_into()?;
+        match k.as_str() {
+            Some("major") => major = Some(v.try_into()?),
+            Some("minor") => minor = Some(v.try_into()?),
+            Some("patch") => patch = Some(v.try_into()?),
+            Some("prerelease") => prerelease = Some(v.try_into()?),
+            Some("api_level") => api_level = Some(v.try_into()?),
+            Some("api_compatible") => api_compatible = Some(v.try_into()?),
+            Some("api_prerelease") => api_prerelase = Some(v.try_into()?),
+            _ => {}
+        }
+    }
+
+    Ok(ApiVersion {
+        major: major.ok_or("major field is misssing")?,
+        minor: minor.ok_or("minor field is misssing")?,
+        patch: patch.ok_or("patch field is misssing")?,
+        prerelease: prerelease.ok_or("prerelease field is misssing")?,
+        api_level: api_level.ok_or("api_level field is misssing")?,
+        api_compatible: api_compatible.ok_or("api_compatible field is misssing")?,
+        api_prerelease: api_prerelase.ok_or("api_prerelease field is misssing")?,
+    })
+}
+
+fn parse_function(value: ValueRef) -> std::result::Result<ApiFunction, ApiInfoParseError> {
+    let mut name = None;
+    let mut parameters = None;
+    let mut return_type = None;
+    let mut method = None;
+    let mut since = None;
+    let mut deprecated_since = None;
+    let fields: Vec<(ValueRef, ValueRef)> = value.try_into()?;
+    for (key, v) in fields {
+        let k: Utf8StringRef = key.try_into()?;
+        match k.as_str() {
+            Some("name") => {
+                let n: Utf8StringRef = v.try_into()?;
+                name = n.as_str().map(|n| n.to_owned())
+            }
+            Some("parameters") => parameters = Some(parse_parameters(v)?),
+            Some("return_type") => return_type = Some(parse_paramteter_type(v)?),
+            Some("method") => method = Some(v.try_into()?),
+            Some("since") => since = Some(v.try_into()?),
+            Some("deprecated_since") => deprecated_since = Some(v.try_into()?),
+            Some(key) => return Err(key.into()),
+            _ => {}
+        }
+    }
+    Ok(ApiFunction {
+        name: name.ok_or("name field is misssing")?,
+        parameters: parameters.ok_or("parameters field is misssing")?,
+        return_type,
+        method,
+        since: since.ok_or("since field is misssing")?,
+        deprecated_since,
+    })
+}
+
+fn parse_functions(
+    value: ValueRef,
+) -> std::result::Result<HashSet<ApiFunction>, ApiInfoParseError> {
+    let functions: Vec<ValueRef> = value.try_into()?;
+    functions
+        .into_iter()
+        .map(parse_function)
+        .collect::<std::result::Result<HashSet<_>, _>>()
+}
+
+fn parse_paramteter_type(
+    value: ValueRef,
+) -> std::result::Result<ApiParameterType, ApiInfoParseError> {
+    let parameter_type: Utf8StringRef = value.try_into()?;
+    Ok(ApiParameterType::new(parameter_type.as_str()))
+}
+
+fn parse_parameter(value: ValueRef) -> std::result::Result<ApiParameter, ApiInfoParseError> {
+    let info: Vec<ValueRef> = value.try_into()?;
+    if let Some((t, n)) = info.into_iter().collect_tuple() {
+        let name: Utf8StringRef = n.try_into()?;
+        let name = name.as_str();
+        let parameter_type = parse_paramteter_type(t)?;
+        Ok(ApiParameter {
+            name: name.map_or(Err("name field is misssing"), |v| Ok(v.to_owned()))?,
+            parameter_type,
+        })
+    } else {
+        Err("Invalid parameter".into())
+    }
+}
+
+fn parse_parameters(value: ValueRef) -> std::result::Result<Vec<ApiParameter>, ApiInfoParseError> {
+    let parameters: Vec<ValueRef> = value.try_into()?;
+    parameters
+        .into_iter()
+        .map(parse_parameter)
+        .collect::<std::result::Result<Vec<_>, _>>()
+}
+
+fn parse_string(value: ValueRef) -> std::result::Result<String, ApiInfoParseError> {
+    let value: Utf8StringRef = value.try_into()?;
+    value
+        .as_str()
+        .map(|value| value.to_owned())
+        .ok_or_else(|| "Failed to parse string value".into())
+}
+
+fn parse_string_vec(value: ValueRef) -> std::result::Result<Vec<String>, ApiInfoParseError> {
+    let options: Vec<ValueRef> = value.try_into()?;
+    options
+        .into_iter()
+        .map(parse_string)
+        .collect::<std::result::Result<Vec<_>, _>>()
+}
+
+pub fn parse_api_info(value: &[Value]) -> std::result::Result<ApiInformation, ApiInfoParseError> {
+    let channel = value[0].as_ref().try_into()?;
+
+    let metadata: Vec<(ValueRef, ValueRef)> = value[1].as_ref().try_into()?;
+
+    let mut version = None;
+    let mut functions = None;
+    let mut ui_events = None;
+    let mut ui_options = None;
+
+    for (k, v) in metadata {
+        let k: Utf8StringRef = k.try_into()?;
+        match k.as_str() {
+            Some("version") => version = Some(parse_version(v)?),
+            Some("functions") => functions = Some(parse_functions(v)?),
+            Some("ui_events") => ui_events = Some(parse_functions(v)?),
+            Some("ui_options") => ui_options = Some(parse_string_vec(v)?),
+            _ => {}
+        }
+    }
+
+    Ok(ApiInformation {
+        channel,
+        version: version.ok_or("version field is misssing")?,
+        functions: functions.ok_or("functions field is missing")?,
+        ui_events: ui_events.ok_or("ui_events field is missing")?,
+        ui_options: ui_options.ok_or("ui_options field is missing")?,
+    })
+}

--- a/src/bridge/api_info.rs
+++ b/src/bridge/api_info.rs
@@ -37,6 +37,18 @@ pub struct ApiVersion {
     pub api_prerelease: bool,
 }
 
+impl ApiVersion {
+    pub fn has_version(&self, major: u64, minor: u64) -> bool {
+        let actual_major = self.major;
+        let actual_minor = self.minor;
+        log::trace!("actual nvim version: {actual_major}.{actual_minor}");
+        log::trace!("expect nvim version: {major}.{minor}");
+        let ret = actual_major > major || (actual_major == major && actual_minor >= minor);
+        log::trace!("has desired nvim version: {ret}");
+        return ret;
+    }
+}
+
 #[derive(Debug)]
 pub struct ApiFunction {
     pub name: String,

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -235,6 +235,13 @@ pub enum RedrawEvent {
         line_count: Option<f64>,
         scroll_delta: Option<f64>,
     },
+    WindowViewportMargins {
+        grid: u64,
+        top: u64,
+        bottom: u64,
+        left: u64,
+        right: u64,
+    },
     CommandLineShow {
         content: StyledContent,
         position: u64,
@@ -780,6 +787,18 @@ fn parse_win_viewport(win_viewport_arguments: Vec<Value>) -> Result<RedrawEvent>
     })
 }
 
+fn parse_win_viewport_margins(win_viewport_margins_arguments: Vec<Value>) -> Result<RedrawEvent> {
+    let [grid, _window, top, bottom, left, right] = extract_values(win_viewport_margins_arguments)?;
+
+    Ok(RedrawEvent::WindowViewportMargins {
+        grid: parse_u64(grid)?,
+        top: parse_u64(top)?,
+        bottom: parse_u64(bottom)?,
+        left: parse_u64(left)?,
+        right: parse_u64(right)?,
+    })
+}
+
 fn parse_styled_content(line: Value) -> Result<StyledContent> {
     parse_array(line)?
         .into_iter()
@@ -947,6 +966,7 @@ pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
             "win_close" => Some(parse_win_close(event_parameters)),
             "msg_set_pos" => Some(parse_msg_set_pos(event_parameters)),
             "win_viewport" => Some(parse_win_viewport(event_parameters)),
+            "win_viewport_margins" => Some(parse_win_viewport_margins(event_parameters)),
             "cmdline_show" => Some(parse_cmdline_show(event_parameters)),
             "cmdline_pos" => Some(parse_cmdline_pos(event_parameters)),
             "cmdline_special_char" => Some(parse_cmdline_special_char(event_parameters)),

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -211,8 +211,10 @@ async fn launch(handler: NeovimHandler, grid_size: Option<Dimensions>) -> Result
     SETTINGS.read_initial_values(&session.neovim).await?;
 
     let mut options = UiAttachOptions::new();
+    if !api_information.has_event("win_viewport_margins") {
+        options.set_hlstate_external(true);
+    }
     options.set_linegrid_external(true);
-    options.set_hlstate_external(true);
     options.set_multigrid_external(!settings.no_multi_grid);
     options.set_rgb(true);
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -24,6 +24,7 @@ pub use handler::NeovimHandler;
 use session::{NeovimInstance, NeovimSession};
 use setup::{get_api_information, setup_neovide_specific_state};
 
+pub use api_info::*;
 pub use command::create_nvim_command;
 pub use events::*;
 pub use session::NeovimWriter;
@@ -202,11 +203,11 @@ async fn launch(handler: NeovimHandler, grid_size: Option<Dimensions>) -> Result
         api_information.channel
     );
     // This is too verbose to keep enabled all the time
-    //log::info!("Api information {:#?}", api_information);
+    // log::info!("Api information {:#?}", api_information);
     setup_neovide_specific_state(&session.neovim, should_handle_clipboard, &api_information)
         .await?;
 
-    start_ui_command_handler(session.neovim.clone());
+    start_ui_command_handler(session.neovim.clone(), &api_information);
     SETTINGS.read_initial_values(&session.neovim).await?;
 
     let mut options = UiAttachOptions::new();

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -5,14 +5,11 @@ use log::trace;
 use anyhow::{Context, Result};
 use nvim_rs::{call_args, error::CallError, rpc::model::IntoVal, Neovim, Value};
 use strum::AsRefStr;
-use tokio::sync::{
-    mpsc::{unbounded_channel, UnboundedReceiver},
-    OnceCell,
-};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
 use super::{show_error_message, show_intro_message};
 use crate::{
-    bridge::NeovimWriter,
+    bridge::{ApiInformation, NeovimWriter},
     profiling::{tracy_dynamic_zone, tracy_fiber_enter, tracy_fiber_leave},
     running_tracker::RUNNING_TRACKER,
     LoggingSender,
@@ -46,56 +43,13 @@ pub enum SerialCommand {
     },
 }
 
-fn has_nvim_version(metadata: &Value, major: i64, minor: i64) -> bool {
-    if let Some(map) = metadata.as_map() {
-        if let Some(Some(y)) = map
-            .iter()
-            .find(|&(k, _)| k.as_str() == Some("version"))
-            .map(|(_, value)| value.as_map())
-        {
-            let mut actual_major: i64 = -1;
-            let mut actual_minor: i64 = -1;
-            for (k, v) in y {
-                match (k.as_str(), v.as_i64()) {
-                    (Some("major"), Some(v)) => actual_major = v,
-                    (Some("minor"), Some(v)) => actual_minor = v,
-                    _ => {}
-                }
-            }
-            log::trace!("actual nvim version: {actual_major}.{actual_minor}");
-            log::trace!("expect nvim version: {major}.{minor}");
-            let ret = actual_major > major || (actual_major == major && actual_minor >= minor);
-            log::trace!("has desired nvim version: {ret}");
-            return ret;
-        }
-    }
-    false
-}
-
 impl SerialCommand {
-    async fn execute(self, nvim: &Neovim<NeovimWriter>) {
+    async fn execute(self, nvim: &Neovim<NeovimWriter>, has_x_buttons: bool) {
         // Don't panic here unless there's absolutely no chance of continuing the program, Instead
         // just log the error and hope that it's something temporary or recoverable A normal reason
         // for failure is when neovim has already quit, and a command, for example mouse move is
         // being sent
-        static HAS_X: OnceCell<bool> = OnceCell::const_new();
         log::trace!("In Serial Command");
-        let has_x = HAS_X
-            .get_or_init(|| async {
-                log::trace!("Requesting nvim version");
-                match nvim.get_api_info().await.as_deref() {
-                    Ok([_, metadata]) if metadata.is_map() => has_nvim_version(metadata, 0, 10),
-                    Err(e) => {
-                        log::warn!("Failed to get neovim api info: {e}");
-                        false
-                    }
-                    Ok(v) => {
-                        log::warn!("Unrecogonized API metadata format {:?}", v);
-                        false
-                    }
-                }
-            })
-            .await;
         let result = match self {
             SerialCommand::Keyboard(input_command) => {
                 trace!("Keyboard Input Sent: {}", input_command);
@@ -111,7 +65,7 @@ impl SerialCommand {
                 position: (grid_x, grid_y),
                 modifier_string,
             } => match &*button {
-                "x1" | "x2" if !has_x => {
+                "x1" | "x2" if !has_x_buttons => {
                     log::debug!("Ignoring unsupported {button} mouse event");
                     Ok(())
                 }
@@ -150,7 +104,7 @@ impl SerialCommand {
                 position: (grid_x, grid_y),
                 modifier_string,
             } => match &*button {
-                "x1" | "x2" if !has_x => Ok(()),
+                "x1" | "x2" if !has_x_buttons => Ok(()),
                 _ => nvim
                     .input_mouse(
                         &button,
@@ -340,7 +294,7 @@ lazy_static! {
     static ref UI_CHANNELS: UIChannels = UIChannels::new();
 }
 
-pub fn start_ui_command_handler(nvim: Neovim<NeovimWriter>) {
+pub fn start_ui_command_handler(nvim: Neovim<NeovimWriter>, api_information: &ApiInformation) {
     let (serial_tx, mut serial_rx) = unbounded_channel::<SerialCommand>();
     let ui_command_nvim = nvim.clone();
     tokio::spawn(async move {
@@ -366,6 +320,8 @@ pub fn start_ui_command_handler(nvim: Neovim<NeovimWriter>) {
         }
     });
 
+    let has_x_buttons = api_information.version.has_version(10, 0);
+
     tokio::spawn(async move {
         tracy_fiber_enter!("Serial command");
         while RUNNING_TRACKER.is_running() {
@@ -376,7 +332,7 @@ pub fn start_ui_command_handler(nvim: Neovim<NeovimWriter>) {
                 Some(serial_command) => {
                     tracy_dynamic_zone!(serial_command.as_ref());
                     tracy_fiber_leave();
-                    serial_command.execute(&nvim).await;
+                    serial_command.execute(&nvim, has_x_buttons).await;
                     tracy_fiber_enter!("Serial command");
                 }
                 None => {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -288,6 +288,16 @@ impl Editor {
                 self.set_ui_ready();
                 self.send_updated_viewport(grid, scroll_delta)
             }
+            RedrawEvent::WindowViewportMargins {
+                grid,
+                top,
+                bottom,
+                left,
+                right,
+            } => {
+                tracy_zone!("EditorWindowViewportMargins");
+                self.send_updated_viewport_margins(grid, top, bottom, left, right)
+            }
             RedrawEvent::ShowIntro { message } => {
                 // Support the yet unmerged intro message support
                 // This could probably be handled completely on the lua side
@@ -551,6 +561,21 @@ impl Editor {
     fn send_updated_viewport(&mut self, grid: u64, scroll_delta: f64) {
         if let Some(window) = self.windows.get_mut(&grid) {
             window.update_viewport(scroll_delta);
+        } else {
+            trace!("viewport event received before window initialized");
+        }
+    }
+
+    fn send_updated_viewport_margins(
+        &mut self,
+        grid: u64,
+        top: u64,
+        bottom: u64,
+        left: u64,
+        right: u64,
+    ) {
+        if let Some(window) = self.windows.get_mut(&grid) {
+            window.update_viewport_margins(top, bottom, left, right);
         } else {
             trace!("viewport event received before window initialized");
         }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -325,4 +325,13 @@ impl Window {
     pub fn update_viewport(&self, scroll_delta: f64) {
         self.send_command(WindowDrawCommand::Viewport { scroll_delta });
     }
+
+    pub fn update_viewport_margins(&self, top: u64, bottom: u64, left: u64, right: u64) {
+        self.send_command(WindowDrawCommand::ViewportMargins {
+            top,
+            bottom,
+            left,
+            right,
+        });
+    }
 }

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -260,8 +260,8 @@ impl CursorRenderer {
             let mut grid_y = cursor_grid_y as f32 + window.grid_current_position.y
                 - window.scroll_animation.position;
 
-            let top_border = (window.top_border.len() as u64) as f32;
-            let bottom_border = (window.bottom_border.len() as u64) as f32;
+            let top_border = window.viewport_margins.top as f32;
+            let bottom_border = window.viewport_margins.bottom as f32;
 
             // Prevent the cursor from targeting a position outside its current window. Since only
             // the vertical direction is effected by scrolling, we only have to clamp the vertical

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, ops::Range, rc::Rc, sync::Arc};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use skia_safe::{
     canvas::SaveLayerRec,
@@ -28,6 +28,13 @@ pub struct LineFragment {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct ViewportMargins {
+    pub top: u64,
+    pub bottom: u64,
+    pub inferred: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum WindowDrawCommand {
     Position {
         grid_position: (f64, f64),
@@ -54,6 +61,12 @@ pub enum WindowDrawCommand {
     Viewport {
         scroll_delta: f64,
     },
+    ViewportMargins {
+        top: u64,
+        bottom: u64,
+        left: u64,
+        right: u64,
+    },
 }
 
 #[derive(Clone)]
@@ -62,7 +75,7 @@ struct Line {
     background_picture: Option<Picture>,
     foreground_picture: Option<Picture>,
     has_transparency: bool,
-    is_border: bool,
+    is_inferred_border: bool,
     is_valid: bool,
 }
 
@@ -79,8 +92,7 @@ pub struct RenderedWindow {
     scrollback_lines: RingBuffer<Option<Rc<RefCell<Line>>>>,
     actual_lines: RingBuffer<Option<Rc<RefCell<Line>>>>,
     scroll_delta: isize,
-    pub top_border: Range<isize>,
-    pub bottom_border: Range<isize>,
+    pub viewport_margins: ViewportMargins,
 
     grid_start_position: Point,
     pub grid_current_position: Point,
@@ -123,8 +135,11 @@ impl RenderedWindow {
             actual_lines: RingBuffer::new(grid_size.height as usize, None),
             scrollback_lines: RingBuffer::new(2 * grid_size.height as usize, None),
             scroll_delta: 0,
-            top_border: 0..0,
-            bottom_border: 0..0,
+            viewport_margins: ViewportMargins {
+                top: 0,
+                bottom: 0,
+                inferred: true,
+            },
 
             grid_start_position: grid_position,
             grid_current_position: grid_position,
@@ -256,7 +271,7 @@ impl RenderedWindow {
                         pixel_region.left(),
                         pixel_region.top()
                             + (scroll_offset_pixels
-                                + ((i + self.top_border.len() as isize)
+                                + ((i + self.viewport_margins.top as isize)
                                     * font_dimensions.height as isize))
                                 as f32,
                     ));
@@ -267,14 +282,22 @@ impl RenderedWindow {
             Vec::new()
         };
 
-        let border_lines: Vec<_> = self
-            .top_border
-            .clone()
-            .chain(self.bottom_border.clone())
+        let top_border_indices = 0..self.viewport_margins.top as isize;
+        let actual_line_count = self.actual_lines.len() as isize;
+        let bottom_border_indices =
+            actual_line_count - self.viewport_margins.bottom as isize..actual_line_count;
+        let margins_inferred = self.viewport_margins.inferred;
+
+        let border_lines: Vec<_> = top_border_indices
+            .chain(bottom_border_indices)
             .filter_map(|i| {
-                self.actual_lines[i]
-                    .as_ref()
-                    .and_then(|line| line.borrow().is_border.then_some((i, line)))
+                self.actual_lines[i].as_ref().and_then(|line| {
+                    if !margins_inferred || line.borrow().is_inferred_border {
+                        Some((i, line))
+                    } else {
+                        None
+                    }
+                })
             })
             .map(|(i, line)| {
                 let mut matrix = Matrix::new_identity();
@@ -288,10 +311,10 @@ impl RenderedWindow {
 
         let inner_region = Rect::from_xywh(
             pixel_region.x(),
-            pixel_region.y() + self.top_border.len() as f32 * line_height,
+            pixel_region.y() + self.viewport_margins.top as f32 * line_height,
             pixel_region.width(),
             pixel_region.height()
-                - (self.top_border.len() + self.bottom_border.len()) as f32 * line_height,
+                - (self.viewport_margins.top + self.viewport_margins.bottom) as f32 * line_height,
         );
 
         let mut background_paint = Paint::default();
@@ -517,42 +540,48 @@ impl RenderedWindow {
             } => {
                 tracy_zone!("draw_line_cmd", 0);
 
-                let check_border = |fragment: &LineFragment, check: &dyn Fn(&str) -> bool| {
-                    fragment.style.as_ref().map_or(false, |style| {
-                        style.infos.last().map_or(false, |info| {
-                            // The specification seems to indicate that kind should be UI and
-                            // then we only need to test ui_name. But at least for FloatTitle,
-                            // that is not the case, the kind is set to syntax and hi_name is
-                            // set.
-                            check(&info.ui_name) || check(&info.hi_name)
-                        })
-                    })
-                };
-
-                let float_border =
-                    |s: &str| matches!(s, "FloatBorder" | "FloatTitle" | "FloatFooter");
-                let winbar = |s: &str| matches!(s, "WinBar" | "WinBarNC");
-
-                // Lines with purly border highlight groups are considered borders.
-                let mut is_border = line_fragments
-                    .iter()
-                    .map(|fragment| check_border(fragment, &float_border))
-                    .all(|v| v);
-
-                // And also lines with a winbar highlight anywhere
-                is_border |= line_fragments
-                    .iter()
-                    .map(|fragment| check_border(fragment, &winbar))
-                    .any(|v| v);
-
-                self.actual_lines[row] = Some(Rc::new(RefCell::new(Line {
+                let mut line = Line {
                     line_fragments,
                     background_picture: None,
                     foreground_picture: None,
                     has_transparency: false,
-                    is_border,
+                    is_inferred_border: false,
                     is_valid: false,
-                })));
+                };
+
+                if self.viewport_margins.inferred {
+                    let check_border = |fragment: &LineFragment, check: &dyn Fn(&str) -> bool| {
+                        fragment.style.as_ref().map_or(false, |style| {
+                            style.infos.last().map_or(false, |info| {
+                                // The specification seems to indicate that kind should be UI and
+                                // then we only need to test ui_name. But at least for FloatTitle,
+                                // that is not the case, the kind is set to syntax and hi_name is
+                                // set.
+                                check(&info.ui_name) || check(&info.hi_name)
+                            })
+                        })
+                    };
+
+                    let float_border =
+                        |s: &str| matches!(s, "FloatBorder" | "FloatTitle" | "FloatFooter");
+                    let winbar = |s: &str| matches!(s, "WinBar" | "WinBarNC");
+
+                    // Lines with purly border highlight groups are considered borders.
+                    line.is_inferred_border = line
+                        .line_fragments
+                        .iter()
+                        .map(|fragment| check_border(fragment, &float_border))
+                        .all(|v| v);
+
+                    // And also lines with a winbar highlight anywhere
+                    line.is_inferred_border |= line
+                        .line_fragments
+                        .iter()
+                        .map(|fragment| check_border(fragment, &winbar))
+                        .any(|v| v)
+                }
+
+                self.actual_lines[row] = Some(Rc::new(RefCell::new(line)));
             }
             WindowDrawCommand::Scroll {
                 top,
@@ -598,43 +627,51 @@ impl RenderedWindow {
                 log::trace!("Handling Viewport {}", self.id);
                 self.scroll_delta = scroll_delta.round() as isize;
             }
+            WindowDrawCommand::ViewportMargins { top, bottom, .. } => {
+                self.viewport_margins = ViewportMargins {
+                    top,
+                    bottom,
+                    inferred: false,
+                }
+            }
             _ => {}
         };
     }
 
-    fn calculate_borders(&mut self) {
-        let top_border = self
-            .actual_lines
-            .iter()
-            .take_while(|line| {
-                if let Some(line) = line {
-                    line.borrow().is_border
-                } else {
-                    false
-                }
-            })
-            .count();
-        let bottom_border = (top_border..self.actual_lines.len())
-            .rev()
-            .map(|i| self.actual_lines[i].as_ref())
-            .take_while(|line| {
-                if let Some(line) = line {
-                    line.borrow().is_border
-                } else {
-                    false
-                }
-            })
-            .count();
-        self.top_border = 0..top_border as isize;
-        self.bottom_border =
-            (self.actual_lines.len() - bottom_border) as isize..self.actual_lines.len() as isize
+    fn infer_viewport_margins(&mut self) {
+        if self.viewport_margins.inferred {
+            self.viewport_margins.top = self
+                .actual_lines
+                .iter()
+                .take_while(|line| {
+                    if let Some(line) = line {
+                        line.borrow().is_inferred_border
+                    } else {
+                        false
+                    }
+                })
+                .count() as u64;
+            self.viewport_margins.bottom = (self.viewport_margins.top as usize
+                ..self.actual_lines.len())
+                .rev()
+                .map(|i| self.actual_lines[i].as_ref())
+                .take_while(|line| {
+                    if let Some(line) = line {
+                        line.borrow().is_inferred_border
+                    } else {
+                        false
+                    }
+                })
+                .count() as u64;
+        }
     }
 
     pub fn flush(&mut self, renderer_settings: &RendererSettings) {
-        self.calculate_borders();
+        self.infer_viewport_margins();
 
         // If the borders are changed, reset the scrollback to only fit the inner view
-        let inner_range = self.top_border.end..self.bottom_border.start;
+        let inner_range = self.viewport_margins.top as isize
+            ..(self.actual_lines.len() - self.viewport_margins.bottom as usize) as isize;
         let inner_size = inner_range.len();
         let inner_view = self.actual_lines.iter_range(inner_range);
         if inner_size != self.scrollback_lines.len() / 2 {
@@ -760,14 +797,17 @@ impl RenderedWindow {
 
         for line in self
             .actual_lines
-            .iter_range_mut(self.top_border.clone())
+            .iter_range_mut(0..self.viewport_margins.top as isize)
             .flatten()
         {
             prepare_line(line)
         }
+        let actual_line_count = self.actual_lines.len() as isize;
         for line in self
             .actual_lines
-            .iter_range_mut(self.bottom_border.clone())
+            .iter_range_mut(
+                actual_line_count - self.viewport_margins.bottom as isize..actual_line_count,
+            )
             .flatten()
         {
             prepare_line(line)


### PR DESCRIPTION
Implements the neovide side of https://github.com/neovim/neovim/issues/23610 which introduces a new viewport_margins event which tells us what part of the rendered window should actually be scrolled without resorting to inspecting highlight links.

Fully fixes https://github.com/neovide/neovide/issues/2291
Fixes https://github.com/neovide/neovide/issues/2406

Also pulls in apimetadata parsing from https://github.com/neovide/neovide/pull/2438 so that we can disable the hlstate_external extension when we don't need it for performance reasons.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No. Leaves the existing heuristics for inferring the border intact when the new api not available.
