### PR TITLE
fix!: Use points instead of pixels for the config file

### DIFF
--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -318,7 +318,7 @@ impl FontHinting {
     }
 }
 
-fn points_to_pixels(value: f32) -> f32 {
+pub fn points_to_pixels(value: f32) -> f32 {
     // Fonts in neovim are using points, not pixels.
     //
     // Skia docs is incorrectly stating it uses points, but uses pixels:
@@ -329,14 +329,17 @@ fn points_to_pixels(value: f32) -> f32 {
     //
     // In reality, this depends on DPI/PPI of monitor, but here we only care about converting
     // from points to pixels, so this is standard constant values.
-    if cfg!(target_os = "macos") {
+    let pixels = if cfg!(target_os = "macos") {
         // On macos points == pixels
         value
     } else {
         let pixels_per_inch = 96.0;
         let points_per_inch = 72.0;
         value * (pixels_per_inch / points_per_inch)
-    }
+    };
+
+    log::info!("point_to_pixels {value} -> {pixels}");
+    pixels
 }
 
 impl FontDescription {

--- a/src/settings/font.rs
+++ b/src/settings/font.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 use crate::renderer::fonts::font_options::{
-    FontDescription, FontEdging, FontFeature, FontHinting, FontOptions, SecondaryFontDescription,
+    points_to_pixels, FontDescription, FontEdging, FontFeature, FontHinting, FontOptions,
+    SecondaryFontDescription,
 };
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -118,8 +119,8 @@ impl From<FontSettings> for FontOptions {
                         .collect()
                 })
                 .unwrap_or_default(),
-            size: value.size,
-            width: value.width.unwrap_or_default(),
+            size: points_to_pixels(value.size),
+            width: points_to_pixels(value.width.unwrap_or_default()),
             hinting: value
                 .hinting
                 .map(|hinting| FontHinting::parse(&hinting).unwrap_or_default())


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* The `width` and `size` arguments in the font config are now read as points, like `guifont` and almost any other software.

## Did this PR introduce a breaking change? 
Yes, users that have adjusted their size in pixels will now see too big fonts.
