### PR TITLE
Migrate dependency from `winapi` to `windows`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -726,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "4556222738635b7a3417ae6130d8f52201e45a0c4d1a907f0826383adb5f85e7"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1289,9 +1289,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1436,7 +1436,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shlex",
- "simple_moving_average",
  "skia-safe",
  "spin_sleep",
  "strum",
@@ -1729,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1739,15 +1738,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2020,6 +2019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,18 +2182,18 @@ checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2257,15 +2265,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simple_moving_average"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4b144ad185430cd033299e2c93e465d5a7e65fbb858593dc57181fa13cd310"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "siphasher"
@@ -2639,7 +2638,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.6",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -3313,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,24 +226,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -616,19 +610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,15 +781,6 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "fsevent-sys"
@@ -1117,16 +1089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "image"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,9 +1184,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -1414,7 +1376,7 @@ dependencies = [
  "ndk-sys",
  "num_enum",
  "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "thiserror",
 ]
 
@@ -1486,12 +1448,10 @@ dependencies = [
  "tracy-client-sys",
  "unicode-segmentation",
  "which 6.0.1",
- "winapi",
  "windows",
  "windows-registry",
  "winit",
  "winres",
- "wio",
  "wslpath-rs",
  "xdg",
 ]
@@ -1797,12 +1757,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -2033,9 +1987,9 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "raw-window-handle"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
+checksum = "8cc3bcbdb1ddfc11e700e62968e6b4cc9c75bb466464ad28fb61c5b2c964418b"
 
 [[package]]
 name = "read-fonts"
@@ -2106,21 +2060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.14",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,46 +2094,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -2216,6 +2124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96560eea317a9cc4e0bb1f6a2c93c09a19b8c4fc5cb3fcc0ec1c094cd783e2"
+dependencies = [
+ "sdd",
 ]
 
 [[package]]
@@ -2248,6 +2165,12 @@ dependencies = [
  "smithay-client-toolkit",
  "tiny-skia",
 ]
+
+[[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "serde"
@@ -2291,23 +2214,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+checksum = "adb86f9315df5df6a70eae0cc22395a44e544a0d8897586820770a35ede74449"
 dependencies = [
- "dashmap",
  "futures 0.3.30",
- "lazy_static",
  "log",
+ "once_cell",
  "parking_lot",
+ "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
+checksum = "a9bb72430492e9549b0c4596725c0f82729bff861c45aa8099c0a8e67fc3b721"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2322,9 +2245,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -2337,9 +2260,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple_moving_average"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd19d3808aad2604c824399fd270260d634678b010328c9d96851bb0fb63121"
+checksum = "3a4b144ad185430cd033299e2c93e465d5a7e65fbb858593dc57181fa13cd310"
 dependencies = [
  "num-traits",
 ]
@@ -2352,33 +2275,31 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skia-bindings"
-version = "0.68.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af1b86d01552a56d70b515e2bc1af9123acffcc679a7410010e2648f59fbec3"
+checksum = "43555ec5d87ee8c14273f3045bf09504a58c6afe842c51d1593b62abf095aa96"
 dependencies = [
  "bindgen",
  "cc",
  "flate2",
- "heck 0.4.1",
+ "heck 0.5.0",
  "lazy_static",
  "regex",
  "serde_json",
  "tar",
  "toml 0.8.12",
- "ureq",
 ]
 
 [[package]]
 name = "skia-safe"
-version = "0.68.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed678303df69daf5b666faf477800ff7fcb7b67316b10a94c31d748d42dd5a83"
+checksum = "c431cc5c1ca6008199bf2e849083dd05539c9f2a2ffc1c24b521e6e0ef2c31a7"
 dependencies = [
  "bitflags 2.5.0",
  "lazy_static",
  "skia-bindings",
- "winapi",
- "wio",
+ "windows",
 ]
 
 [[package]]
@@ -2452,12 +2373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spin_sleep"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,12 +2414,6 @@ dependencies = [
  "rustversion",
  "syn 2.0.60",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swash"
@@ -2550,18 +2459,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,21 +2532,6 @@ dependencies = [
  "bytemuck",
  "strict-num",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2781,15 +2675,9 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "typed-path"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a90726108dab678edab76459751e1cc7c597c3484a6384d6423191255fa641b"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "668404597c2c687647f6f8934f97c280fd500db28557f52b07c56b92d3dc500a"
 
 [[package]]
 name = "unicode-ident"
@@ -2798,53 +2686,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "rustls-webpki",
- "url",
- "webpki-roots",
-]
-
-[[package]]
-name = "url"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "utf8parse"
@@ -3076,15 +2921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,11 +2962,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3444,7 +3280,7 @@ dependencies = [
  "orbclient",
  "percent-encoding",
  "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle 0.6.1",
  "redox_syscall 0.3.5",
  "rustix",
  "sctk-adwaita",
@@ -3498,15 +3334,6 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
-name = "wio"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "wslpath-rs"
@@ -3626,9 +3453,3 @@ dependencies = [
  "quote",
  "syn 2.0.60",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ rmpv = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 shlex = "1.1.0"
-simple_moving_average = "0.1.2"
+simple_moving_average = "1.0.2"
 spin_sleep = "1.1.1"
 strum = { version = "0.26.2", features = ["derive"] }
 swash = { version = "0.1.8", default-features = false }
@@ -85,37 +85,23 @@ scoped-env = "2.1.0"
 serial_test = "3.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-# NOTE: winerror is only needed because the indirect dependency parity-tokio-ipc does not set it even if it uses it
-winapi = { version = "0.3.9", features = [
-    "d3d12",
-    "d3d12sdklayers",
-    "dwmapi",
-    "dxgi",
-    "dxgi1_2",
-    "dxgi1_3",
-    "dxgi1_4",
-    "dxgi1_6",
-    "impl-default",
-    "profileapi",
-    "synchapi",
-    "wincon",
-    "winerror",
-    "winuser",
-] }
-# for ComPtr
-wio = { version = "0.2.2" }
 wslpath-rs = "0.1"
-skia-safe = { version = "0.68.0", features = ["gl", "d3d", "textlayout"] }
+skia-safe = { version = "0.73.0", features = ["gl", "d3d", "textlayout"] }
 windows = { version = "0.56.0", features = [
+    "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Direct3D12",
+    "Win32_Graphics_Dwm",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Dxgi_Common",
     "Win32_Security",
-    "Win32_System_LibraryLoader",
-    "Win32_System_Registry",
+    "Win32_System_Performance",
+    "Win32_System_Threading",
     "Win32_UI_HiDpi",
 ] }
 windows-registry = "0.1.1"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-skia-safe = { version = "0.68.0", features = ["gl", "textlayout"] }
+skia-safe = { version = "0.73.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 icrate = { version = "0.0.4", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ rmpv = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 shlex = "1.1.0"
-simple_moving_average = "1.0.2"
 spin_sleep = "1.1.1"
 strum = { version = "0.26.2", features = ["derive"] }
 swash = { version = "0.1.8", default-features = false }

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -22,7 +22,7 @@ pub fn create_nvim_command() -> Result<TokioCommand> {
     cmd.stderr(Stdio::inherit());
 
     #[cfg(windows)]
-    cmd.creation_flags(winapi::um::winbase::CREATE_NO_WINDOW);
+    cmd.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
 
     Ok(cmd)
 }
@@ -88,14 +88,14 @@ fn create_platform_shell_command(command: &str, args: &[&str]) -> StdCommand {
             result.args(["$SHELL", "-lc"]);
             result.arg(format!("{} {}", command, args.join(" ")));
 
-            result.creation_flags(winapi::um::winbase::CREATE_NO_WINDOW);
+            result.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
 
             result
         } else {
             let mut result = StdCommand::new(command);
             result.args(args);
 
-            result.creation_flags(winapi::um::winbase::CREATE_NO_WINDOW);
+            result.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
 
             result
         }

--- a/src/profiling/d3d.rs
+++ b/src/profiling/d3d.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::VecDeque,
-    ffi::c_void,
+    ffi::{c_void, CString},
     mem,
     ptr::null_mut,
     slice::from_raw_parts,
@@ -10,19 +10,16 @@ use std::{
 use windows::core::Interface;
 use windows::Win32::Graphics::Direct3D12::{
     ID3D12CommandAllocator, ID3D12CommandQueue, ID3D12Device, ID3D12Fence,
-    ID3D12GraphicsCommandList, ID3D12QueryHeap, ID3D12Resource, D3D12_COMMAND_LIST_TYPE_COPY,
-    D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_CPU_PAGE_PROPERTY_UNKNOWN, D3D12_FEATURE_D3D12_OPTIONS3,
-    D3D12_FEATURE_DATA_D3D12_OPTIONS3, D3D12_FENCE_FLAG_NONE, D3D12_HEAP_FLAG_NONE,
-    D3D12_HEAP_PROPERTIES, D3D12_HEAP_TYPE_READBACK, D3D12_MEMORY_POOL_UNKNOWN,
-    D3D12_QUERY_HEAP_DESC, D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP,
+    ID3D12GraphicsCommandList, ID3D12PipelineState, ID3D12QueryHeap, ID3D12Resource,
+    D3D12_COMMAND_LIST_TYPE_COPY, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+    D3D12_FEATURE_D3D12_OPTIONS3, D3D12_FEATURE_DATA_D3D12_OPTIONS3, D3D12_FENCE_FLAG_NONE,
+    D3D12_HEAP_FLAG_NONE, D3D12_HEAP_PROPERTIES, D3D12_HEAP_TYPE_READBACK,
+    D3D12_MEMORY_POOL_UNKNOWN, D3D12_QUERY_HEAP_DESC, D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP,
     D3D12_QUERY_HEAP_TYPE_TIMESTAMP, D3D12_QUERY_TYPE_TIMESTAMP, D3D12_RANGE, D3D12_RESOURCE_DESC,
     D3D12_RESOURCE_DIMENSION_BUFFER, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COPY_DEST,
     D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
 };
-use windows::Win32::Graphics::{
-    Direct3D12::ID3D12PipelineState,
-    Dxgi::Common::{DXGI_FORMAT_UNKNOWN, DXGI_SAMPLE_DESC},
-};
+use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_UNKNOWN, DXGI_SAMPLE_DESC};
 use windows::Win32::System::Performance::QueryPerformanceFrequency;
 
 use tracy_client_sys::{
@@ -261,10 +258,10 @@ pub fn create_d3d_gpu_context(name: &str, renderer: &D3DSkiaRenderer) -> Box<dyn
         flags: GpuContextFlags::GpuContextCalibration as u8,
         type_: GpuContextType::Direct3D12 as u8,
     };
-    // let namestring = CString::new(name).unwrap();
+    let namestring = CString::new(name).unwrap();
     let name_data = ___tracy_gpu_context_name_data {
         context: ctx_id,
-        name: name.as_ptr() as *const i8,
+        name: namestring.as_ptr(),
         len: name.len() as u16,
     };
     unsafe {

--- a/src/profiling/profiling_enabled.rs
+++ b/src/profiling/profiling_enabled.rs
@@ -19,6 +19,7 @@ unsafe impl Send for _LocationData {}
 unsafe impl Sync for _LocationData {}
 
 #[allow(unconditional_panic)]
+#[allow(clippy::out_of_bounds_indexing)]
 const fn illegal_null_in_string() {
     [][0]
 }

--- a/src/renderer/d3d.rs
+++ b/src/renderer/d3d.rs
@@ -1,6 +1,3 @@
-use std::ptr::{null, null_mut};
-
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use skia_safe::{
     gpu::{
         d3d::{BackendContext, TextureResourceInfo},
@@ -10,176 +7,108 @@ use skia_safe::{
     surface::BackendSurfaceAccess,
     Canvas, ColorType, Surface,
 };
-use winapi::{
-    shared::{
-        dxgi::{
-            IDXGIAdapter1, DXGI_ADAPTER_DESC1, DXGI_ADAPTER_FLAG_SOFTWARE,
-            DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT, DXGI_SWAP_EFFECT_FLIP_DISCARD,
-        },
-        dxgi1_2::{DXGI_ALPHA_MODE_UNSPECIFIED, DXGI_SCALING_NONE, DXGI_SWAP_CHAIN_DESC1},
-        dxgi1_3::{CreateDXGIFactory2, DXGI_CREATE_FACTORY_DEBUG},
-        dxgi1_4::{IDXGIFactory4, IDXGISwapChain3},
-        dxgi1_6::{IDXGIFactory6, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE},
-        dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM,
-        dxgitype::{DXGI_SAMPLE_DESC, DXGI_USAGE_RENDER_TARGET_OUTPUT},
-        guiddef::REFIID,
-        windef::HWND,
-        winerror::SUCCEEDED,
-    },
-    um::{
-        d3d12::{
-            D3D12CreateDevice, D3D12GetDebugInterface, ID3D12CommandQueue, ID3D12Device,
-            ID3D12Fence, ID3D12Resource, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_QUEUE_DESC,
-            D3D12_COMMAND_QUEUE_FLAG_NONE, D3D12_FENCE_FLAG_NONE, D3D12_RESOURCE_STATE_PRESENT,
-        },
-        d3d12sdklayers::ID3D12Debug,
-        d3dcommon::{D3D_FEATURE_LEVEL, D3D_FEATURE_LEVEL_11_0},
-        handleapi::CloseHandle,
-        synchapi::{CreateEventA as CreateEvent, WaitForSingleObjectEx},
-        unknwnbase::IUnknown,
-        winbase::INFINITE,
-        winnt::{HANDLE, HRESULT},
-    },
-    Interface,
+use windows::core::{Interface, Result, PCWSTR};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, HWND};
+use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
+use windows::Win32::Graphics::Direct3D12::{
+    D3D12CreateDevice, D3D12GetDebugInterface, ID3D12CommandQueue, ID3D12Debug, ID3D12Device,
+    ID3D12Fence, ID3D12Resource, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_QUEUE_DESC,
+    D3D12_COMMAND_QUEUE_FLAG_NONE, D3D12_FENCE_FLAG_NONE, D3D12_RESOURCE_STATE_PRESENT,
 };
-use winit::{event_loop::EventLoopProxy, window::Window};
-use wio::com::ComPtr;
+use windows::Win32::Graphics::Dxgi::Common::{
+    DXGI_ALPHA_MODE_UNSPECIFIED, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC,
+};
+use windows::Win32::Graphics::Dxgi::{
+    CreateDXGIFactory2, IDXGIAdapter1, IDXGIFactory4, IDXGISwapChain1, IDXGISwapChain3,
+    DXGI_ADAPTER_FLAG, DXGI_ADAPTER_FLAG_NONE, DXGI_ADAPTER_FLAG_SOFTWARE,
+    DXGI_CREATE_FACTORY_DEBUG, DXGI_SCALING_NONE, DXGI_SWAP_CHAIN_DESC1,
+    DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT, DXGI_SWAP_EFFECT_FLIP_DISCARD,
+    DXGI_USAGE_RENDER_TARGET_OUTPUT,
+};
+use windows::Win32::System::Threading::{CreateEventW, WaitForSingleObjectEx, INFINITE};
+use winit::{
+    event_loop::EventLoopProxy,
+    raw_window_handle::{HasWindowHandle, RawWindowHandle},
+    window::Window,
+};
 
 use super::{vsync::VSyncWinSwapChain, SkiaRenderer, VSync};
 #[cfg(feature = "gpu_profiling")]
 use crate::profiling::{d3d::create_d3d_gpu_context, GpuCtx};
 use crate::{profiling::tracy_gpu_zone, window::UserEvent};
 
-const D3D_FEATUREL_LEVEL: D3D_FEATURE_LEVEL = D3D_FEATURE_LEVEL_11_0;
+fn get_hardware_adapter(factory: &IDXGIFactory4) -> Result<IDXGIAdapter1> {
+    for i in 0.. {
+        let adapter = unsafe { factory.EnumAdapters1(i)? };
 
-pub fn call_com_fn<T0, T1, F>(fun: F) -> Result<ComPtr<T1>, ()>
-where
-    T1: Interface,
-    F: FnOnce(&mut *mut T0, REFIID) -> HRESULT,
-{
-    let mut ptr = null_mut();
-    let res = fun(&mut ptr, &T1::uuidof());
-    if SUCCEEDED(res) {
-        Ok(unsafe { ComPtr::from_raw(ptr as *mut T1) })
-    } else {
-        Err(())
-    }
-}
+        let mut desc = Default::default();
+        unsafe { adapter.GetDesc1(&mut desc)? };
 
-fn is_adapter_suitable(adapter: *mut IDXGIAdapter1) -> bool {
-    let mut desc = DXGI_ADAPTER_DESC1::default();
-    if SUCCEEDED(unsafe { (*adapter).GetDesc1(&mut desc) }) {
-        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) == DXGI_ADAPTER_FLAG_SOFTWARE {
-            // Don't select the Basic Render Driver adapter.
-            false
-        } else {
-            // Check to see whether the adapter supports Direct3D 12, but don't create the
-            // actual device yet.
-            unsafe {
-                SUCCEEDED(D3D12CreateDevice(
-                    adapter as *mut IUnknown,
-                    D3D_FEATUREL_LEVEL,
-                    &ID3D12Device::uuidof(),
-                    null_mut(),
-                ))
-            }
+        if (DXGI_ADAPTER_FLAG(desc.Flags as i32) & DXGI_ADAPTER_FLAG_SOFTWARE)
+            != DXGI_ADAPTER_FLAG_NONE
+        {
+            continue;
         }
-    } else {
-        false
-    }
-}
 
-fn find_first_suitable(
-    enumerator: &dyn Fn(u32) -> Result<ComPtr<IDXGIAdapter1>, ()>,
-) -> Result<ComPtr<IDXGIAdapter1>, ()> {
-    let mut adapter_index = 0;
-    loop {
-        if let Ok(adapter) = enumerator(adapter_index) {
-            if is_adapter_suitable(adapter.as_raw()) {
-                break Ok(adapter);
-            }
-        } else {
-            break Err(());
+        if unsafe {
+            D3D12CreateDevice(
+                &adapter,
+                D3D_FEATURE_LEVEL_11_0,
+                &mut Option::<ID3D12Device>::None,
+            )
+            .is_ok()
+        } {
+            return Ok(adapter);
         }
-        adapter_index += 1;
     }
-}
 
-// Helper function for acquiring the first available hardware adapter that supports Direct3D 12.
-// If no such adapter can be found, *ppAdapter will be set to nullptr.
-fn get_hardware_adapter(factory: &ComPtr<IDXGIFactory4>) -> Result<ComPtr<IDXGIAdapter1>, ()> {
-    let adapter = if let Ok(factory6) = factory.cast::<IDXGIFactory6>() {
-        find_first_suitable(&|index: u32| -> Result<ComPtr<IDXGIAdapter1>, ()> {
-            call_com_fn(|adapter, id| unsafe {
-                factory6.EnumAdapterByGpuPreference(
-                    index,
-                    DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
-                    id,
-                    adapter,
-                )
-            })
-        })
-    } else {
-        Err(())
-    };
-
-    if adapter.is_err() {
-        find_first_suitable(&|index: u32| -> Result<ComPtr<IDXGIAdapter1>, ()> {
-            call_com_fn(|adapter, _| unsafe { factory.EnumAdapters(index, adapter) })
-        })
-    } else {
-        adapter
-    }
+    unreachable!()
 }
 
 pub struct D3DSkiaRenderer {
     gr_context: DirectContext,
-    swap_chain: ComPtr<IDXGISwapChain3>,
+    swap_chain: IDXGISwapChain3,
     swap_chain_desc: DXGI_SWAP_CHAIN_DESC1,
     swap_chain_waitable: HANDLE,
-    pub command_queue: ComPtr<ID3D12CommandQueue>,
-    buffers: Vec<ComPtr<ID3D12Resource>>,
+    pub command_queue: ID3D12CommandQueue,
+    buffers: Vec<ID3D12Resource>,
     surfaces: Vec<Surface>,
     fence_values: Vec<u64>,
-    fence: ComPtr<ID3D12Fence>,
+    fence: ID3D12Fence,
     fence_event: HANDLE,
     frame_swapped: bool,
     frame_index: usize,
     _backend_context: BackendContext,
-    pub device: ComPtr<ID3D12Device>,
-    _adapter: ComPtr<IDXGIAdapter1>,
+    pub device: ID3D12Device,
+    _adapter: IDXGIAdapter1,
     window: Window,
 }
 
 impl D3DSkiaRenderer {
     pub fn new(window: Window) -> Self {
-        let mut factory_flags = 0;
-
-        let debug_controller: ComPtr<ID3D12Debug> = call_com_fn(|debug_controller, id| unsafe {
-            D3D12GetDebugInterface(id, debug_controller)
-        })
-        .expect("Failed to create Direct3D debug controller");
+        let mut debug_controller: Option<ID3D12Debug> = None;
         unsafe {
-            debug_controller.EnableDebugLayer();
-        }
-        // Enable additional debug layers.
-        factory_flags |= DXGI_CREATE_FACTORY_DEBUG;
+            D3D12GetDebugInterface(&mut debug_controller)
+                .expect("Failed to create Direct3D debug controller")
+        };
+        unsafe {
+            debug_controller
+                .expect("Failed to enable debug layer")
+                .EnableDebugLayer()
+        };
 
-        let dxgi_factory: ComPtr<IDXGIFactory4> =
-            call_com_fn(|factory, id| unsafe { CreateDXGIFactory2(factory_flags, id, factory) })
-                .expect("Failed to create DXGI factory");
+        let dxgi_factory: IDXGIFactory4 = unsafe {
+            CreateDXGIFactory2(DXGI_CREATE_FACTORY_DEBUG).expect("Failed to create DXGI factory")
+        };
         let adapter = get_hardware_adapter(&dxgi_factory)
             .expect("Failed to find any suitable Direct3D 12 adapters");
 
-        let device: ComPtr<ID3D12Device> = call_com_fn(|device, id| unsafe {
-            D3D12CreateDevice(
-                adapter.as_raw() as *mut IUnknown,
-                D3D_FEATUREL_LEVEL,
-                id,
-                device,
-            )
-        })
-        .expect("Failed to create a Direct3D 12 device");
+        let mut device: Option<ID3D12Device> = None;
+        unsafe {
+            D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_11_0, &mut device)
+                .expect("Failed to create a Direct3D 12 device")
+        };
+        let device = device.expect("Failed to create a Direct3D 12 device");
 
         // Describe and create the command queue.
         let queue_desc = D3D12_COMMAND_QUEUE_DESC {
@@ -187,9 +116,11 @@ impl D3DSkiaRenderer {
             Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
             ..Default::default()
         };
-        let command_queue: ComPtr<ID3D12CommandQueue> =
-            call_com_fn(|queue, id| unsafe { device.CreateCommandQueue(&queue_desc, id, queue) })
-                .expect("Failed to create the Direct3D command queue");
+        let command_queue: ID3D12CommandQueue = unsafe {
+            device
+                .CreateCommandQueue(&queue_desc)
+                .expect("Failed to create the Direct3D command queue")
+        };
 
         // Describe and create the swap chain.
         let swap_chain_desc = DXGI_SWAP_CHAIN_DESC1 {
@@ -206,44 +137,56 @@ impl D3DSkiaRenderer {
             Scaling: DXGI_SCALING_NONE,
             SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
             AlphaMode: DXGI_ALPHA_MODE_UNSPECIFIED,
-            Flags: DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT,
+            Flags: DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT.0 as u32,
         };
 
-        let hwnd = if let RawWindowHandle::Win32(handle) = window.raw_window_handle() {
+        let hwnd = if let RawWindowHandle::Win32(handle) = window
+            .window_handle()
+            .expect("Failed to fetch window handle")
+            .as_raw()
+        {
             handle.hwnd
         } else {
             panic!("Not a Win32 window");
         };
 
-        let swap_chain: ComPtr<IDXGISwapChain3> = call_com_fn(|swap_chain, _| unsafe {
-            dxgi_factory.CreateSwapChainForHwnd(
-                command_queue.as_raw() as *mut IUnknown,
-                hwnd as HWND,
-                &swap_chain_desc,
-                null(),
-                null_mut(),
-                swap_chain,
-            )
-        })
-        .expect("Failed to create the Direct3D swap chain");
+        let swap_chain = unsafe {
+            dxgi_factory
+                .CreateSwapChainForHwnd(
+                    &command_queue,
+                    HWND(hwnd.get()),
+                    &swap_chain_desc,
+                    None,
+                    None,
+                )
+                .expect("Failed to create the Direct3D swap chain")
+        };
+
+        let swap_chain: IDXGISwapChain3 =
+            IDXGISwapChain1::cast(&swap_chain).expect("Failed to cast");
 
         unsafe {
-            swap_chain.SetMaximumFrameLatency(1);
+            swap_chain
+                .SetMaximumFrameLatency(1)
+                .expect("Failed to set maximum frame latency")
         };
 
         let swap_chain_waitable = unsafe { swap_chain.GetFrameLatencyWaitableObject() };
-        if swap_chain_waitable.is_null() {
+        if swap_chain_waitable.is_invalid() {
             panic!("Failed to get swapchain waitable object");
         }
 
         // use a high value to make it easier to track these in PIX
         let fence_values = vec![10000; swap_chain_desc.BufferCount as usize];
-        let fence: ComPtr<ID3D12Fence> = call_com_fn(|fence, id| unsafe {
-            device.CreateFence(fence_values[0], D3D12_FENCE_FLAG_NONE, id, fence)
-        })
-        .expect("Failed to create fence");
+        let fence: ID3D12Fence = unsafe {
+            device
+                .CreateFence(fence_values[0], D3D12_FENCE_FLAG_NONE)
+                .expect("Failed to create fence")
+        };
 
-        let fence_event = unsafe { CreateEvent(null_mut(), false.into(), false.into(), null()) };
+        let fence_event = unsafe {
+            CreateEventW(None, false, false, PCWSTR::null()).expect("Failed to create event")
+        };
         let frame_index = unsafe { swap_chain.GetCurrentBackBufferIndex() as usize };
 
         let backend_context = BackendContext {
@@ -288,7 +231,8 @@ impl D3DSkiaRenderer {
 
                 // Schedule a Signal command in the queue.
                 self.command_queue
-                    .Signal(self.fence.as_raw(), current_fence_value);
+                    .Signal(&self.fence, current_fence_value)
+                    .unwrap();
 
                 // Update the frame index.
                 self.frame_index = self.swap_chain.GetCurrentBackBufferIndex() as usize;
@@ -297,33 +241,34 @@ impl D3DSkiaRenderer {
                 // If the next frame is not ready to be rendered yet, wait until it is ready.
                 if self.fence.GetCompletedValue() < old_fence_value {
                     self.fence
-                        .SetEventOnCompletion(old_fence_value, self.fence_event);
-                    WaitForSingleObjectEx(self.fence_event, INFINITE, false.into());
+                        .SetEventOnCompletion(old_fence_value, self.fence_event)
+                        .unwrap();
+                    WaitForSingleObjectEx(self.fence_event, INFINITE, false);
                 }
 
                 // Set the fence value for the next frame.
                 self.fence_values[self.frame_index] = current_fence_value + 1;
                 self.frame_swapped = false;
-            };
+            }
         }
     }
 
     unsafe fn wait_for_gpu(&mut self) {
-        unsafe {
-            let current_fence_value = *self.fence_values.iter().max().unwrap();
-            // Schedule a Signal command in the queue.
-            self.command_queue
-                .Signal(self.fence.as_raw(), current_fence_value);
+        let current_fence_value = *self.fence_values.iter().max().unwrap();
+        // Schedule a Signal command in the queue.
+        self.command_queue
+            .Signal(&self.fence, current_fence_value)
+            .unwrap();
 
-            // Wait until the fence has been processed.
-            self.fence
-                .SetEventOnCompletion(current_fence_value, self.fence_event);
-            WaitForSingleObjectEx(self.fence_event, INFINITE, false.into());
+        // Wait until the fence has been processed.
+        self.fence
+            .SetEventOnCompletion(current_fence_value, self.fence_event)
+            .unwrap();
+        WaitForSingleObjectEx(self.fence_event, INFINITE, false);
 
-            // Increment all fence values
-            for v in &mut self.fence_values {
-                *v = current_fence_value + 1;
-            }
+        // Increment all fence values
+        for v in &mut self.fence_values {
+            *v = current_fence_value + 1;
         }
     }
 
@@ -337,9 +282,11 @@ impl D3DSkiaRenderer {
         self.buffers.clear();
         self.surfaces.clear();
         for i in 0..self.swap_chain_desc.BufferCount {
-            let buffer: ComPtr<ID3D12Resource> =
-                call_com_fn(|buffer, id| unsafe { self.swap_chain.GetBuffer(i, id, buffer) })
-                    .expect("Could not get swapchain buffer");
+            let buffer: ID3D12Resource = unsafe {
+                self.swap_chain
+                    .GetBuffer(i)
+                    .expect("Could not get swapchain buffer")
+            };
             self.buffers.push(buffer.clone());
 
             let info = TextureResourceInfo {
@@ -353,11 +300,9 @@ impl D3DSkiaRenderer {
                 protected: Protected::No,
             };
 
-            let backend_render_target = BackendRenderTarget::new_d3d(size, &info);
-
             let surface = wrap_backend_render_target(
                 &mut self.gr_context,
-                &backend_render_target,
+                &BackendRenderTarget::new_d3d(size, &info),
                 SurfaceOrigin::TopLeft,
                 ColorType::RGBA8888,
                 None,
@@ -378,7 +323,6 @@ impl SkiaRenderer for D3DSkiaRenderer {
     fn flush(&mut self) {}
 
     fn swap_buffers(&mut self) {
-        let info = FlushInfo::default();
         unsafe {
             {
                 tracy_gpu_zone!("submit surface");
@@ -388,16 +332,12 @@ impl SkiaRenderer for D3DSkiaRenderer {
                 self.gr_context.flush_surface_with_access(
                     &mut self.surfaces[buffer_index],
                     BackendSurfaceAccess::Present,
-                    &info,
+                    &FlushInfo::default(),
                 );
                 self.gr_context.submit(Some(SyncCpu::No));
             }
 
-            let res = {
-                tracy_gpu_zone!("present");
-                self.swap_chain.Present(1, 0)
-            };
-            if SUCCEEDED(res) {
+            if self.swap_chain.Present(1, 0).is_ok() {
                 self.frame_swapped = true;
             }
         }
@@ -425,13 +365,15 @@ impl SkiaRenderer for D3DSkiaRenderer {
         let size = self.window.inner_size();
 
         unsafe {
-            self.swap_chain.ResizeBuffers(
-                0,
-                size.width,
-                size.height,
-                self.swap_chain_desc.Format,
-                self.swap_chain_desc.Flags,
-            );
+            self.swap_chain
+                .ResizeBuffers(
+                    0,
+                    size.width,
+                    size.height,
+                    self.swap_chain_desc.Format,
+                    self.swap_chain_desc.Flags,
+                )
+                .unwrap();
         }
         self.setup_surfaces();
     }
@@ -442,7 +384,7 @@ impl SkiaRenderer for D3DSkiaRenderer {
 
     #[cfg(feature = "gpu_profiling")]
     fn tracy_create_gpu_context(&self, name: &str) -> Box<dyn GpuCtx> {
-        create_d3d_gpu_context(name, &self)
+        create_d3d_gpu_context(name, self)
     }
 }
 
@@ -451,7 +393,7 @@ impl Drop for D3DSkiaRenderer {
         unsafe {
             self.gr_context.release_resources_and_abandon();
             self.wait_for_gpu();
-            CloseHandle(self.fence_event);
+            CloseHandle(self.fence_event).unwrap();
         }
     }
 }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -340,7 +340,7 @@ impl CachingShaper {
                     // Last Resort covers all of the unicode space so we will always have a fallback
                     results.push((
                         cluster.to_owned(),
-                        self.font_loader.get_or_load_last_resort(),
+                        self.font_loader.get_or_load_last_resort().unwrap(),
                     ));
                 }
             }

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -6,9 +6,7 @@ use std::{
 
 use log::trace;
 use lru::LruCache;
-use skia_safe::{
-    font::Edging as SkiaEdging, Data, Font, FontHinting as SkiaHinting, FontMgr, Typeface,
-};
+use skia_safe::{font::Edging as SkiaEdging, Data, Font, FontHinting as SkiaHinting, FontMgr};
 
 use crate::renderer::fonts::font_options::{FontEdging, FontHinting};
 use crate::renderer::fonts::swash_font::SwashFont;
@@ -30,8 +28,8 @@ impl FontPair {
         skia_font.set_hinting(font_hinting(&key.hinting));
         skia_font.set_edging(font_edging(&key.edging));
 
-        let typeface = skia_font.typeface().unwrap();
-        let (font_data, index) = typeface.to_font_data().unwrap();
+        let typeface = skia_font.typeface();
+        let (font_data, index) = typeface.to_font_data()?;
         // Only the lower 16 bits are part of the index, the rest indicates named instances. But we
         // don't care about those here, since we are just loading the font, so ignore them
         let index = index & 0xFFFF;
@@ -95,7 +93,7 @@ impl FontLoader {
             FontPair::new(font_key, Font::from_typeface(typeface, self.font_size))
         } else {
             let data = Data::new_copy(DEFAULT_FONT);
-            let typeface = Typeface::from_data(data, 0).unwrap();
+            let typeface = self.font_mgr.new_from_data(&data, 0)?;
             FontPair::new(font_key, Font::from_typeface(typeface, self.font_size))
         }
     }
@@ -143,20 +141,22 @@ impl FontLoader {
         Some(font_pair)
     }
 
-    pub fn get_or_load_last_resort(&mut self) -> Arc<FontPair> {
-        if let Some(last_resort) = self.last_resort.clone() {
-            last_resort
-        } else {
-            let font_key = FontKey::default();
-            let data = Data::new_copy(LAST_RESORT_FONT);
-            let typeface = Typeface::from_data(data, 0).unwrap();
+    pub fn get_or_load_last_resort(&mut self) -> Option<Arc<FontPair>> {
+        match self.last_resort.clone() {
+            Some(font_pair) => Some(font_pair),
+            None => {
+                let font_key = FontKey::default();
+                let data = Data::new_copy(LAST_RESORT_FONT);
 
-            let font_pair =
-                FontPair::new(font_key, Font::from_typeface(typeface, self.font_size)).unwrap();
-            let font_pair = Arc::new(font_pair);
+                let typeface = self.font_mgr.new_from_data(&data, 0)?;
+                let font_pair = Arc::new(FontPair::new(
+                    font_key,
+                    Font::from_typeface(typeface, self.font_size),
+                )?);
 
-            self.last_resort = Some(font_pair.clone());
-            font_pair
+                self.last_resort = Some(font_pair.clone());
+                Some(font_pair)
+            }
         }
     }
 

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -142,21 +142,20 @@ impl FontLoader {
     }
 
     pub fn get_or_load_last_resort(&mut self) -> Option<Arc<FontPair>> {
-        match self.last_resort.clone() {
-            Some(font_pair) => Some(font_pair),
-            None => {
-                let font_key = FontKey::default();
-                let data = Data::new_copy(LAST_RESORT_FONT);
+        if self.last_resort.is_some() {
+            self.last_resort.clone()
+        } else {
+            let font_key = FontKey::default();
+            let data = Data::new_copy(LAST_RESORT_FONT);
 
-                let typeface = self.font_mgr.new_from_data(&data, 0)?;
-                let font_pair = Arc::new(FontPair::new(
-                    font_key,
-                    Font::from_typeface(typeface, self.font_size),
-                )?);
+            let typeface = self.font_mgr.new_from_data(&data, 0)?;
+            let font_pair = Arc::new(FontPair::new(
+                font_key,
+                Font::from_typeface(typeface, self.font_size),
+            )?);
 
-                self.last_resort = Some(font_pair.clone());
-                Some(font_pair)
-            }
+            self.last_resort = Some(font_pair.clone());
+            Some(font_pair)
         }
     }
 

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -104,9 +104,7 @@ impl FontLoader {
         }
 
         let loaded_font = self.load(font_key.clone())?;
-
         let font_arc = Arc::new(loaded_font);
-
         self.cache.put(font_key.clone(), font_arc.clone());
 
         Some(font_arc)

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -121,7 +121,7 @@ impl OpenGLSkiaRenderer {
         })
         .expect("Could not create interface");
 
-        let mut gr_context = skia_safe::gpu::DirectContext::new_gl(Some(interface), None)
+        let mut gr_context = skia_safe::gpu::DirectContext::new_gl(interface, None)
             .expect("Could not create direct context");
         let fb_info = {
             let mut fboid: GLint = 0;

--- a/src/renderer/vsync/vsync_win_dwm.rs
+++ b/src/renderer/vsync/vsync_win_dwm.rs
@@ -6,15 +6,12 @@ use std::{
     thread::{spawn, JoinHandle},
     time::Duration,
 };
-use winapi::{
-    shared::ntdef::LARGE_INTEGER,
-    um::dwmapi::{DwmGetCompositionTimingInfo, DWM_TIMING_INFO},
-    um::profileapi::{QueryPerformanceCounter, QueryPerformanceFrequency},
-};
-
-use winit::event_loop::EventLoopProxy;
 
 use spin_sleep::SpinSleeper;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::Graphics::Dwm::{DwmGetCompositionTimingInfo, DWM_TIMING_INFO};
+use windows::Win32::System::Performance::{QueryPerformanceCounter, QueryPerformanceFrequency};
+use winit::event_loop::EventLoopProxy;
 
 use crate::{
     profiling::{tracy_plot, tracy_zone},
@@ -61,9 +58,9 @@ impl VSyncWinDwm {
             let redraw_requested = Arc::clone(&redraw_requested);
             Some(spawn(move || {
                 let performance_frequency = unsafe {
-                    let mut performance_frequency: LARGE_INTEGER = std::mem::zeroed();
-                    QueryPerformanceFrequency(&mut performance_frequency as *mut LARGE_INTEGER);
-                    *performance_frequency.QuadPart() as f64
+                    let mut performance_frequency: i64 = std::mem::zeroed();
+                    QueryPerformanceFrequency(&mut performance_frequency).unwrap();
+                    performance_frequency as f64
                 };
                 let sleeper = SpinSleeper::default();
                 while !should_exit.load(Ordering::SeqCst) {
@@ -72,12 +69,13 @@ impl VSyncWinDwm {
                         let mut timing_info: DWM_TIMING_INFO = std::mem::zeroed();
                         timing_info.cbSize = std::mem::size_of::<DWM_TIMING_INFO>() as u32;
                         DwmGetCompositionTimingInfo(
-                            std::ptr::null_mut(),
+                            HWND::default(),
                             &mut timing_info as *mut DWM_TIMING_INFO,
-                        );
-                        let mut time_now: LARGE_INTEGER = std::mem::zeroed();
-                        QueryPerformanceCounter(&mut time_now as *mut LARGE_INTEGER);
-                        let time_now = *time_now.QuadPart() as f64;
+                        )
+                        .unwrap();
+                        let mut time_now: i64 = std::mem::zeroed();
+                        QueryPerformanceCounter(&mut time_now).unwrap();
+                        let time_now = time_now as f64;
                         let vblank_delay =
                             (timing_info.qpcVBlank as f64 - time_now) / performance_frequency;
                         let period = ((timing_info.qpcRefreshPeriod as f64)

--- a/src/renderer/vsync/vsync_win_dwm.rs
+++ b/src/renderer/vsync/vsync_win_dwm.rs
@@ -90,7 +90,7 @@ impl VSyncWinDwm {
                     tracy_plot!("sleep_time", _sleep_time);
 
                     if redraw_requested.swap(false, Ordering::Relaxed) {
-                        proxy.send_event(UserEvent::RedrawRequested).unwrap();
+                        proxy.send_event(UserEvent::RedrawRequested).ok();
                     }
                 }
             }))

--- a/src/renderer/vsync/vsync_win_swap_chain.rs
+++ b/src/renderer/vsync/vsync_win_swap_chain.rs
@@ -3,7 +3,8 @@ use std::{
     thread::{spawn, JoinHandle},
 };
 
-use winapi::um::{synchapi::WaitForSingleObjectEx, winnt::HANDLE};
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::System::Threading::WaitForSingleObjectEx;
 
 use winit::event_loop::EventLoopProxy;
 
@@ -40,7 +41,7 @@ impl VSyncWinSwapChain {
             while let Ok(Message::RequestRedraw) = receiver.recv() {
                 tracy_zone!("wait for vblank");
                 unsafe {
-                    WaitForSingleObjectEx(handle.handle, 1000, true.into());
+                    WaitForSingleObjectEx(handle.handle, 1000, true);
                 }
                 proxy.send_event(UserEvent::RedrawRequested).ok();
             }


### PR DESCRIPTION
Briefly complete migrating from `winapi` to `windows`. Known issue: Program will not show a window and closed immediately when building with `profiling` and `gpu_profiling` features enabled. On the other hand, you can still use the program when building without any features enabled. This issue will be fixed in the next commit(s).

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Refactor

## Did this PR introduce a breaking change? 
- No
