### PR TITLE
fix: set startup directory failed is not an error

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -98,7 +98,12 @@ pub async fn setup_tty_startup_directory(
         cmd = format!("{} | {}", cmd, handle_command_arg(pos, neovim_args));
     }
 
-    nvim.command(cmd.as_str()).await
+    match nvim.command(cmd.as_str()).await {
+        Ok(_) => {}
+        Err(e) => log::error!("Error setting startup directory: {}", e),
+    }
+
+    Ok(())
 }
 
 fn get_startup_directory(path: &str) -> Option<String> {


### PR DESCRIPTION
Fix launching neovide with a "fake" neovim instance `neovide --neovim-bin nvim.dev.local`:

nvim.dev.local:
```bash
#!/bin/bash
ssh dev.local "bash -l -c \"nvim $@\"" 
```

## What kind of change does this PR introduce?
- Fix


## Did this PR introduce a breaking change? 
- No
