### PR TITLE
chore: Use typesafe pixel and grid units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225"
+checksum = "8e08104bebc65a46f8bc7aa733d39ea6874bfa7156f41a46b805785e3af1587d"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -195,7 +195,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.57",
+ "syn 2.0.58",
  "which 4.4.2",
 ]
 
@@ -302,6 +302,20 @@ name = "bytemuck"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
 
 [[package]]
 name = "byteorder"
@@ -353,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
 dependencies = [
  "jobserver",
  "libc",
@@ -451,7 +465,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -536,9 +550,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -630,7 +644,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -671,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -695,6 +709,15 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -742,9 +765,12 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7f6040d337bd44434ab21fc6509154edf2cece88b23758d9d64654c4e7730b"
+checksum = "bd6784a76a9c2b136ea3b8462391e9328252e938eb706eb44d752723b4c3a533"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "foreign-types"
@@ -764,7 +790,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -853,7 +879,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -911,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1100,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b4f005360d32e9325029b38ba47ebd7a56f3316df09249368939562d518645"
+checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1266,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
@@ -1277,13 +1303,12 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
- "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -1413,6 +1438,7 @@ dependencies = [
  "csscolorparser",
  "derive-new",
  "dirs",
+ "euclid",
  "flexi_logger",
  "futures 0.3.30",
  "gl",
@@ -1605,7 +1631,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1800,7 +1826,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1877,7 +1903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1975,7 +2001,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -2001,10 +2027,11 @@ checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "read-fonts"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c524658d3b77930a391f559756d91dbe829ab6cf4687083f615d395df99722"
+checksum = "ea75b5ec052843434d263ef7a4c31cf86db5908c729694afb1ad3c884252a1b6"
 dependencies = [
+ "bytemuck",
  "font-types",
 ]
 
@@ -2028,12 +2055,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.12",
- "libredox 0.0.1",
+ "getrandom 0.2.14",
+ "libredox 0.1.3",
  "thiserror",
 ]
 
@@ -2074,7 +2101,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "libc",
  "spin",
  "untrusted",
@@ -2160,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"
@@ -2227,7 +2254,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2272,7 +2299,7 @@ checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2435,9 +2462,9 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -2458,7 +2485,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2469,9 +2496,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swash"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af636fb90d39858650cae1088a37e2862dab4e874a0bb49d6dfb5b2dacf0e24"
+checksum = "06ec889a8e0a6fcb91041996c8f1f6be0fe1a09e94478785e07c32ce2bca2d2b"
 dependencies = [
  "read-fonts",
 ]
@@ -2489,9 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2526,7 +2553,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2638,7 +2665,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2856,7 +2883,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -2890,7 +2917,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3479,9 +3506,9 @@ checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "zerocopy"
@@ -3500,7 +3527,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ copypasta = "0.10.1"
 csscolorparser = "0.6.2"
 derive-new = "0.6.0"
 dirs = "5.0.0"
+euclid = "0.22.9"
 flexi_logger = { version = "0.28.0", default-features = false }
 futures = "0.3.21"
 gl = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ copypasta = "0.10.1"
 csscolorparser = "0.6.2"
 derive-new = "0.6.0"
 dirs = "5.0.0"
-euclid = "0.22.9"
+euclid = { version = "0.22.9", features = ["serde"] }
 flexi_logger = { version = "0.28.0", default-features = false }
 futures = "0.3.21"
 gl = "0.14.0"

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -17,8 +17,8 @@ use tokio::runtime::{Builder, Runtime};
 use winit::event_loop::EventLoopProxy;
 
 use crate::{
-    cmd_line::CmdLineSettings, dimensions::Dimensions, editor::start_editor, running_tracker::*,
-    settings::*, window::UserEvent,
+    cmd_line::CmdLineSettings, editor::start_editor, running_tracker::*, settings::*,
+    units::GridSize, window::UserEvent,
 };
 pub use handler::NeovimHandler;
 use session::{NeovimInstance, NeovimSession};
@@ -77,7 +77,7 @@ pub async fn show_error_message(
     nvim.echo(prepared_lines, true, vec![]).await
 }
 
-async fn launch(handler: NeovimHandler, grid_size: Option<Dimensions>) -> Result<NeovimSession> {
+async fn launch(handler: NeovimHandler, grid_size: Option<GridSize<u32>>) -> Result<NeovimSession> {
     let neovim_instance = neovim_instance()?;
 
     let session = NeovimSession::new(neovim_instance, handler)
@@ -123,7 +123,7 @@ async fn launch(handler: NeovimHandler, grid_size: Option<Dimensions>) -> Result
 
     // Triggers loading the user config
 
-    let grid_size = grid_size.map_or(DEFAULT_GRID_SIZE, |v| v.clamped_grid_size());
+    let grid_size = grid_size.map_or(DEFAULT_GRID_SIZE, |v| clamped_grid_size(&v));
     let res = session
         .neovim
         .ui_attach(grid_size.width as i64, grid_size.height as i64, &options)
@@ -159,7 +159,7 @@ impl NeovimRuntime {
     pub fn launch(
         &mut self,
         event_loop_proxy: EventLoopProxy<UserEvent>,
-        grid_size: Option<Dimensions>,
+        grid_size: Option<GridSize<u32>>,
     ) -> Result<()> {
         let handler = start_editor(event_loop_proxy);
         let runtime = self.runtime.as_ref().unwrap();

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -7,30 +7,11 @@ use std::{
 use serde::{Deserialize, Serialize};
 use winit::dpi::PhysicalSize;
 
-use crate::settings;
-
 // Maybe this should be independent from serialization?
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Dimensions {
     pub width: u64,
     pub height: u64,
-}
-
-impl Dimensions {
-    pub fn clamped_grid_size(&self) -> Self {
-        let min = settings::MIN_GRID_SIZE;
-        let max = settings::MAX_GRID_SIZE;
-        Dimensions {
-            width: self.width.clamp(min.width, max.width),
-            height: self.height.clamp(min.height, max.height),
-        }
-    }
-}
-
-impl Default for Dimensions {
-    fn default() -> Self {
-        settings::DEFAULT_GRID_SIZE
-    }
 }
 
 impl FromStr for Dimensions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod profiling;
 mod renderer;
 mod running_tracker;
 mod settings;
+mod units;
 mod utils;
 mod window;
 

--- a/src/renderer/animation_utils.rs
+++ b/src/renderer/animation_utils.rs
@@ -1,4 +1,4 @@
-use skia_safe::Point;
+use crate::units::PixelPos;
 
 #[allow(dead_code)]
 pub fn ease_linear(t: f32) -> f32 {
@@ -73,11 +73,16 @@ pub fn ease(ease_func: fn(f32) -> f32, start: f32, end: f32, t: f32) -> f32 {
     lerp(start, end, ease_func(t))
 }
 
-pub fn ease_point(ease_func: fn(f32) -> f32, start: Point, end: Point, t: f32) -> Point {
-    Point {
-        x: ease(ease_func, start.x, end.x, t),
-        y: ease(ease_func, start.y, end.y, t),
-    }
+pub fn ease_point(
+    ease_func: fn(f32) -> f32,
+    start: PixelPos<f32>,
+    end: PixelPos<f32>,
+    t: f32,
+) -> PixelPos<f32> {
+    PixelPos::new(
+        ease(ease_func, start.x, end.x, t),
+        ease(ease_func, start.y, end.y, t),
+    )
 }
 
 pub struct CriticallyDampedSpringAnimation {
@@ -205,79 +210,70 @@ mod test {
 
     #[test]
     fn test_ease_point_linear() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
         assert_eq!(ease_point(ease_linear, start, end, 1.0), end);
     }
 
     #[test]
     fn test_ease_point_in_quad() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
         assert_eq!(ease_point(ease_in_quad, start, end, 1.0), end);
     }
 
     #[test]
     fn test_ease_point_out_quad() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
         assert_eq!(ease_point(ease_out_quad, start, end, 1.0), end);
     }
 
     #[test]
     fn test_ease_point_in_out_quad() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
-        let expected = Point {
-            x: 0.68000007,
-            y: 0.68000007,
-        };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
+        let expected = PixelPos::new(0.68000007, 0.68000007);
         assert_eq!(ease_point(ease_in_out_quad, start, end, 1.0), end);
         assert_eq!(ease_point(ease_in_out_quad, start, end, 1.4), expected);
     }
 
     #[test]
     fn test_ease_point_in_cubic() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
         assert_eq!(ease_point(ease_in_cubic, start, end, 1.0), end);
     }
 
     #[test]
     fn test_ease_point_out_cubic() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
         assert_eq!(ease_point(ease_out_cubic, start, end, 1.0), end);
     }
 
     #[test]
     fn test_ease_point_in_out_cubic() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
-        let expected = Point {
-            x: 0.0625,
-            y: 0.0625,
-        };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
+        let expected = PixelPos::new(0.0625, 0.0625);
         assert_eq!(ease_point(ease_in_out_cubic, start, end, 1.0), end);
         assert_eq!(ease_point(ease_in_out_cubic, start, end, 0.25), expected);
     }
 
     #[test]
     fn test_ease_point_in_expo() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
         assert_eq!(ease_point(ease_in_expo, start, end, 1.0), end);
         assert_eq!(ease_point(ease_in_expo, start, end, 0.0), start);
     }
 
     #[test]
     fn test_ease_point_out_expo() {
-        let start = Point { x: 0.0, y: 0.0 };
-        let end = Point { x: 1.0, y: 1.0 };
-        let expected = Point {
-            x: 0.9995117,
-            y: 0.9995117,
-        };
+        let start = PixelPos::new(0.0, 0.0);
+        let end = PixelPos::new(1.0, 1.0);
+        let expected = PixelPos::new(0.9995117, 0.9995117);
         assert_eq!(ease_point(ease_out_expo, start, end, 1.0), end);
         assert_eq!(ease_point(ease_out_expo, start, end, 1.1), expected);
     }

--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -1,24 +1,25 @@
 use log::error;
 use nvim_rs::Value;
-use skia_safe::{paint::Style, BlendMode, Canvas, Color, Paint, Point, Rect};
+use skia_safe::{paint::Style, BlendMode, Canvas, Color, Paint, Rect};
 
 use crate::{
     editor::Cursor,
     renderer::cursor_renderer::CursorSettings,
     renderer::{animation_utils::*, grid_renderer::GridRenderer},
     settings::*,
+    units::{PixelPos, PixelSize, PixelVec},
 };
 
 pub trait CursorVfx {
     fn update(
         &mut self,
         settings: &CursorSettings,
-        current_cursor_destination: Point,
-        cursor_dimensions: Point,
+        current_cursor_destination: PixelPos<f32>,
+        cursor_dimensions: PixelSize<f32>,
         immediate_movement: bool,
         dt: f32,
     ) -> bool;
-    fn restart(&mut self, position: Point);
+    fn restart(&mut self, position: PixelPos<f32>);
     fn render(
         &self,
         settings: &CursorSettings,
@@ -95,7 +96,7 @@ pub fn new_cursor_vfx(mode: &VfxMode) -> Option<Box<dyn CursorVfx>> {
 
 pub struct PointHighlight {
     t: f32,
-    center_position: Point,
+    center_position: PixelPos<f32>,
     mode: HighlightMode,
 }
 
@@ -103,7 +104,7 @@ impl PointHighlight {
     pub fn new(mode: &HighlightMode) -> PointHighlight {
         PointHighlight {
             t: 0.0,
-            center_position: Point::new(0.0, 0.0),
+            center_position: PixelPos::new(0.0, 0.0),
             mode: mode.clone(),
         }
     }
@@ -113,8 +114,8 @@ impl CursorVfx for PointHighlight {
     fn update(
         &mut self,
         _settings: &CursorSettings,
-        _current_cursor_destination: Point,
-        _cursor_dimensions: Point,
+        _current_cursor_destination: PixelPos<f32>,
+        _cursor_dimensions: PixelSize<f32>,
         _immediate_movement: bool,
         dt: f32,
     ) -> bool {
@@ -122,7 +123,7 @@ impl CursorVfx for PointHighlight {
         self.t < 1.0
     }
 
-    fn restart(&mut self, position: Point) {
+    fn restart(&mut self, position: PixelPos<f32>) {
         self.t = 0.0;
         self.center_position = position;
     }
@@ -148,9 +149,9 @@ impl CursorVfx for PointHighlight {
 
         paint.set_color(color);
 
-        let cursor_height = grid_renderer.font_dimensions.height;
-        let size = 3 * cursor_height;
-        let radius = self.t * size as f32;
+        let cursor_height = grid_renderer.grid_scale.0.height;
+        let size = 3.0 * cursor_height;
+        let radius = self.t * size;
         let hr = radius * 0.5;
         let rect = Rect::from_xywh(
             self.center_position.x - hr,
@@ -165,12 +166,12 @@ impl CursorVfx for PointHighlight {
             }
             HighlightMode::Ripple => {
                 paint.set_style(Style::Stroke);
-                paint.set_stroke_width(cursor_height as f32 * 0.2);
+                paint.set_stroke_width(cursor_height * 0.2);
                 canvas.draw_oval(rect, &paint);
             }
             HighlightMode::Wireframe => {
                 paint.set_style(Style::Stroke);
-                paint.set_stroke_width(cursor_height as f32 * 0.2);
+                paint.set_stroke_width(cursor_height * 0.2);
                 canvas.draw_rect(rect, &paint);
             }
         }
@@ -179,15 +180,15 @@ impl CursorVfx for PointHighlight {
 
 #[derive(Clone)]
 struct ParticleData {
-    pos: Point,
-    speed: Point,
+    pos: PixelPos<f32>,
+    speed: PixelVec<f32>,
     rotation_speed: f32,
     lifetime: f32,
 }
 
 pub struct ParticleTrail {
     particles: Vec<ParticleData>,
-    previous_cursor_dest: Point,
+    previous_cursor_dest: PixelPos<f32>,
     trail_mode: TrailMode,
     rng: RngState,
 }
@@ -196,13 +197,19 @@ impl ParticleTrail {
     pub fn new(trail_mode: &TrailMode) -> ParticleTrail {
         ParticleTrail {
             particles: vec![],
-            previous_cursor_dest: Point::new(0.0, 0.0),
+            previous_cursor_dest: PixelPos::new(0.0, 0.0),
             trail_mode: trail_mode.clone(),
             rng: RngState::new(),
         }
     }
 
-    fn add_particle(&mut self, pos: Point, speed: Point, rotation_speed: f32, lifetime: f32) {
+    fn add_particle(
+        &mut self,
+        pos: PixelPos<f32>,
+        speed: PixelVec<f32>,
+        rotation_speed: f32,
+        lifetime: f32,
+    ) {
         self.particles.push(ParticleData {
             pos,
             speed,
@@ -222,8 +229,8 @@ impl CursorVfx for ParticleTrail {
     fn update(
         &mut self,
         settings: &CursorSettings,
-        current_cursor_dest: Point,
-        cursor_dimensions: Point,
+        current_cursor_dest: PixelPos<f32>,
+        cursor_dimensions: PixelSize<f32>,
         immediate_movement: bool,
         dt: f32,
     ) -> bool {
@@ -253,7 +260,7 @@ impl CursorVfx for ParticleTrail {
                 let travel_distance = travel.length();
 
                 // Increase amount of particles when cursor travels further
-                let particle_count = ((travel_distance / cursor_dimensions.y).powf(1.5)
+                let particle_count = ((travel_distance / cursor_dimensions.height).powf(1.5)
                     * settings.vfx_particle_density
                     * 0.01) as usize;
 
@@ -266,20 +273,19 @@ impl CursorVfx for ParticleTrail {
                         TrailMode::Railgun => {
                             let phase = t / std::f32::consts::PI
                                 * settings.vfx_particle_phase
-                                * (travel_distance / cursor_dimensions.y);
-                            Point::new(phase.sin(), phase.cos()) * 2.0 * settings.vfx_particle_speed
+                                * (travel_distance / cursor_dimensions.height);
+                            PixelVec::new(phase.sin(), phase.cos())
+                                * 2.0
+                                * settings.vfx_particle_speed
                         }
                         TrailMode::Torpedo => {
-                            let mut travel_dir = travel;
-                            travel_dir.normalize();
-                            let mut particle_dir =
-                                self.rng.rand_dir_normalized() - travel_dir * 1.5;
-                            particle_dir.normalize();
-                            particle_dir * settings.vfx_particle_speed
+                            let travel_dir = travel.normalize();
+                            let particle_dir = self.rng.rand_dir_normalized() - travel_dir * 1.5;
+                            particle_dir.normalize() * settings.vfx_particle_speed
                         }
                         TrailMode::PixieDust => {
                             let base_dir = self.rng.rand_dir_normalized();
-                            let dir = Point::new(base_dir.x * 0.5, 0.4 + base_dir.y.abs());
+                            let dir = PixelVec::new(base_dir.x * 0.5, 0.4 + base_dir.y.abs());
                             dir * 3.0 * settings.vfx_particle_speed
                         }
                     };
@@ -290,7 +296,7 @@ impl CursorVfx for ParticleTrail {
                         TrailMode::PixieDust | TrailMode::Torpedo => {
                             prev_p
                                 + travel * self.rng.next_f32()
-                                + Point::new(0.0, cursor_dimensions.y * 0.5)
+                                + PixelVec::new(0.0, cursor_dimensions.height * 0.5)
                         }
                     };
 
@@ -319,7 +325,7 @@ impl CursorVfx for ParticleTrail {
         !self.particles.is_empty()
     }
 
-    fn restart(&mut self, _position: Point) {}
+    fn restart(&mut self, _position: PixelPos<f32>) {}
 
     fn render(
         &self,
@@ -329,11 +335,11 @@ impl CursorVfx for ParticleTrail {
         cursor: &Cursor,
     ) {
         let mut paint = Paint::new(skia_safe::colors::WHITE, None);
-        let font_dimensions = grid_renderer.font_dimensions;
+        let font_dimensions = grid_renderer.grid_scale.0;
         match self.trail_mode {
             TrailMode::Torpedo | TrailMode::Railgun => {
                 paint.set_style(Style::Stroke);
-                paint.set_stroke_width(font_dimensions.height as f32 * 0.2);
+                paint.set_stroke_width(font_dimensions.height * 0.2);
             }
             _ => {}
         }
@@ -350,10 +356,8 @@ impl CursorVfx for ParticleTrail {
             paint.set_color(color);
 
             let radius = match self.trail_mode {
-                TrailMode::Torpedo | TrailMode::Railgun => {
-                    font_dimensions.width as f32 * 0.5 * lifetime
-                }
-                TrailMode::PixieDust => font_dimensions.width as f32 * 0.2,
+                TrailMode::Torpedo | TrailMode::Railgun => font_dimensions.width * 0.5 * lifetime,
+                TrailMode::PixieDust => font_dimensions.width * 0.2,
             };
 
             let hr = radius * 0.5;
@@ -426,23 +430,21 @@ impl RngState {
 
     // Produces a random vector with x and y in the [-1,1) range
     // Note: Vector is not normalized.
-    fn rand_dir(&mut self) -> Point {
+    fn rand_dir(&mut self) -> PixelVec<f32> {
         let x = self.next_f32();
         let y = self.next_f32();
 
-        Point::new(x * 2.0 - 1.0, y * 2.0 - 1.0)
+        PixelVec::new(x * 2.0 - 1.0, y * 2.0 - 1.0)
     }
 
-    fn rand_dir_normalized(&mut self) -> Point {
-        let mut v = self.rand_dir();
-        v.normalize();
-        v
+    fn rand_dir_normalized(&mut self) -> PixelVec<f32> {
+        self.rand_dir().normalize()
     }
 }
 
-fn rotate_vec(v: Point, rot: f32) -> Point {
+fn rotate_vec(v: PixelVec<f32>, rot: f32) -> PixelVec<f32> {
     let sin = rot.sin();
     let cos = rot.cos();
 
-    Point::new(v.x * cos - v.y * sin, v.x * sin + v.y * cos)
+    PixelVec::new(v.x * cos - v.y * sin, v.x * sin + v.y * cos)
 }

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -3,16 +3,16 @@ mod cursor_vfx;
 
 use std::collections::HashMap;
 
-use skia_safe::{op, Canvas, Paint, Path, Point};
+use skia_safe::{op, Canvas, Paint, Path};
 use winit::event::{Event, WindowEvent};
 
 use crate::{
     bridge::EditorMode,
     editor::{Cursor, CursorShape},
     profiling::{tracy_plot, tracy_zone},
-    renderer::animation_utils::*,
-    renderer::{GridRenderer, RenderedWindow},
+    renderer::{animation_utils::*, GridRenderer, RenderedWindow},
     settings::{ParseFromValue, SETTINGS},
+    units::{to_skia_point, GridPos, GridScale, PixelPos, PixelSize, PixelVec},
     window::{ShouldRender, UserEvent},
 };
 
@@ -68,10 +68,10 @@ impl Default for CursorSettings {
 
 #[derive(Debug, Clone)]
 pub struct Corner {
-    start_position: Point,
-    current_position: Point,
-    relative_position: Point,
-    previous_destination: Point,
+    start_position: PixelPos<f32>,
+    current_position: PixelPos<f32>,
+    relative_position: GridPos<f32>,
+    previous_destination: PixelPos<f32>,
     length_multiplier: f32,
     t: f32,
 }
@@ -79,10 +79,10 @@ pub struct Corner {
 impl Corner {
     pub fn new() -> Corner {
         Corner {
-            start_position: Point::new(0.0, 0.0),
-            current_position: Point::new(0.0, 0.0),
-            relative_position: Point::new(0.0, 0.0),
-            previous_destination: Point::new(-1000.0, -1000.0),
+            start_position: PixelPos::origin(),
+            current_position: PixelPos::origin(),
+            relative_position: GridPos::<f32>::origin(),
+            previous_destination: PixelPos::new(-1000.0, -1000.0),
             length_multiplier: 1.0,
             t: 0.0,
         }
@@ -91,8 +91,8 @@ impl Corner {
     pub fn update(
         &mut self,
         settings: &CursorSettings,
-        font_dimensions: Point,
-        destination: Point,
+        cursor_dimensions: GridScale,
+        destination: PixelPos<f32>,
         dt: f32,
         immediate_movement: bool,
     ) -> bool {
@@ -116,13 +116,9 @@ impl Corner {
         }
 
         // Calculate window-space destination for corner
-        let relative_scaled_position: Point = (
-            self.relative_position.x * font_dimensions.x,
-            self.relative_position.y * font_dimensions.y,
-        )
-            .into();
+        let relative_scaled_position = self.relative_position * cursor_dimensions;
 
-        let corner_destination = destination + relative_scaled_position;
+        let corner_destination = destination + relative_scaled_position.to_vector();
 
         if immediate_movement {
             self.t = 1.0;
@@ -134,16 +130,11 @@ impl Corner {
         // with the direction of motion. Corners in front will move faster than corners in the
         // back
         let travel_direction = {
-            let mut d = destination - self.current_position;
-            d.normalize();
-            d
+            let d = destination - self.current_position;
+            d.normalize()
         };
 
-        let corner_direction = {
-            let mut d = self.relative_position;
-            d.normalize();
-            d
-        };
+        let corner_direction = self.relative_position.to_vector().normalize().cast_unit();
 
         let direction_alignment = travel_direction.dot(corner_direction);
 
@@ -175,7 +166,7 @@ impl Corner {
 pub struct CursorRenderer {
     pub corners: Vec<Corner>,
     cursor: Cursor,
-    destination: Point,
+    destination: PixelPos<f32>,
     blink_status: BlinkStatus,
     previous_cursor_shape: Option<CursorShape>,
     previous_editor_mode: EditorMode,
@@ -250,15 +241,15 @@ impl CursorRenderer {
 
     pub fn update_cursor_destination(
         &mut self,
-        (font_width, font_height): (u64, u64),
+        grid_scale: GridScale,
         windows: &HashMap<u64, RenderedWindow>,
     ) {
-        let (cursor_grid_x, cursor_grid_y) = self.cursor.grid_position;
-
+        let cursor_grid_position = GridPos::<u64>::from(self.cursor.grid_position)
+            .try_cast()
+            .unwrap();
         if let Some(window) = windows.get(&self.cursor.parent_window_id) {
-            let grid_x = cursor_grid_x as f32 + window.grid_current_position.x;
-            let mut grid_y = cursor_grid_y as f32 + window.grid_current_position.y
-                - window.scroll_animation.position;
+            let mut grid = cursor_grid_position + window.grid_current_position.to_vector();
+            grid.y -= window.scroll_animation.position;
 
             let top_border = window.viewport_margins.top as f32;
             let bottom_border = window.viewport_margins.bottom as f32;
@@ -266,19 +257,15 @@ impl CursorRenderer {
             // Prevent the cursor from targeting a position outside its current window. Since only
             // the vertical direction is effected by scrolling, we only have to clamp the vertical
             // grid position.
-            grid_y = grid_y.max(window.grid_current_position.y + top_border).min(
+            grid.y = grid.y.max(window.grid_current_position.y + top_border).min(
                 window.grid_current_position.y + window.grid_size.height as f32
                     - 1.0
                     - bottom_border,
             );
 
-            self.destination = (grid_x * font_width as f32, grid_y * font_height as f32).into();
+            self.destination = grid * grid_scale;
         } else {
-            self.destination = (
-                (cursor_grid_x * font_width) as f32,
-                (cursor_grid_y * font_height) as f32,
-            )
-                .into();
+            self.destination = cursor_grid_position * grid_scale;
         }
     }
 
@@ -339,7 +326,7 @@ impl CursorRenderer {
         for blob in blobs.iter() {
             canvas.draw_text_blob(
                 blob,
-                (self.destination.x, self.destination.y + y_adjustment as f32),
+                (self.destination.x, self.destination.y + y_adjustment),
                 &paint,
             );
         }
@@ -365,23 +352,19 @@ impl CursorRenderer {
             self.previous_vfx_mode = settings.vfx_mode.clone();
         }
 
-        let mut cursor_width = grid_renderer.font_dimensions.width;
+        let mut cursor_width = grid_renderer.grid_scale.0.width;
         if self.cursor.double_width && self.cursor.shape == CursorShape::Block {
-            cursor_width *= 2;
+            cursor_width *= 2.0;
         }
 
-        let cursor_dimensions: Point = (
-            cursor_width as f32,
-            grid_renderer.font_dimensions.height as f32,
-        )
-            .into();
+        let cursor_dimensions = PixelSize::new(cursor_width, grid_renderer.grid_scale.0.height);
 
         let in_insert_mode = matches!(current_mode, EditorMode::Insert);
 
         let changed_to_from_cmdline = !matches!(self.previous_editor_mode, EditorMode::CmdLine)
             ^ matches!(current_mode, EditorMode::CmdLine);
 
-        let center_destination = self.destination + cursor_dimensions * 0.5;
+        let center_destination = self.destination + cursor_dimensions.to_vector() * 0.5;
 
         if self.previous_cursor_shape.as_ref() != Some(&self.cursor.shape) {
             self.previous_cursor_shape = Some(self.cursor.shape.clone());
@@ -399,13 +382,13 @@ impl CursorRenderer {
 
         let mut animating = false;
 
-        if !center_destination.is_zero() {
+        if center_destination != PixelPos::origin() {
             let immediate_movement = !settings.animate_in_insert_mode && in_insert_mode
                 || !settings.animate_command_line && !changed_to_from_cmdline;
             for corner in self.corners.iter_mut() {
                 let corner_animating = corner.update(
                     &settings,
-                    cursor_dimensions,
+                    GridScale(cursor_dimensions),
                     center_destination,
                     dt,
                     immediate_movement,
@@ -445,10 +428,10 @@ impl CursorRenderer {
         // corners.
         let mut path = Path::new();
 
-        path.move_to(self.corners[0].current_position);
-        path.line_to(self.corners[1].current_position);
-        path.line_to(self.corners[2].current_position);
-        path.line_to(self.corners[3].current_position);
+        path.move_to(to_skia_point(self.corners[0].current_position));
+        path.line_to(to_skia_point(self.corners[1].current_position));
+        path.line_to(to_skia_point(self.corners[2].current_position));
+        path.line_to(to_skia_point(self.corners[3].current_position));
         path.close();
 
         canvas.draw_path(&path, paint);
@@ -457,13 +440,13 @@ impl CursorRenderer {
 
     fn draw_rectangular_outline(&self, canvas: &Canvas, paint: &Paint, outline_width: f32) -> Path {
         let mut rectangle = Path::new();
-        rectangle.move_to(self.corners[0].current_position);
-        rectangle.line_to(self.corners[1].current_position);
-        rectangle.line_to(self.corners[2].current_position);
-        rectangle.line_to(self.corners[3].current_position);
+        rectangle.move_to(to_skia_point(self.corners[0].current_position));
+        rectangle.line_to(to_skia_point(self.corners[1].current_position));
+        rectangle.line_to(to_skia_point(self.corners[2].current_position));
+        rectangle.line_to(to_skia_point(self.corners[3].current_position));
         rectangle.close();
 
-        let offsets: [Point; 4] = [
+        let offsets: [PixelVec<f32>; 4] = [
             (outline_width, outline_width).into(),
             (-outline_width, outline_width).into(),
             (-outline_width, -outline_width).into(),
@@ -471,10 +454,10 @@ impl CursorRenderer {
         ];
 
         let mut subtract = Path::new();
-        subtract.move_to(self.corners[0].current_position + offsets[0]);
-        subtract.line_to(self.corners[1].current_position + offsets[1]);
-        subtract.line_to(self.corners[2].current_position + offsets[2]);
-        subtract.line_to(self.corners[3].current_position + offsets[3]);
+        subtract.move_to(to_skia_point(self.corners[0].current_position + offsets[0]));
+        subtract.line_to(to_skia_point(self.corners[1].current_position + offsets[1]));
+        subtract.line_to(to_skia_point(self.corners[2].current_position + offsets[2]));
+        subtract.line_to(to_skia_point(self.corners[3].current_position + offsets[3]));
         subtract.close();
 
         // We have two "rectangles"; create an outline path by subtracting the smaller rectangle
@@ -485,7 +468,7 @@ impl CursorRenderer {
         path
     }
 
-    pub fn get_current_position(&self) -> Point {
+    pub fn get_destination(&self) -> PixelPos<f32> {
         self.destination
     }
 }

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -1,16 +1,15 @@
 use log::trace;
-use skia_safe::{
-    colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, Point, Rect, HSV,
-};
+use skia_safe::{colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, HSV};
 use std::sync::Arc;
-use winit::dpi::PhysicalSize;
 
 use crate::{
-    dimensions::Dimensions,
     editor::{Colors, Style, UnderlineStyle},
     profiling::tracy_zone,
     renderer::{CachingShaper, RendererSettings},
     settings::*,
+    units::{
+        to_skia_point, to_skia_rect, GridPos, GridScale, GridSize, PixelPos, PixelRect, PixelVec,
+    },
 };
 
 use super::fonts::font_options::FontOptions;
@@ -19,7 +18,7 @@ pub struct GridRenderer {
     pub shaper: CachingShaper,
     pub default_style: Arc<Style>,
     pub em_size: f32,
-    pub font_dimensions: Dimensions,
+    pub grid_scale: GridScale,
     pub is_ready: bool,
 }
 
@@ -55,29 +54,19 @@ impl GridRenderer {
             Some(colors::GREY),
         )));
         let em_size = shaper.current_size();
-        let font_dimensions: Dimensions = shaper.font_base_dimensions().into();
+        let font_dimensions = shaper.font_base_dimensions();
 
         GridRenderer {
             shaper,
             default_style,
             em_size,
-            font_dimensions,
+            grid_scale: GridScale(font_dimensions),
             is_ready: false,
         }
     }
 
     pub fn font_names(&self) -> Vec<String> {
         self.shaper.font_names()
-    }
-
-    /// Convert PhysicalSize to grid size.
-    pub fn convert_physical_to_grid(&self, physical: PhysicalSize<u32>) -> Dimensions {
-        Dimensions::from(physical) / self.font_dimensions
-    }
-
-    /// Convert grid size to PhysicalSize.
-    pub fn convert_grid_to_physical(&self, grid: Dimensions) -> PhysicalSize<u32> {
-        (grid * self.font_dimensions).into()
     }
 
     pub fn handle_scale_factor_update(&mut self, scale_factor: f64) {
@@ -95,23 +84,22 @@ impl GridRenderer {
         self.update_font_dimensions();
     }
 
-    pub fn update_linespace(&mut self, linespace_setting: i64) {
+    pub fn update_linespace(&mut self, linespace_setting: f32) {
         self.shaper.update_linespace(linespace_setting);
         self.update_font_dimensions();
     }
 
     fn update_font_dimensions(&mut self) {
         self.em_size = self.shaper.current_size();
-        self.font_dimensions = self.shaper.font_base_dimensions().into();
+        self.grid_scale = GridScale(self.shaper.font_base_dimensions());
         self.is_ready = true;
-        trace!("Updated font dimensions: {:?}", self.font_dimensions,);
+        trace!("Updated font dimensions: {:?}", self.grid_scale.0);
     }
 
-    fn compute_text_region(&self, grid_position: (u64, u64), cell_width: u64) -> Rect {
-        let (x, y) = grid_position * self.font_dimensions;
-        let width = cell_width * self.font_dimensions.width;
-        let height = self.font_dimensions.height;
-        Rect::new(x as f32, y as f32, (x + width) as f32, (y + height) as f32)
+    fn compute_text_region(&self, grid_position: GridPos<i32>, cell_width: i32) -> PixelRect<f32> {
+        let pos = grid_position.cast() * self.grid_scale;
+        let size = GridSize::new(cell_width, 1).cast() * self.grid_scale;
+        PixelRect::from_origin_and_size(pos, size)
     }
 
     pub fn get_default_background(&self) -> Color {
@@ -126,8 +114,8 @@ impl GridRenderer {
     pub fn draw_background(
         &mut self,
         canvas: &Canvas,
-        grid_position: (u64, u64),
-        cell_width: u64,
+        grid_position: GridPos<i32>,
+        cell_width: i32,
         style: &Option<Arc<Style>>,
     ) -> BackgroundInfo {
         tracy_zone!("draw_background");
@@ -161,7 +149,7 @@ impl GridRenderer {
 
         let custom_color = paint.color4f() != self.default_style.colors.background.unwrap();
         if custom_color {
-            canvas.draw_rect(region, &paint);
+            canvas.draw_rect(to_skia_rect(&region), &paint);
         }
 
         BackgroundInfo {
@@ -176,42 +164,34 @@ impl GridRenderer {
         &mut self,
         canvas: &Canvas,
         text: &str,
-        grid_position: (u64, u64),
-        cell_width: u64,
+        grid_position: GridPos<i32>,
+        cell_width: i32,
         style: &Option<Arc<Style>>,
     ) -> bool {
         tracy_zone!("draw_foreground");
-        let (x, y) = grid_position * self.font_dimensions;
-        let width = cell_width * self.font_dimensions.width;
+        let pos = grid_position.cast() * self.grid_scale;
+        let size = GridSize::new(cell_width, 0).cast() * self.grid_scale;
+        let width = size.width;
 
         let style = style.as_ref().unwrap_or(&self.default_style);
         let mut drawn = false;
 
         // We don't want to clip text in the x position, only the y so we add a buffer of 1
         // character on either side of the region so that we clip vertically but not horizontally.
-        let (grid_x, grid_y) = grid_position;
-        let clip_position = (grid_x.saturating_sub(1), grid_y);
+        let clip_position = (grid_position.x.saturating_sub(1), grid_position.y).into();
         let region = self.compute_text_region(clip_position, cell_width + 2);
 
         if let Some(underline_style) = style.underline {
-            let line_position = self.shaper.underline_position();
-            let p1 = (
-                x as f32,
-                (y - line_position + self.font_dimensions.height) as f32,
-            );
-            let p2 = (
-                (x + width) as f32,
-                (y - line_position + self.font_dimensions.height) as f32,
-            );
+            let line_position = self.grid_scale.0.height - self.shaper.underline_position();
+            let p1 = pos + PixelVec::new(0.0, line_position);
+            let p2 = pos + PixelVec::new(width, line_position);
 
-            self.draw_underline(canvas, style, underline_style, p1.into(), p2.into());
+            self.draw_underline(canvas, style, underline_style, p1, p2);
             drawn = true;
         }
 
         canvas.save();
-        canvas.clip_rect(region, None, Some(false));
-
-        let y_adjustment = self.shaper.y_adjustment();
+        canvas.clip_rect(to_skia_rect(&region), None, Some(false));
 
         let mut paint = Paint::default();
         paint.set_anti_alias(false);
@@ -236,7 +216,10 @@ impl GridRenderer {
         let leading_space_bytes = text.len() - trimmed.len();
         let leading_spaces = text[..leading_space_bytes].chars().count();
         let trimmed = trimmed.trim_end();
-        let x_adjustment = leading_spaces as u64 * self.font_dimensions.width;
+        let adjustment = PixelVec::new(
+            leading_spaces as f32 * self.grid_scale.0.width,
+            self.shaper.y_adjustment(),
+        );
 
         if !trimmed.is_empty() {
             for blob in self
@@ -245,21 +228,17 @@ impl GridRenderer {
                 .iter()
             {
                 tracy_zone!("draw_text_blob");
-                canvas.draw_text_blob(
-                    blob,
-                    ((x + x_adjustment) as f32, (y + y_adjustment) as f32),
-                    &paint,
-                );
+                canvas.draw_text_blob(blob, to_skia_point(pos + adjustment), &paint);
                 drawn = true;
             }
         }
 
         if style.strikethrough {
-            let line_position = region.center_y();
+            let line_position = region.center().y;
             paint.set_color(style.special(&self.default_style.colors).to_color());
             canvas.draw_line(
-                (x as f32, line_position),
-                ((x + width) as f32, line_position),
+                (pos.x, line_position),
+                (pos.x + width, line_position),
                 &paint,
             );
             drawn = true;
@@ -274,8 +253,8 @@ impl GridRenderer {
         canvas: &Canvas,
         style: &Arc<Style>,
         underline_style: UnderlineStyle,
-        p1: Point,
-        p2: Point,
+        p1: PixelPos<f32>,
+        p2: PixelPos<f32>,
     ) {
         tracy_zone!("draw_underline");
         canvas.save();
@@ -295,11 +274,11 @@ impl GridRenderer {
         match underline_style {
             UnderlineStyle::Underline => {
                 underline_paint.set_path_effect(None);
-                canvas.draw_line(p1, p2, &underline_paint);
+                canvas.draw_line(to_skia_point(p1), to_skia_point(p2), &underline_paint);
             }
             UnderlineStyle::UnderDouble => {
                 underline_paint.set_path_effect(None);
-                canvas.draw_line(p1, p2, &underline_paint);
+                canvas.draw_line(to_skia_point(p1), to_skia_point(p2), &underline_paint);
                 let p1 = (p1.x, p1.y - 2.);
                 let p2 = (p2.x, p2.y - 2.);
                 canvas.draw_line(p1, p2, &underline_paint);
@@ -315,7 +294,7 @@ impl GridRenderer {
                 path.move_to(p1);
                 let mut i = p1.0;
                 let mut sin = -2. * stroke_width;
-                let increment = self.font_dimensions.width as f32 / 2.;
+                let increment = self.grid_scale.0.width / 2.;
                 while i < p2.0 {
                     sin *= -1.;
                     i += increment;
@@ -328,14 +307,14 @@ impl GridRenderer {
                     &[6.0 * stroke_width, 2.0 * stroke_width],
                     0.0,
                 ));
-                canvas.draw_line(p1, p2, &underline_paint);
+                canvas.draw_line(to_skia_point(p1), to_skia_point(p2), &underline_paint);
             }
             UnderlineStyle::UnderDot => {
                 underline_paint.set_path_effect(dash_path_effect::new(
                     &[1.0 * stroke_width, 1.0 * stroke_width],
                     0.0,
                 ));
-                canvas.draw_line(p1, p2, &underline_paint);
+                canvas.draw_line(to_skia_point(p1), to_skia_point(p2), &underline_paint);
             }
         }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -18,8 +18,8 @@ use winit::event_loop::EventLoopProxy;
 use crate::{bridge::NeovimWriter, window::UserEvent};
 pub use from_value::ParseFromValue;
 pub use window_size::{
-    load_last_window_settings, save_window_size, PersistentWindowSettings, DEFAULT_GRID_SIZE,
-    MAX_GRID_SIZE, MIN_GRID_SIZE,
+    clamped_grid_size, load_last_window_settings, save_window_size, PersistentWindowSettings,
+    DEFAULT_GRID_SIZE, MIN_GRID_SIZE,
 };
 
 mod config;

--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -4,25 +4,14 @@ use serde::{Deserialize, Serialize};
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 
 use crate::{
-    dimensions::Dimensions, settings::SETTINGS, window::WindowSettings, window::WinitWindowWrapper,
+    settings::SETTINGS, units::GridSize, window::WindowSettings, window::WinitWindowWrapper,
 };
 
 const SETTINGS_FILE: &str = "neovide-settings.json";
 
-pub const DEFAULT_GRID_SIZE: Dimensions = Dimensions {
-    width: 100,
-    height: 50,
-};
-
-pub const MIN_GRID_SIZE: Dimensions = Dimensions {
-    width: 20,
-    height: 6,
-};
-
-pub const MAX_GRID_SIZE: Dimensions = Dimensions {
-    width: 10000,
-    height: 1000,
-};
+pub const DEFAULT_GRID_SIZE: GridSize<u32> = GridSize::new(100, 50);
+pub const MIN_GRID_SIZE: GridSize<u32> = GridSize::new(20, 6);
+pub const MAX_GRID_SIZE: GridSize<u32> = GridSize::new(10000, 1000);
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PersistentWindowSettings {
@@ -33,7 +22,7 @@ pub enum PersistentWindowSettings {
         #[serde(default)]
         pixel_size: Option<PhysicalSize<u32>>,
         #[serde(default)]
-        grid_size: Option<Dimensions>,
+        grid_size: Option<GridSize<u32>>,
     },
 }
 
@@ -103,4 +92,8 @@ pub fn save_window_size(window_wrapper: &WinitWindowWrapper) {
     log::debug!("Saved Window Settings: {}", json);
     std::fs::write(&settings_path, json)
         .unwrap_or_else(|_| panic!("Can't write to {settings_path:?}"));
+}
+
+pub fn clamped_grid_size(grid_size: &GridSize<u32>) -> GridSize<u32> {
+    grid_size.clamp(MIN_GRID_SIZE, MAX_GRID_SIZE)
 }

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,0 +1,109 @@
+use std::ops::{Div, Mul};
+
+use euclid::{Box2D, Point2D, Size2D, Vector2D};
+
+/// Coordinates in grid units (multiplies of the font size)
+pub struct Grid;
+/// Coordinates in pixel units
+pub struct Pixel;
+
+pub type GridVec<T> = Vector2D<T, Grid>;
+pub type PixelVec<T> = Vector2D<T, Pixel>;
+
+pub type GridSize<T> = Size2D<T, Grid>;
+pub type PixelSize<T> = Size2D<T, Pixel>;
+
+pub type GridPos<T> = Point2D<T, Grid>;
+pub type PixelPos<T> = Point2D<T, Pixel>;
+
+pub type GridRect<T> = Box2D<T, Grid>;
+pub type PixelRect<T> = Box2D<T, Pixel>;
+
+pub fn to_skia_point(pos: PixelPos<f32>) -> skia_safe::Point {
+    skia_safe::Point::new(pos.x, pos.y)
+}
+
+pub fn to_skia_rect(rect: &PixelRect<f32>) -> skia_safe::Rect {
+    skia_safe::Rect {
+        left: rect.min.x,
+        top: rect.min.y,
+        right: rect.max.x,
+        bottom: rect.max.y,
+    }
+}
+
+// The Euclid library doesn't support two dimensional scales, so make our own simplified one
+#[derive(Copy, Clone)]
+pub struct GridScale(pub PixelSize<f32>);
+
+impl Mul<GridScale> for GridVec<f32> {
+    type Output = PixelVec<f32>;
+
+    #[inline]
+    fn mul(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.x * scale.0.width, self.y * scale.0.height)
+    }
+}
+
+impl Mul<GridScale> for GridSize<f32> {
+    type Output = PixelSize<f32>;
+
+    #[inline]
+    fn mul(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.width * scale.0.width, self.height * scale.0.height)
+    }
+}
+
+impl Mul<GridScale> for GridPos<f32> {
+    type Output = PixelPos<f32>;
+
+    #[inline]
+    fn mul(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.x * scale.0.width, self.y * scale.0.height)
+    }
+}
+
+impl Mul<GridScale> for GridRect<f32> {
+    type Output = PixelRect<f32>;
+
+    #[inline]
+    fn mul(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.min * scale, self.max * scale)
+    }
+}
+
+impl Div<GridScale> for PixelVec<f32> {
+    type Output = GridVec<f32>;
+
+    #[inline]
+    fn div(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.x / scale.0.width, self.y / scale.0.height)
+    }
+}
+
+impl Div<GridScale> for PixelSize<f32> {
+    type Output = GridSize<f32>;
+
+    #[inline]
+    fn div(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.width / scale.0.width, self.height / scale.0.height)
+    }
+}
+
+impl Div<GridScale> for PixelPos<f32> {
+    type Output = GridPos<f32>;
+
+    #[inline]
+    fn div(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.x / scale.0.width, self.y / scale.0.height)
+    }
+}
+
+impl Div<GridScale> for PixelRect<f32> {
+    type Output = GridRect<f32>;
+
+    #[inline]
+    fn div(self, scale: GridScale) -> Self::Output {
+        Self::Output::new(self.min / scale, self.max / scale)
+    }
+}

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -38,14 +38,14 @@ use update_loop::UpdateLoop;
 
 use crate::{
     cmd_line::{CmdLineSettings, GeometryArgs},
-    dimensions::Dimensions,
     frame::Frame,
     renderer::{build_window_config, DrawCommand, WindowConfig},
     running_tracker::*,
     settings::{
-        load_last_window_settings, save_window_size, FontSettings, HotReloadConfigs,
-        PersistentWindowSettings, SettingsChanged, SETTINGS,
+        clamped_grid_size, load_last_window_settings, save_window_size, FontSettings,
+        HotReloadConfigs, PersistentWindowSettings, SettingsChanged, SETTINGS,
     },
+    units::GridSize,
 };
 pub use error_window::show_error_window;
 pub use settings::{WindowSettings, WindowSettingsChanged};
@@ -244,7 +244,7 @@ pub fn create_window(
 pub enum WindowSize {
     Size(PhysicalSize<u32>),
     Maximized,
-    Grid(Dimensions),
+    Grid(GridSize<u32>),
     NeovimGrid, // The geometry is read from init.vim/lua
 }
 
@@ -255,7 +255,10 @@ pub fn determine_window_size(window_settings: Option<&PersistentWindowSettings>)
         GeometryArgs {
             grid: Some(Some(dimensions)),
             ..
-        } => WindowSize::Grid(dimensions.clamped_grid_size()),
+        } => WindowSize::Grid(clamped_grid_size(&GridSize::new(
+            dimensions.width.try_into().unwrap(),
+            dimensions.height.try_into().unwrap(),
+        ))),
         GeometryArgs {
             grid: Some(None), ..
         } => WindowSize::NeovimGrid,


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This is a big refactor that adds typesafe units almost everywhere, using the [euclid](https://docs.rs/euclid/latest/euclid/) library. The code has also been simplified in a lot of places by using primitives provided by euclid instead of individual points.

Furthermore, many of the type casts have been replaced by safer alternatives, like like `try_into().unwrap()`, crashing instead of doing something completely unexpected. In some places where invalid values are more expected, clamping is used instead.

Most calculations are also done using either floating point or signed numbers, which reduces the need for type casts, so a lot of those could be deleted.

This is a lot of changes, but the code is much easier to read and understand IMO now. It's also safer, since you usually get a compilation error instead of runtime problem if you for example think that a value is using grid coordinates, while it's in fact is using pixel coordinates. It will also help with the support for fractional grid sizes, and arbitrary font sizes. In fact, most of the coordinates are already using fractional pixels, so the change will not be that big.

This is still draft, since it includes:
* https://github.com/neovide/neovide/pull/2483

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
