### PR TITLE
Address viewport margin regression by sorting DrawCommand batches

### DIFF
--- a/src/editor/draw_command_batcher.rs
+++ b/src/editor/draw_command_batcher.rs
@@ -20,7 +20,7 @@ impl DrawCommandBatcher {
     }
 
     pub fn send_batch(&self, proxy: &EventLoopProxy<UserEvent>) {
-        let mut batch: Vec<DrawCommand> = self.batch.borrow_mut().split_off(0).into();
+        let mut batch: Vec<DrawCommand> = self.batch.borrow_mut().split_off(0);
         // Order the draw command batches such that window draw commands are handled first
         // by grid id, and then by the draw command such that they are positioned first.
         batch.sort_by_key(|draw_command| match draw_command {

--- a/src/editor/draw_command_batcher.rs
+++ b/src/editor/draw_command_batcher.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::{editor::DrawCommand, window::UserEvent};
+use crate::{editor::DrawCommand, renderer::WindowDrawCommand, window::UserEvent};
 
 use winit::event_loop::EventLoopProxy;
 
@@ -20,6 +20,20 @@ impl DrawCommandBatcher {
     }
 
     pub fn send_batch(&self, proxy: &EventLoopProxy<UserEvent>) {
-        let _ = proxy.send_event(self.batch.borrow_mut().split_off(0).into());
+        let mut batch: Vec<DrawCommand> = self.batch.borrow_mut().split_off(0).into();
+        // Order the draw command batches such that window draw commands are handled first
+        // by grid id, and then by the draw command such that they are positioned first.
+        batch.sort_by_key(|draw_command| match draw_command {
+            DrawCommand::CloseWindow(_) => 0,
+            DrawCommand::Window { grid_id, command } => {
+                (grid_id + 1) * 100
+                    + match command {
+                        WindowDrawCommand::Position { .. } => 0,
+                        _ => 1,
+                    }
+            }
+            _ => 200,
+        });
+        proxy.send_event(batch.into()).ok();
     }
 }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -321,17 +321,4 @@ impl Window {
     pub fn close(&self) {
         self.send_command(WindowDrawCommand::Close);
     }
-
-    pub fn update_viewport(&self, scroll_delta: f64) {
-        self.send_command(WindowDrawCommand::Viewport { scroll_delta });
-    }
-
-    pub fn update_viewport_margins(&self, top: u64, bottom: u64, left: u64, right: u64) {
-        self.send_command(WindowDrawCommand::ViewportMargins {
-            top,
-            bottom,
-            left,
-            right,
-        });
-    }
 }

--- a/src/renderer/vsync/vsync_win_swap_chain.rs
+++ b/src/renderer/vsync/vsync_win_swap_chain.rs
@@ -33,6 +33,9 @@ impl VSyncWinSwapChain {
         };
         let (sender, receiver) = channel();
         let vsync_thread = spawn(move || {
+            // Removing this asignment causes a build failure complaining that
+            // `*mut c_void` cannot be sent between threads safely.
+            #[allow(clippy::redundant_locals)]
             let handle = handle;
             while let Ok(Message::RequestRedraw) = receiver.recv() {
                 tracy_zone!("wait for vblank");


### PR DESCRIPTION
According to neovim folks, they can and do send redraw events in any order so long as its in the same batch. This PR addresses our first issue to come of that by manually sorting the batches so that our position WindowDrawCommands always happen before all others.

Fixes https://github.com/neovide/neovide/issues/2464

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
