### PR TITLE
fix:! Don't fork by default

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -1,6 +1,5 @@
 use std::{iter, mem};
 
-use crate::utils::is_tty;
 use crate::{dimensions::Dimensions, frame::Frame, settings::*};
 
 use anyhow::Result;
@@ -22,14 +21,6 @@ fn get_styles() -> Styles {
         .usage(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
         .literal(styling::AnsiColor::Blue.on_default() | styling::Effects::BOLD)
         .placeholder(styling::AnsiColor::Cyan.on_default())
-}
-
-fn is_tty_str() -> &'static str {
-    if is_tty() {
-        "1"
-    } else {
-        "0"
-    }
 }
 
 #[derive(Clone, Debug, Parser)]
@@ -77,7 +68,7 @@ pub struct CmdLineSettings {
     pub title_hidden: bool,
 
     /// Spawn a child process and leak it [DEFAULT]
-    #[arg(long = "fork", env = "NEOVIDE_FORK", action = ArgAction::SetTrue, default_value = is_tty_str(), value_parser = FalseyValueParser::new())]
+    #[arg(long = "fork", env = "NEOVIDE_FORK", action = ArgAction::SetTrue, default_value = "0", value_parser = FalseyValueParser::new())]
     pub fork: bool,
 
     /// Be "blocking" and let the shell persist as parent process. Takes precedence over `--fork`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,8 @@ fn maybe_disown() {
 
     let settings = SETTINGS.get::<CmdLineSettings>();
 
-    if cfg!(debug_assertions) || !settings.fork {
+    // Never fork unless a tty is attached
+    if !settings.fork || !utils::is_tty() {
         return;
     }
 

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -109,14 +109,14 @@ This disables neovim's multigrid functionality which will also disable floating 
 backgrounds, smooth scrolling, and window animations. This can solve some issues where neovide
 acts differently from terminal neovim.
 
-### No Fork
+### Fork
 
 ```sh
---no-fork or $NEOVIDE_FORK=0|1
+--fork or $NEOVIDE_FORK=0|1
 ```
 
-By default, neovide detaches itself from the terminal. Instead of spawning a child process and
-leaking it, be "blocking" and have the shell directly as parent process.
+Detach from the terminal instead of waiting for the Neovide process to
+terminate. This parameter has no effect when launching from a GUI.
 
 ### No Idle
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Based on discussion here, we should change the defaults to not fork, so this is done here.
* https://github.com/neovide/neovide/issues/2147

Additionally, this prevents any attempts to fork when a terminal isn't attached, since that would have no effect.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, this changes the defaults, previously Neovide always forked.

