### PR TITLE
docs: Fix reversed autocmds for setting input_ime

### DIFF
--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -618,8 +618,8 @@ augroup ime_input
     autocmd!
     autocmd InsertLeave * execute "let g:neovide_input_ime=v:false"
     autocmd InsertEnter * execute "let g:neovide_input_ime=v:true"
-    autocmd CmdlineEnter [/\?] execute "let g:neovide_input_ime=v:false"
-    autocmd CmdlineLeave [/\?] execute "let g:neovide_input_ime=v:true"
+    autocmd CmdlineLeave [/\?] execute "let g:neovide_input_ime=v:false"
+    autocmd CmdlineEnter [/\?] execute "let g:neovide_input_ime=v:true"
 augroup END
 ```
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

The sample Vimscript autocmds for setting `neovide_input_ime` are reversed on the `Cmdline` events, compared to the `Insert` events, and the Lua sample.

## What kind of change does this PR introduce?
- Documentation (fix)

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
