### PR TITLE
fix: clipping rect regression

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -209,10 +209,7 @@ impl Renderer {
                 // Group floating windows by consecutive z indices
                 if zindex - last_zindex > 1 && !current_windows.is_empty() {
                     for windows in group_windows(current_windows, grid_scale) {
-                        floating_layers.push(FloatingLayer {
-                            sort_order: base_zindex,
-                            windows,
-                        });
+                        floating_layers.push(FloatingLayer { windows });
                     }
                     current_windows = vec![];
                 }
@@ -226,10 +223,7 @@ impl Renderer {
 
             if !current_windows.is_empty() {
                 for windows in group_windows(current_windows, grid_scale) {
-                    floating_layers.push(FloatingLayer {
-                        sort_order: base_zindex,
-                        windows,
-                    });
+                    floating_layers.push(FloatingLayer { windows });
                 }
             }
 

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -102,7 +102,6 @@ impl<'w> FloatingLayer<'w> {
             ret.push(WindowDrawDetails {
                 id: window.id,
                 region: regions[i],
-                floating_order: window.anchor_info.as_ref().map(|v| v.sort_order),
             });
         });
 

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -16,7 +16,6 @@ struct LayerWindow<'w> {
 }
 
 pub struct FloatingLayer<'w> {
-    pub sort_order: u64,
     pub windows: Vec<&'w mut RenderedWindow>,
 }
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -663,9 +663,12 @@ impl RenderedWindow {
     fn iter_scrollable_lines(&self) -> impl Iterator<Item = (isize, &Rc<RefCell<Line>>)> {
         let scroll_offset_lines = self.scroll_animation.position.floor();
         let scroll_offset_lines = scroll_offset_lines as isize;
+        let inner_size = self.actual_lines.len() as isize
+            - self.viewport_margins.top as isize
+            - self.viewport_margins.bottom as isize;
 
-        let line_indices = if !self.scrollback_lines.is_empty() {
-            0..self.grid_size.height as isize + 1
+        let line_indices = if inner_size > 0 {
+            0..inner_size + 1
         } else {
             0..0
         };

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -103,7 +103,6 @@ pub struct RenderedWindow {
 pub struct WindowDrawDetails {
     pub id: u64,
     pub region: PixelRect<f32>,
-    pub floating_order: Option<u64>,
 }
 
 impl WindowDrawDetails {
@@ -394,7 +393,6 @@ impl RenderedWindow {
         WindowDrawDetails {
             id: self.id,
             region: pixel_region_box,
-            floating_order: self.anchor_info.as_ref().map(|v| v.sort_order),
         }
     }
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -723,13 +723,10 @@ impl RenderedWindow {
     /// the window.
     pub fn inner_region(&self, pixel_region: PixelRect<f32>, grid_scale: GridScale) -> Rect {
         let line_height = grid_scale.height();
+
         let adjusted_region = PixelRect::new(
             pixel_region.min + PixelVec::new(0., self.viewport_margins.top as f32 * line_height),
-            pixel_region.max
-                + PixelVec::new(
-                    0.,
-                    (self.viewport_margins.top - self.viewport_margins.bottom) as f32 * line_height,
-                ),
+            pixel_region.max - PixelVec::new(0., self.viewport_margins.bottom as f32 * line_height),
         );
 
         to_skia_rect(&adjusted_region)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This fixes the cacluation of the inner region clipping rectangle, which caused this regression.
 * https://github.com/neovide/neovide/pull/2467#issuecomment-2067342150

It also reduces the range of the scrollable lines iterator, which previously did not take border into account. That's not really a problem in practice, since we always need to iterate one more line than the actual grid size anyway, and the clipping rect will take care of clipping it correctly. But it could enable transparency modes when no transparent lines are visible for example.

The `floating_order` field was removed again, since it's unused and causing clippy warnings.
The `sort_order` field was also unused and removed

## Did this PR introduce a breaking change? 
- No
