### PR TITLE
fix: fractional border positions

### DIFF
--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -712,7 +712,7 @@ impl RenderedWindow {
             let mut matrix = Matrix::new_identity();
             matrix.set_translate((
                 pixel_region.min.x,
-                pixel_region.min.y + (i * grid_scale.height() as isize) as f32,
+                pixel_region.min.y + (i as f32 * grid_scale.height()),
             ));
             (matrix, line)
         })


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
https://github.com/neovide/neovide/pull/2485 did not calculate the position of the borders properly, which led to issues like this https://github.com/neovide/neovide/pull/2485#issuecomment-2073429344. This fixes that.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
