### PR TITLE
feat: draw block characters with background opacity

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use log::trace;
 use skia_safe::{
     colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, Point, Rect, HSV,
 };
+use std::sync::Arc;
 use winit::dpi::PhysicalSize;
 
 use crate::{
@@ -29,6 +28,23 @@ pub struct GridRenderer {
 pub struct BackgroundInfo {
     pub custom_color: bool,
     pub transparent: bool,
+}
+
+fn is_box_drawing_character(c: char) -> bool {
+    // box drawing characters
+    ('\u{2500}'..'\u{257F}').contains(&c)
+        // block elements
+        || ('\u{2580}'..'\u{259F}').contains(&c)
+        // geometric shapes
+        || ('\u{25A0}'..'\u{25FF}').contains(&c)
+        // nerdfont powerline
+        || ('\u{e0a0}'..'\u{e0a2}').contains(&c)
+        || ('\u{e0b0}'..'\u{e0b3}').contains(&c)
+        // nerdfont powerline extras
+        || (c == '\u{e0a3}')
+        || ('\u{e0b4}'..'\u{e0c8}').contains(&c)
+        || (c == '\u{e0ca}')
+        || ('\u{e0cc}'..'\u{e0d7}').contains(&c)
 }
 
 impl GridRenderer {
@@ -201,7 +217,11 @@ impl GridRenderer {
 
         let mut paint = Paint::default();
         paint.set_anti_alias(false);
-        paint.set_blend_mode(BlendMode::SrcOver);
+        if text.chars().all(is_box_drawing_character) {
+            paint.set_blend_mode(BlendMode::SrcATop);
+        } else {
+            paint.set_blend_mode(BlendMode::SrcOver);
+        }
 
         if SETTINGS.get::<RendererSettings>().debug_renderer {
             let random_hsv: HSV = (rand::random::<f32>() * 360.0, 1.0, 1.0).into();


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->


## What kind of change does this PR introduce?

This fixes https://github.com/neovide/neovide/issues/2275 by letting [box drawing](https://en.wikipedia.org/wiki/Box-drawing_characters), [block elements](https://en.wikipedia.org/wiki/Block_Elements), [geometric shapes](https://en.wikipedia.org/wiki/Geometric_Shapes_(Unicode_block)) as well as the [Nerdfont Powerline](https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-Points#powerline-symbols) (+[Extras](https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-Points#powerline-extra-symbols)) inherit the background opacity instead.

- (Fix?)
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

| Main | This PR |
| --- | --- |
| ![image](https://github.com/neovide/neovide/assets/19289296/a40300b0-27b7-4fba-af08-279b0f1c4339) | ![image](https://github.com/neovide/neovide/assets/19289296/fad336f4-d973-4894-99f4-0eb322ab21ae) |

