### PR TITLE
fix: don't group floating windows unless one is fully contained in the other

### DIFF
--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -3,7 +3,7 @@ use skia_safe::{
     canvas::SaveLayerRec,
     image_filters::blur,
     utils::shadow_utils::{draw_shadow, ShadowFlags},
-    BlendMode, Canvas, ClipOp, Color, Paint, Path, PathOp, Point3, Rect,
+    BlendMode, Canvas, ClipOp, Color, Contains, Paint, Path, PathOp, Point3, Rect,
 };
 
 use crate::units::{to_skia_rect, GridScale, PixelRect};
@@ -156,8 +156,8 @@ fn get_window_group(windows: &mut Vec<LayerWindow>, index: usize) -> usize {
     windows[index].group
 }
 
-fn rect_intersect(a: &Rect, b: &Rect) -> bool {
-    Rect::intersects2(a, b)
+fn rect_contains(a: &Rect, b: &Rect) -> bool {
+    Rect::contains(a, b) || Rect::contains(b, a)
 }
 
 fn group_windows_with_regions(windows: &mut Vec<LayerWindow>, regions: &[PixelRect<f32>]) {
@@ -166,7 +166,7 @@ fn group_windows_with_regions(windows: &mut Vec<LayerWindow>, regions: &[PixelRe
             let group_i = get_window_group(windows, i);
             let group_j = get_window_group(windows, j);
             if group_i != group_j
-                && rect_intersect(&to_skia_rect(&regions[i]), &to_skia_rect(&regions[j]))
+                && rect_contains(&to_skia_rect(&regions[i]), &to_skia_rect(&regions[j]))
             {
                 let new_group = group_i.min(group_j);
                 if group_i != group_j {


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

This is an attempt to make it less likely that floating windows with consecutive z-indexes are rendered together if they shouldn't be rendered together, like the first screenshot in #2502.

Instead of checking if the window rects intersect, I check if one is contained in the other. This isn't foolproof, because we could still have windows with consecutive indexes that should not be rendered together (like the first screenshot in #2502, but in a bigger directory), so the whole window grouping thing needs a lot more thought, and should probably be able to be disabled entirely by an option.

Still, I can't think of any time it would make sense to render two windows with consecutive z-indexes together if one isn't fully contained in the other.