### PR TITLE
fix: Some more font fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,7 +1431,7 @@ dependencies = [
  "log",
  "lru",
  "neovide-derive",
- "notify",
+ "notify-debouncer-full",
  "num",
  "nvim-rs",
  "objc2",
@@ -1491,6 +1500,20 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ unicode-segmentation = "1.9.0"
 which = "6.0.1"
 winit = { version = "=0.29.15", features = ["serde"] }
 xdg = "2.4.1"
-notify = "6.1.1"
+notify-debouncer-full = "0.3.1"
 regex = "1.10.3"
 
 [dev-dependencies]

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -298,10 +298,10 @@ impl FontEdging {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
 pub enum FontHinting {
+    #[default]
     Full,
     Normal,
     Slight,
-    #[default]
     None,
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -398,10 +398,10 @@ impl Renderer {
             .handle_scale_factor_update(self.os_scale_factor * self.user_scale_factor);
     }
 
-    pub fn prepare_lines(&mut self) {
+    pub fn prepare_lines(&mut self, force: bool) {
         self.rendered_windows
             .iter_mut()
-            .for_each(|(_, w)| w.prepare_lines(&mut self.grid_renderer));
+            .for_each(|(_, w)| w.prepare_lines(&mut self.grid_renderer, force));
     }
 
     fn handle_draw_command(&mut self, draw_command: DrawCommand, result: &mut DrawCommandResult) {

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -752,7 +752,8 @@ impl RenderedWindow {
         smallest_blend_value
     }
 
-    pub fn prepare_lines(&mut self, grid_renderer: &mut GridRenderer) {
+    pub fn prepare_lines(&mut self, grid_renderer: &mut GridRenderer, force: bool) {
+        log::trace!("prepare_lines force: {force}");
         let scroll_offset_lines = self.scroll_animation.position.floor() as isize;
         let height = self.grid_size.height as isize;
         if height == 0 {
@@ -762,7 +763,7 @@ impl RenderedWindow {
 
         let mut prepare_line = |line: &Rc<RefCell<Line>>| {
             let mut line = line.borrow_mut();
-            if line.is_valid {
+            if line.is_valid && !force {
                 return;
             }
 

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -1,8 +1,11 @@
 //! Config file handling
 
-use std::{env, fs, sync::mpsc};
+use std::{env, fs, sync::mpsc, time::Duration};
 
-use notify::Watcher;
+use notify_debouncer_full::{
+    new_debouncer,
+    notify::{RecursiveMode, Watcher},
+};
 use serde::Deserialize;
 use winit::event_loop::EventLoopProxy;
 
@@ -136,16 +139,14 @@ impl Config {
 
 fn watcher_thread(init_config: Config, event_loop_proxy: EventLoopProxy<UserEvent>) {
     let (tx, rx) = mpsc::channel();
-    let mut watcher =
-        notify::RecommendedWatcher::new(tx, notify::Config::default().with_compare_contents(true))
-            .unwrap();
+    let mut debouncer = new_debouncer(Duration::from_millis(500), None, tx).unwrap();
 
-    if let Err(e) = watcher.watch(
+    if let Err(e) = debouncer.watcher().watch(
         // watching the directory rather than the config file itself to also allow it to be deleted/created later on
         config_path()
             .parent()
             .expect("config path to point to a file which must be in some directory"),
-        notify::RecursiveMode::NonRecursive,
+        RecursiveMode::NonRecursive,
     ) {
         log::error!("Could not watch config file, chances are it just doesn't exist: {e}");
         return;

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -444,6 +444,10 @@ impl WinitWindowWrapper {
 
     pub fn draw_frame(&mut self, dt: f32) {
         tracy_zone!("draw_frame");
+        if self.font_changed_last_frame {
+            self.font_changed_last_frame = false;
+            self.renderer.prepare_lines(true);
+        }
         self.renderer.draw_frame(self.skia_renderer.canvas(), dt);
         self.skia_renderer.flush();
         {
@@ -462,7 +466,7 @@ impl WinitWindowWrapper {
             .renderer
             .animate_frame(&self.get_grid_rect_from_window(GridSize::zero()).cast(), dt);
         tracy_plot!("animate_frame", res as u8 as f64);
-        self.renderer.prepare_lines();
+        self.renderer.prepare_lines(false);
         #[allow(clippy::let_and_return)]
         res
     }
@@ -553,7 +557,6 @@ impl WinitWindowWrapper {
             if self.saved_inner_size != new_size || self.font_changed_last_frame || padding_changed
             {
                 self.window_padding = window_padding;
-                self.font_changed_last_frame = false;
                 self.saved_inner_size = new_size;
 
                 self.update_grid_size_from_window();

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -71,10 +71,10 @@ as such it's also documented in `:h guifont`. But to sum it up and also add Neov
       - alias
     - `#h-X` (available since 0.10.2) - Sets level of glyph outline adjustment, while `X` is
       a type of hinting:
-      - full
+      - full (default)
       - normal
       - slight
-      - none (default)
+      - none
 - Some examples:
   - `Hack,Noto_Color_Emoji:h12:b` — Hack at size 12 in bold, with Noto Color Emoji as fallback
     should Hack fail to contain any glyph.


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* Full font hinting is now the default again. None was causing some quality issues, especially with some font sizes. Note that full hinting can cause some font distortion, but that can mostly be avoided by using font sizes that are exact pixels. Here are some examples with a scale factor of 100% : 8.25, 9, 9.75, 10.5, 11.25, 12, 12.75
* Loading of the config file uses debouncing to make it much more reliable. Before this it sometimes failed to detect new settings, and sometimes read partial files. At least on Linux.
* The edging and hinting now takes effect immediately when changing them from the config file
* Contrast and Gamma is enabled for D3D, which was forgotten in the original PR.

## Did this PR introduce a breaking change? 
- No
