### PR TITLE
fix: save grid size for maximized windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,7 @@ fn setup(
         // Clippy wrongly suggests to use unwrap or default here
         #[allow(clippy::manual_unwrap_or_default)]
         _ => match window_settings {
+            Some(PersistentWindowSettings::Maximized { grid_size, .. }) => grid_size,
             Some(PersistentWindowSettings::Windowed { grid_size, .. }) => grid_size,
             _ => None,
         },

--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -15,7 +15,10 @@ pub const MAX_GRID_SIZE: GridSize<u32> = GridSize::new(10000, 1000);
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PersistentWindowSettings {
-    Maximized,
+    Maximized {
+        #[serde(default)]
+        grid_size: Option<GridSize<u32>>,
+    },
     Windowed {
         #[serde(default)]
         position: PhysicalPosition<i32>,
@@ -70,7 +73,9 @@ pub fn save_window_size(window_wrapper: &WinitWindowWrapper) {
 
     let settings = PersistentSettings {
         window: if maximized && window_settings.remember_window_size {
-            PersistentWindowSettings::Maximized
+            PersistentWindowSettings::Maximized {
+                grid_size: { window_settings.remember_window_size.then_some(grid_size) },
+            }
         } else {
             PersistentWindowSettings::Windowed {
                 pixel_size: { window_settings.remember_window_size.then_some(pixel_size) },

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -270,7 +270,7 @@ pub fn determine_window_size(window_settings: Option<&PersistentWindowSettings>)
             maximized: true, ..
         } => WindowSize::Maximized,
         _ => match window_settings {
-            Some(PersistentWindowSettings::Maximized) => WindowSize::Maximized,
+            Some(PersistentWindowSettings::Maximized { .. }) => WindowSize::Maximized,
             Some(PersistentWindowSettings::Windowed {
                 pixel_size: Some(pixel_size),
                 ..


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

We're currently saving the grid size for non-maximized windows only. This PR also saves it for maximized windows, because it has the same benefit as for non-maximized windows.