### PR TITLE
fix!: Perform a clean exit again

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -12,15 +12,10 @@ use itertools::Itertools;
 use log::info;
 use nvim_rs::{error::CallError, Neovim, UiAttachOptions, Value};
 use rmpv::Utf8String;
-use std::{
-    io::Error,
-    ops::Add,
-    time::{Duration, Instant},
-};
+use std::{io::Error, ops::Add, time::Duration};
 use tokio::{
     runtime::{Builder, Runtime},
     select,
-    task::JoinSet,
     time::timeout,
 };
 use winit::event_loop::EventLoopProxy;
@@ -37,16 +32,13 @@ pub use api_info::*;
 pub use command::create_nvim_command;
 pub use events::*;
 pub use session::NeovimWriter;
-pub use ui_commands::{
-    send_ui, shutdown_ui, start_ui_command_handler, ParallelCommand, SerialCommand,
-};
+pub use ui_commands::{send_ui, start_ui_command_handler, ParallelCommand, SerialCommand};
 
 const INTRO_MESSAGE_LUA: &str = include_str!("../../lua/intro.lua");
 const NEOVIM_REQUIRED_VERSION: &str = "0.9.2";
 
 pub struct NeovimRuntime {
     runtime: Runtime,
-    join_set: JoinSet<()>,
 }
 
 fn neovim_instance() -> Result<NeovimInstance> {
@@ -89,11 +81,7 @@ pub async fn show_error_message(
     nvim.echo(prepared_lines, true, vec![]).await
 }
 
-async fn launch(
-    handler: NeovimHandler,
-    grid_size: Option<GridSize<u32>>,
-    join_set: &mut JoinSet<()>,
-) -> Result<NeovimSession> {
+async fn launch(handler: NeovimHandler, grid_size: Option<GridSize<u32>>) -> Result<NeovimSession> {
     let neovim_instance = neovim_instance()?;
 
     let session = NeovimSession::new(neovim_instance, handler)
@@ -126,7 +114,7 @@ async fn launch(
     setup_neovide_specific_state(&session.neovim, should_handle_clipboard, &api_information)
         .await?;
 
-    start_ui_command_handler(session.neovim.clone(), &api_information, join_set);
+    start_ui_command_handler(session.neovim.clone(), &api_information);
     SETTINGS.read_initial_values(&session.neovim).await?;
 
     let mut options = UiAttachOptions::new();
@@ -179,18 +167,11 @@ async fn run(session: NeovimSession, proxy: EventLoopProxy<UserEvent>) {
     proxy.send_event(UserEvent::NeovimExited).ok();
 }
 
-async fn wait(join_set: &mut JoinSet<()>) {
-    while join_set.join_next().await.is_some() {}
-}
-
 impl NeovimRuntime {
     pub fn new() -> Result<Self, Error> {
         let runtime = Builder::new_multi_thread().enable_all().build()?;
 
-        Ok(Self {
-            runtime,
-            join_set: JoinSet::new(),
-        })
+        Ok(Self { runtime })
     }
 
     pub fn launch(
@@ -199,22 +180,8 @@ impl NeovimRuntime {
         grid_size: Option<GridSize<u32>>,
     ) -> Result<()> {
         let handler = start_editor(event_loop_proxy.clone());
-        let session = self
-            .runtime
-            .block_on(launch(handler, grid_size, &mut self.join_set))?;
-        self.join_set
-            .spawn_on(run(session, event_loop_proxy), self.runtime.handle());
+        let session = self.runtime.block_on(launch(handler, grid_size))?;
+        self.runtime.spawn(run(session, event_loop_proxy));
         Ok(())
-    }
-}
-
-impl Drop for NeovimRuntime {
-    fn drop(&mut self) {
-        log::info!("Starting neovim runtime shutdown");
-        let start = Instant::now();
-        shutdown_ui();
-        self.runtime.block_on(wait(&mut self.join_set));
-        let elapsed = start.elapsed().as_millis();
-        log::info!("Neovim runtime shutdown took {elapsed} ms");
     }
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -21,7 +21,7 @@ use tokio::{
     runtime::{Builder, Runtime},
     select,
     task::JoinSet,
-    time::sleep,
+    time::timeout,
 };
 use winit::event_loop::EventLoopProxy;
 
@@ -154,30 +154,24 @@ async fn run(session: NeovimSession, proxy: EventLoopProxy<UserEvent>) {
     let mut session = session;
 
     if let Some(process) = session.neovim_process.as_mut() {
-        let neovim_exited = select! {
-            _ = &mut session.io_handle => false,
-            _ = process.wait() => {
-                log::info!("The Neovim process quit before the IO stream, waiting two seconds");
-                true
-            }
-        };
-
         // We primarily wait for the stdio to finish, but due to bugs,
         // for example, this one in in Neovim 0.9.5
         // https://github.com/neovim/neovim/issues/26743
         // it does not always finish.
         // So wait for some additional time, both to make the bug obvious and to prevent incomplete
         // data.
-        if neovim_exited {
-            let sleep = sleep(Duration::from_millis(2000));
-            tokio::pin!(sleep);
-            select! {
-                _ = session.io_handle => {}
-                _ = &mut sleep  => {
+        select! {
+            _ = &mut session.io_handle => {}
+            _ = process.wait() => {
+                log::info!("The Neovim process quit before the IO stream, waiting two seconds");
+                if timeout(Duration::from_millis(2000), session.io_handle)
+                        .await
+                        .is_err()
+                {
                     log::info!("The IO stream was never closed, forcing Neovide to exit");
                 }
             }
-        }
+        };
     } else {
         session.io_handle.await.ok();
     }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -17,8 +17,8 @@ use tokio::runtime::{Builder, Runtime};
 use winit::event_loop::EventLoopProxy;
 
 use crate::{
-    cmd_line::CmdLineSettings, editor::start_editor, settings::*,
-    window::UserEvent, units::GridSize,
+    cmd_line::CmdLineSettings, editor::start_editor, settings::*, units::GridSize,
+    window::UserEvent,
 };
 pub use handler::NeovimHandler;
 use session::{NeovimInstance, NeovimSession};

--- a/src/channel_utils.rs
+++ b/src/channel_utils.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc::{error::SendError as TokioSendError, UnboundedSender};
 
 use crate::profiling::tracy_dynamic_zone;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LoggingSender<T>
 where
     T: Debug + AsRef<str>,

--- a/src/running_tracker.rs
+++ b/src/running_tracker.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    atomic::{AtomicBool, AtomicI32, Ordering},
+    atomic::{AtomicI32, Ordering},
     Arc,
 };
 
@@ -10,34 +10,26 @@ lazy_static! {
 }
 
 pub struct RunningTracker {
-    running: Arc<AtomicBool>,
     exit_code: Arc<AtomicI32>,
 }
 
 impl RunningTracker {
     fn new() -> Self {
         Self {
-            running: Arc::new(AtomicBool::new(true)),
             exit_code: Arc::new(AtomicI32::new(0)),
         }
     }
 
     pub fn quit(&self, reason: &str) {
-        self.running.store(false, Ordering::Relaxed);
         info!("Quit {}", reason);
     }
 
     pub fn quit_with_code(&self, code: i32, reason: &str) {
-        self.exit_code.store(code, Ordering::Relaxed);
-        self.running.store(false, Ordering::Relaxed);
+        self.exit_code.store(code, Ordering::Release);
         info!("Quit with code {}: {}", code, reason);
     }
 
-    pub fn is_running(&self) -> bool {
-        self.running.load(Ordering::Relaxed)
-    }
-
     pub fn exit_code(&self) -> i32 {
-        self.exit_code.load(Ordering::Relaxed)
+        self.exit_code.load(Ordering::Acquire)
     }
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -320,7 +320,7 @@ pub fn main_loop(
             return;
         }
 
-        if !RUNNING_TRACKER.is_running() {
+        if !RUNNING_TRACKER.is_running() && !window_target.exiting() {
             save_window_size(&window_wrapper);
             window_target.exit();
         } else {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -314,7 +314,7 @@ pub fn main_loop(
         let mtm = MainThreadMarker::new().expect("must be on the main thread");
         macos::Menu::new(mtm)
     };
-    event_loop.run(move |e, window_target| {
+    let res = event_loop.run(move |e, window_target| {
         #[cfg(target_os = "macos")]
         menu.ensure_menu_added(&e);
 
@@ -327,7 +327,8 @@ pub fn main_loop(
             _ => window_target
                 .set_control_flow(update_loop.step(window_wrapper.as_mut().unwrap(), e)),
         }
-    })
+    });
+    res
 }
 
 pub fn load_icon() -> Icon {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -14,7 +14,6 @@ use crate::{
     bridge::{send_ui, ParallelCommand, SerialCommand},
     profiling::{tracy_frame, tracy_gpu_collect, tracy_gpu_zone, tracy_plot, tracy_zone},
     renderer::{create_skia_renderer, DrawCommand, Renderer, SkiaRenderer, VSync, WindowConfig},
-    running_tracker::RUNNING_TRACKER,
     settings::{
         clamped_grid_size, FontSettings, HotReloadConfigs, SettingsChanged, DEFAULT_GRID_SIZE,
         MIN_GRID_SIZE, SETTINGS,
@@ -293,11 +292,7 @@ impl WinitWindowWrapper {
     }
 
     pub fn handle_quit(&mut self) {
-        if SETTINGS.get::<CmdLineSettings>().server.is_none() {
-            send_ui(ParallelCommand::Quit);
-        } else {
-            RUNNING_TRACKER.quit("window closed");
-        }
+        send_ui(ParallelCommand::Quit);
     }
 
     pub fn handle_focus_lost(&mut self) {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The main loop now waits for Neovim to quit before exiting. This allows error messages to be shown and dealt with, instead of leaking nvim processes, as neovide will block here https://github.com/neovim/neovim/blob/15a2dd9e963784123273ec830e82e24ecea4ad0b/src/nvim/main.c#L802-L807

It primarily waits for the stdio stream to finish, but due to bugs, like https://github.com/neovim/neovim/issues/26743, that does not always happen, so it additionally waits for the process to exit, and forces a quite if the io stream has not finished within 2 seconds after that. **If you use Neovim nightly with https://github.com/neovim/neovim/pull/28157, it should not happen**

An exit crash that happens on some Wayland systems has also been fixed, by properly shutting down the rendering system before the event loop finishes.

* Fixes https://github.com/neovide/neovide/issues/2387
* Fixes https://github.com/neovide/neovide/issues/2223

## Did this PR introduce a breaking change? 
The special handling of just detaching from remote connections when closing the Window, which was added here https://github.com/neovide/neovide/pull/687 has been removed.  It would uneccessarily complicate this change, and I found that re-attaching causes a lot of bugs, like invisible text, the cursor showing the wrong position, the screen not updating and so on, so it's not very usable anyway.

NOTE: That it's still possible to detach manually by the following command: `:call chanclose(g:neovide_channel_id)`

Some hangs that @sid-6581 has reported on Windows might also start to appear again. But it will not hang compltely, just for 2 seconds. If that still happens, the actual cause should be determined and fixed. The same applies to other platforms as well of course.
