### PR TITLE
Add cfg to is_tty so that it isn't built on windows

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub use ring_buffer::*;
 #[cfg(test)]
 pub use test::*;
 
+#[cfg(not(target_os = "windows"))]
 pub fn is_tty() -> bool {
     use std::io::IsTerminal;
     std::io::stdout().is_terminal()


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
