### PR TITLE
fix: relative WSL paths and paths with spaces

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -192,7 +192,10 @@ fn handle_wslpaths(paths: Vec<String>, wsl: bool) -> Vec<String> {
 
     paths
         .into_iter()
-        .map(|path| format!("'{}'", windows_to_wsl(&path).unwrap_or(path)))
+        .map(|path| {
+            let path = std::fs::canonicalize(&path).map_or(path, |p| p.to_string_lossy().into());
+            format!("'{}'", windows_to_wsl(&path).unwrap_or(path))
+        })
         .collect()
 }
 

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -288,9 +288,9 @@ mod tests {
         assert_eq!(
             SETTINGS.get::<CmdLineSettings>().neovim_args,
             vec![
-                "/mnt/c/Users/MyUser/foo.txt",
-                "/mnt/c/bar.md",
-                "/mnt/c/Program Files (x86)/Some Application/Settings.ini"
+                "'/mnt/c/Users/MyUser/foo.txt'",
+                "'/mnt/c/bar.md'",
+                "'/mnt/c/Program Files (x86)/Some Application/Settings.ini'"
             ]
         );
     }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -192,7 +192,7 @@ fn handle_wslpaths(paths: Vec<String>, wsl: bool) -> Vec<String> {
 
     paths
         .into_iter()
-        .map(|path| windows_to_wsl(&path).unwrap_or(path))
+        .map(|path| format!("'{}'", windows_to_wsl(&path).unwrap_or(path)))
         .collect()
 }
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This adds quotes around the wsl paths passed to Neovim, to deal with spaces and special characters. Relative paths are also converted to absolute before passed to `windows_to_wsl`, so they also work correctly now.

* Fixes https://github.com/neovide/neovide/issues/2506

@Holzhaus, maybe these are something you want to add to your library?

## Did this PR introduce a breaking change? 
- No
