### PR TITLE
Prevent intro message hack from showing when the intro message is fixed upstream

### DIFF
--- a/lua/intro.lua
+++ b/lua/intro.lua
@@ -164,20 +164,4 @@ local function setup_autocommand()
     })
 end
 
-
-local function entry(function_name, ...)
-    local api_metadata = vim.fn.api_info()
-    local has_msg_intro = vim.tbl_contains(api_metadata.ui_events, function(v)
-        return v.name == "msg_intro"
-    end, { predicate = true })
-
-    if has_msg_intro then
-        if function_name == "show_intro" then
-            show_intro({...})
-        end
-    elseif function_name == "setup_autocommand" then
-        setup_autocommand()
-    end
-end
-
-entry(...)
+setup_autocommand()

--- a/src/bridge/api_info.rs
+++ b/src/bridge/api_info.rs
@@ -38,12 +38,15 @@ pub struct ApiVersion {
 }
 
 impl ApiVersion {
-    pub fn has_version(&self, major: u64, minor: u64) -> bool {
+    pub fn has_version(&self, major: u64, minor: u64, patch: u64) -> bool {
         let actual_major = self.major;
         let actual_minor = self.minor;
-        log::trace!("actual nvim version: {actual_major}.{actual_minor}");
-        log::trace!("expect nvim version: {major}.{minor}");
-        let ret = actual_major > major || (actual_major == major && actual_minor >= minor);
+        let actual_patch = self.patch;
+        log::trace!("actual nvim version: {actual_major}.{actual_minor}.{actual_patch}");
+        log::trace!("expect nvim version: {major}.{minor}.{patch}");
+        let ret = actual_major > major
+            || (actual_major == major && actual_minor > minor)
+            || (actual_major == major && actual_minor == minor && actual_patch >= patch);
         log::trace!("has desired nvim version: {ret}");
         return ret;
     }

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -285,9 +285,6 @@ pub enum RedrawEvent {
     MessageHistoryShow {
         entries: Vec<(MessageKind, StyledContent)>,
     },
-    ShowIntro {
-        message: Vec<String>,
-    },
     Suspend,
 }
 
@@ -916,17 +913,6 @@ fn parse_msg_history_show(msg_history_show_arguments: Vec<Value>) -> Result<Redr
     })
 }
 
-fn parse_msg_intro(msg_intro_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let [lines] = extract_values(msg_intro_arguments)?;
-
-    Ok(RedrawEvent::ShowIntro {
-        message: parse_array(lines)?
-            .into_iter()
-            .map(parse_string)
-            .collect::<Result<_>>()?,
-    })
-}
-
 pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
     let mut event_contents = parse_array(event_value)?.into_iter();
     let event_name = event_contents
@@ -980,7 +966,6 @@ pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
             "msg_showcmd" => Some(parse_msg_showcmd(event_parameters)),
             "msg_ruler" => Some(parse_msg_ruler(event_parameters)),
             "msg_history_show" => Some(parse_msg_history_show(event_parameters)),
-            "msg_intro" => Some(parse_msg_intro(event_parameters)),
             "suspend" => Some(Ok(RedrawEvent::Suspend)),
             _ => None,
         };

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -140,16 +140,6 @@ pub async fn setup_intro_message_autocommand(
     nvim.exec_lua(INTRO_MESSAGE_LUA, args).await
 }
 
-pub async fn show_intro_message(
-    nvim: &Neovim<NeovimWriter>,
-    message: &[String],
-) -> Result<(), Box<CallError>> {
-    let mut args = vec![Value::from("show_intro")];
-    let lines = message.iter().map(|line| Value::from(line.as_str()));
-    args.extend(lines);
-    nvim.exec_lua(INTRO_MESSAGE_LUA, args).await.map(|_| ())
-}
-
 pub async fn show_error_message(
     nvim: &Neovim<NeovimWriter>,
     lines: &[String],

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -108,9 +108,11 @@ pub async fn setup_neovide_specific_state(
         .await
         .context("Error setting up TTY startup directory")?;
 
-    setup_intro_message_autocommand(nvim)
-        .await
-        .context("Error setting up intro message")?;
+    if !api_information.version.has_version(0, 10, 0) {
+        setup_intro_message_autocommand(nvim)
+            .await
+            .context("Error setting up intro message")?;
+    }
 
     Ok(())
 }

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -320,7 +320,7 @@ pub fn start_ui_command_handler(nvim: Neovim<NeovimWriter>, api_information: &Ap
         }
     });
 
-    let has_x_buttons = api_information.version.has_version(10, 0);
+    let has_x_buttons = api_information.version.has_version(0, 10, 0);
 
     tokio::spawn(async move {
         tracy_fiber_enter!("Serial command");

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -7,7 +7,7 @@ use nvim_rs::{call_args, error::CallError, rpc::model::IntoVal, Neovim, Value};
 use strum::AsRefStr;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
-use super::{show_error_message, show_intro_message};
+use super::show_error_message;
 use crate::{
     bridge::{ApiInformation, NeovimWriter},
     profiling::{tracy_dynamic_zone, tracy_fiber_enter, tracy_fiber_leave},
@@ -134,7 +134,6 @@ pub enum ParallelCommand {
     FocusGained,
     DisplayAvailableFonts(Vec<String>),
     SetBackground(String),
-    ShowIntro { message: Vec<String> },
     ShowError { lines: Vec<String> },
 }
 
@@ -227,9 +226,6 @@ impl ParallelCommand {
             ParallelCommand::DisplayAvailableFonts(fonts) => display_available_fonts(nvim, fonts)
                 .await
                 .context("DisplayAvailableFonts failed"),
-            ParallelCommand::ShowIntro { message } => show_intro_message(nvim, &message)
-                .await
-                .context("ShowIntro failed"),
 
             ParallelCommand::ShowError { lines } => {
                 // nvim.err_write(&message).await.ok();

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -298,13 +298,6 @@ impl Editor {
                 tracy_zone!("EditorWindowViewportMargins");
                 self.send_updated_viewport_margins(grid, top, bottom, left, right)
             }
-            RedrawEvent::ShowIntro { message } => {
-                // Support the yet unmerged intro message support
-                // This could probably be handled completely on the lua side
-                let _ = self
-                    .event_loop_proxy
-                    .send_event(WindowCommand::ShowIntro(message).into());
-            }
             // Interpreting suspend as a window minimize request
             RedrawEvent::Suspend => {
                 let _ = self

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -74,7 +74,6 @@ pub enum WindowCommand {
     ListAvailableFonts,
     FocusWindow,
     Minimize,
-    ShowIntro(Vec<String>),
     #[allow(dead_code)] // Theme change is only used on macOS right now
     ThemeChanged(Option<Theme>),
     #[cfg(windows)]

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -202,9 +202,6 @@ impl WinitWindowWrapper {
                 self.minimize_window();
                 self.is_minimized = true;
             }
-            WindowCommand::ShowIntro(message) => {
-                send_ui(ParallelCommand::ShowIntro { message });
-            }
             WindowCommand::ThemeChanged(new_theme) => {
                 self.handle_theme_changed(new_theme);
             }


### PR DESCRIPTION
Once 0.10.0 is released, we can come back in and remove the intro message stuff altogether, but for now this will prevent the doubled up messages which look funny in current nightly.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
