### PR TITLE
fix: respect floating shadow setting in layer rendering

### DIFF
--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -120,6 +120,10 @@ impl<'w> FloatingLayer<'w> {
     }
 
     fn _draw_shadow(&self, root_canvas: &Canvas, path: &Path, settings: &RendererSettings) {
+        if !settings.floating_shadow {
+            return;
+        }
+
         root_canvas.save();
         // We clip using the Difference op to make sure that the shadow isn't rendered inside
         // the window itself.


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

Floating layer rendering rendered the floating shadow even if disabled in settings. This PR checks the setting before rendering the shadow.