### PR TITLE
fix: Delay the window creation until it's time to draw

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,7 @@ use renderer::{cursor_renderer::CursorSettings, RendererSettings};
 #[cfg_attr(target_os = "windows", allow(unused_imports))]
 use settings::SETTINGS;
 use window::{
-    create_event_loop, create_window, determine_window_size, main_loop, UserEvent, WindowSettings,
-    WindowSize,
+    create_event_loop, determine_window_size, main_loop, UserEvent, WindowSettings, WindowSize,
 };
 
 pub use channel_utils::*;
@@ -97,8 +96,7 @@ fn main() -> NeovideExitCode {
         Err(err) => handle_startup_errors(err, event_loop).into(),
         Ok((window_size, font_settings, _runtime)) => {
             clipboard::init(&event_loop);
-            let window = create_window(&event_loop, &window_size);
-            main_loop(window, window_size, font_settings, event_loop).into()
+            main_loop(window_size, font_settings, event_loop).into()
         }
     }
 }

--- a/src/renderer/d3d.rs
+++ b/src/renderer/d3d.rs
@@ -40,9 +40,14 @@ use winit::{
 use super::{vsync::VSyncWinSwapChain, RendererSettings, SkiaRenderer, VSync};
 #[cfg(feature = "gpu_profiling")]
 use crate::profiling::{d3d::create_d3d_gpu_context, GpuCtx};
-use crate::{profiling::tracy_gpu_zone, settings::SETTINGS, window::UserEvent};
+use crate::{
+    profiling::{tracy_gpu_zone, tracy_zone},
+    settings::SETTINGS,
+    window::UserEvent,
+};
 
 fn get_hardware_adapter(factory: &IDXGIFactory4) -> Result<IDXGIAdapter1> {
+    tracy_zone!("get_hardware_adapter");
     for i in 0.. {
         let adapter = unsafe { factory.EnumAdapters1(i)? };
         let mut desc = Default::default();
@@ -97,6 +102,7 @@ pub struct D3DSkiaRenderer {
 
 impl D3DSkiaRenderer {
     pub fn new(window: Window) -> Self {
+        tracy_zone!("D3DSkiaRenderer::new");
         #[cfg(feature = "d3d_debug")]
         unsafe {
             let mut debug_controller: Option<ID3D12Debug> = None;
@@ -117,6 +123,7 @@ impl D3DSkiaRenderer {
 
         let mut device: Option<ID3D12Device> = None;
         unsafe {
+            tracy_zone!("create_device");
             D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_11_0, &mut device)
                 .expect("Failed to create a Direct3D 12 device");
         }
@@ -167,6 +174,7 @@ impl D3DSkiaRenderer {
         };
 
         let swap_chain = unsafe {
+            tracy_zone!("create swap_chain");
             dxgi_factory
                 .CreateSwapChainForComposition(&command_queue, &swap_chain_desc, None)
                 .expect("Failed to create the Direct3D swap chain")
@@ -232,6 +240,7 @@ impl D3DSkiaRenderer {
             protected_context: Protected::No,
         };
         let gr_context = unsafe {
+            tracy_zone!("create skia context");
             DirectContext::new_d3d(&backend_context, None).expect("Failed to create Skia context")
         };
 
@@ -314,6 +323,7 @@ impl D3DSkiaRenderer {
     }
 
     fn setup_surfaces(&mut self) {
+        tracy_zone!("setup_surfaces");
         let size = self.window.inner_size();
         let size = (
             size.width.try_into().expect("Could not convert width"),

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -151,6 +151,7 @@ impl CachingShaper {
     }
 
     fn reset_font_loader(&mut self) {
+        tracy_zone!("reset_font_loader");
         self.font_info = None;
         let font_size = self.current_size();
 

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -8,10 +8,13 @@ use log::trace;
 use lru::LruCache;
 use skia_safe::{font::Edging as SkiaEdging, Data, Font, FontHinting as SkiaHinting, FontMgr};
 
-use crate::renderer::fonts::font_options::{FontEdging, FontHinting};
-use crate::renderer::fonts::swash_font::SwashFont;
-
-use super::font_options::{CoarseStyle, FontDescription};
+use crate::{
+    profiling::tracy_zone,
+    renderer::fonts::{
+        font_options::{CoarseStyle, FontDescription, FontEdging, FontHinting},
+        swash_font::SwashFont,
+    },
+};
 
 static DEFAULT_FONT: &[u8] = include_bytes!("../../../assets/fonts/FiraCodeNerdFont-Regular.ttf");
 static LAST_RESORT_FONT: &[u8] = include_bytes!("../../../assets/fonts/LastResort-Regular.ttf");
@@ -87,6 +90,7 @@ impl FontLoader {
     }
 
     fn load(&mut self, font_key: FontKey) -> Option<FontPair> {
+        tracy_zone!("load_font");
         trace!("Loading font {:?}", font_key);
         if let Some(desc) = &font_key.font_desc {
             let (family, style) = desc.as_family_and_font_style();

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -23,7 +23,7 @@ use skia_safe::Canvas;
 
 use winit::{
     event::Event,
-    event_loop::{EventLoop, EventLoopProxy},
+    event_loop::{EventLoopProxy, EventLoopWindowTarget},
     window::{Window, WindowBuilder},
 };
 
@@ -526,7 +526,7 @@ pub struct WindowConfig {
 
 pub fn build_window_config<TE>(
     winit_window_builder: WindowBuilder,
-    event_loop: &EventLoop<TE>,
+    event_loop: &EventLoopWindowTarget<TE>,
 ) -> WindowConfig {
     #[cfg(target_os = "windows")]
     {

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -27,7 +27,7 @@ use skia_safe::{
 };
 use winit::{
     dpi::PhysicalSize,
-    event_loop::{EventLoop, EventLoopProxy},
+    event_loop::{EventLoopProxy, EventLoopWindowTarget},
     window::{Window, WindowBuilder},
 };
 
@@ -243,7 +243,7 @@ fn gen_config(mut config_iterator: Box<dyn Iterator<Item = Config> + '_>) -> Con
 
 pub fn build_window<TE>(
     winit_window_builder: WindowBuilder,
-    event_loop: &EventLoop<TE>,
+    event_loop: &EventLoopWindowTarget<TE>,
 ) -> WindowConfig {
     let template_builder = ConfigTemplateBuilder::new()
         .with_stencil_size(8)

--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -59,7 +59,10 @@ pub fn load_last_window_settings() -> Result<PersistentWindowSettings, String> {
 }
 
 pub fn save_window_size(window_wrapper: &WinitWindowWrapper) {
-    let window = window_wrapper.skia_renderer.window();
+    if window_wrapper.skia_renderer.is_none() {
+        return;
+    }
+    let window = window_wrapper.skia_renderer.as_ref().unwrap().window();
     // Don't save the window size when the window is minimized, since the size can be 0
     // Note wayland can't determine this
     if window.is_minimized() == Some(true) {

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -1,10 +1,9 @@
 use crate::bridge::{send_ui, SerialCommand};
 
-use crate::window::UserEvent;
 #[allow(unused_imports)]
 use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 use winit::{
-    event::{ElementState, Event, Ime, KeyEvent, Modifiers, WindowEvent},
+    event::{ElementState, Ime, KeyEvent, Modifiers, WindowEvent},
     keyboard::{Key, KeyCode, KeyLocation, NamedKey, PhysicalKey},
 };
 #[cfg(target_os = "macos")]
@@ -34,15 +33,11 @@ impl KeyboardManager {
         }
     }
 
-    pub fn handle_event(&mut self, event: &Event<UserEvent>) {
+    pub fn handle_event(&mut self, event: &WindowEvent) {
         match event {
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event: key_event,
-                        is_synthetic: false,
-                        ..
-                    },
+            WindowEvent::KeyboardInput {
+                event: key_event,
+                is_synthetic: false,
                 ..
             } if self.ime_preedit.0.is_empty() => {
                 log::trace!("{:#?}", key_event);
@@ -54,21 +49,14 @@ impl KeyboardManager {
                     }
                 }
             }
-            Event::WindowEvent {
-                event: WindowEvent::Ime(Ime::Commit(text)),
-                ..
-            } => {
+            WindowEvent::Ime(Ime::Commit(text)) => {
                 log::trace!("Ime commit {text}");
                 send_ui(SerialCommand::Keyboard(text.to_string()));
             }
-            Event::WindowEvent {
-                event: WindowEvent::Ime(Ime::Preedit(text, cursor_offset)),
-                ..
-            } => self.ime_preedit = (text.to_string(), *cursor_offset),
-            Event::WindowEvent {
-                event: WindowEvent::ModifiersChanged(modifiers),
-                ..
-            } => {
+            WindowEvent::Ime(Ime::Preedit(text, cursor_offset)) => {
+                self.ime_preedit = (text.to_string(), *cursor_offset)
+            }
+            WindowEvent::ModifiersChanged(modifiers) => {
                 // Record the modifier states so that we can properly add them to the keybinding text
                 log::trace!("{:?}", *modifiers);
                 self.modifiers = *modifiers;

--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -29,6 +29,7 @@ use super::{WindowSettings, WindowSettingsChanged};
 
 declare_class!(
     // A view to simulate the double-click-to-zoom effect for `--frame transparency`.
+    #[derive(Debug)]
     struct TitlebarClickHandler;
 
     unsafe impl ClassType for TitlebarClickHandler {
@@ -58,6 +59,7 @@ lazy_static! {
     static ref TITLEBAR_HEIGHT: f64 = MacosWindowFeature::titlebar_height();
 }
 
+#[derive(Debug)]
 pub struct MacosWindowFeature {
     ns_window: Id<NSWindow>,
     titlebar_click_handler: Option<Id<TitlebarClickHandler>>,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -18,7 +18,7 @@ use winit::{
     dpi::{PhysicalSize, Size},
     error::EventLoopError,
     event::Event,
-    event_loop::{EventLoop, EventLoopBuilder},
+    event_loop::{EventLoop, EventLoopBuilder, EventLoopWindowTarget},
     window::{Icon, Theme, WindowBuilder},
 };
 
@@ -131,8 +131,10 @@ pub fn create_event_loop() -> EventLoop<UserEvent> {
 }
 
 pub fn create_window(
-    event_loop: &EventLoop<UserEvent>,
-    initial_window_size: &WindowSize,
+    event_loop: &EventLoopWindowTarget<UserEvent>,
+    window_size: &PhysicalSize<u32>,
+    maximized: bool,
+    title: &str,
 ) -> WindowConfig {
     let icon = load_icon();
 
@@ -145,24 +147,17 @@ pub fn create_window(
         _ => None,
     };
 
-    log::trace!("Settings initial_window_size {:?}", initial_window_size);
-
-    // NOTE: For Geometry, the window is resized when it's shown based on the font and other
-    // settings.
-    let inner_size = match *initial_window_size {
-        WindowSize::Size(size) => size,
-        _ => DEFAULT_WINDOW_SIZE,
-    };
+    log::trace!("Settings initial_window_size {:?}", window_size);
 
     let winit_window_builder = WindowBuilder::new()
-        .with_title("Neovide")
+        .with_title(title)
         .with_window_icon(Some(icon))
-        .with_inner_size(inner_size)
+        .with_inner_size(*window_size)
         // Unfortunately we can't maximize here, because winit shows the window momentarily causing
         // flickering
-        .with_maximized(false)
+        .with_maximized(maximized)
         .with_transparent(true)
-        .with_visible(false);
+        .with_visible(true);
 
     #[cfg(target_os = "windows")]
     let winit_window_builder = if !cmd_line_settings.opengl {
@@ -303,21 +298,19 @@ pub fn determine_window_size(window_settings: Option<&PersistentWindowSettings>)
 }
 
 pub fn main_loop(
-    window: WindowConfig,
     initial_window_size: WindowSize,
     initial_font_settings: Option<FontSettings>,
     event_loop: EventLoop<UserEvent>,
 ) -> Result<(), EventLoopError> {
     let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
-    let window_wrapper = WinitWindowWrapper::new(
-        window,
+    let mut update_loop = UpdateLoop::new(cmd_line_settings.idle);
+
+    let proxy = event_loop.create_proxy();
+    let mut window_wrapper = Some(WinitWindowWrapper::new(
         initial_window_size,
         initial_font_settings,
-        event_loop.create_proxy(),
-    );
-
-    let mut update_loop = UpdateLoop::new(cmd_line_settings.idle);
-    let mut window_wrapper = Some(window_wrapper);
+    ));
+    let mut create_window_allowed = false;
 
     #[cfg(target_os = "macos")]
     let mut menu = {
@@ -329,13 +322,25 @@ pub fn main_loop(
         menu.ensure_menu_added(&e);
 
         match e {
+            Event::Resumed => {
+                create_window_allowed = true;
+                if let Some(window_wrapper) = &mut window_wrapper {
+                    window_wrapper.try_create_window(window_target, &proxy);
+                }
+            }
             Event::LoopExiting => window_wrapper = None,
             Event::UserEvent(UserEvent::NeovimExited) => {
                 save_window_size(window_wrapper.as_ref().unwrap());
                 window_target.exit();
             }
-            _ => window_target
-                .set_control_flow(update_loop.step(window_wrapper.as_mut().unwrap(), e)),
+            _ => {
+                if let Some(window_wrapper) = &mut window_wrapper {
+                    window_target.set_control_flow(update_loop.step(window_wrapper, e));
+                    if create_window_allowed {
+                        window_wrapper.try_create_window(window_target, &proxy);
+                    }
+                }
+            }
         }
     });
     res

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -151,7 +151,7 @@ pub fn create_window(
         .with_window_icon(Some(icon))
         .with_maximized(maximized)
         .with_transparent(true)
-        .with_visible(true);
+        .with_visible(false);
 
     #[cfg(target_os = "windows")]
     let winit_window_builder = if !cmd_line_settings.opengl {

--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -5,10 +5,8 @@ use std::{
 };
 
 use winit::{
-    event::{
-        DeviceId, ElementState, Event, MouseButton, MouseScrollDelta, Touch, TouchPhase,
-        WindowEvent,
-    },
+    event::WindowEvent,
+    event::{DeviceId, ElementState, MouseButton, MouseScrollDelta, Touch, TouchPhase},
     window::Window,
 };
 
@@ -18,7 +16,7 @@ use crate::{
     settings::SETTINGS,
     units::{GridPos, GridScale, GridVec, PixelPos, PixelRect, PixelSize, PixelVec},
     window::keyboard_manager::KeyboardManager,
-    window::{UserEvent, WindowSettings},
+    window::WindowSettings,
 };
 
 fn clamp_position(
@@ -380,7 +378,7 @@ impl MouseManager {
 
     pub fn handle_event(
         &mut self,
-        event: &Event<UserEvent>,
+        event: &WindowEvent,
         keyboard_manager: &KeyboardManager,
         renderer: &Renderer,
         window: &Window,
@@ -392,10 +390,7 @@ impl MouseManager {
             keyboard_manager,
         };
         match event {
-            Event::WindowEvent {
-                event: WindowEvent::CursorMoved { position, .. },
-                ..
-            } => {
+            WindowEvent::CursorMoved { position, .. } => {
                 self.handle_pointer_motion(
                     (position.x as f32, position.y as f32).into(),
                     &editor_state,
@@ -405,53 +400,34 @@ impl MouseManager {
                     self.mouse_hidden = false;
                 }
             }
-            Event::WindowEvent {
-                event:
-                    WindowEvent::MouseWheel {
-                        delta: MouseScrollDelta::LineDelta(x, y),
-                        ..
-                    },
+            WindowEvent::MouseWheel {
+                delta: MouseScrollDelta::LineDelta(x, y),
                 ..
             } => self.handle_line_scroll((*x, *y).into(), &editor_state),
-            Event::WindowEvent {
-                event:
-                    WindowEvent::MouseWheel {
-                        delta: MouseScrollDelta::PixelDelta(delta),
-                        ..
-                    },
+            WindowEvent::MouseWheel {
+                delta: MouseScrollDelta::PixelDelta(delta),
                 ..
             } => self.handle_pixel_scroll((delta.x as f32, delta.y as f32).into(), &editor_state),
-            Event::WindowEvent {
-                event:
-                    WindowEvent::Touch(Touch {
-                        device_id,
-                        id,
-                        location,
-                        phase,
-                        ..
-                    }),
+            WindowEvent::Touch(Touch {
+                device_id,
+                id,
+                location,
+                phase,
                 ..
-            } => self.handle_touch(
+            }) => self.handle_touch(
                 (*device_id, *id),
                 PixelPos::new(location.x as f32, location.y as f32),
                 phase,
                 &editor_state,
             ),
-            Event::WindowEvent {
-                event: WindowEvent::MouseInput { button, state, .. },
-                ..
-            } => self.handle_pointer_transition(
+            WindowEvent::MouseInput { button, state, .. } => self.handle_pointer_transition(
                 *button,
                 state == &ElementState::Pressed,
                 &editor_state,
             ),
 
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event: key_event, ..
-                    },
-                ..
+            WindowEvent::KeyboardInput {
+                event: key_event, ..
             } => {
                 if key_event.state == ElementState::Pressed {
                     let window_settings = SETTINGS.get::<WindowSettings>();

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -139,11 +139,13 @@ impl UpdateLoop {
     }
 
     fn animate(&mut self, window_wrapper: &mut WinitWindowWrapper) {
-        let dt = Duration::from_secs_f32(
-            window_wrapper
-                .vsync
-                .get_refresh_rate(window_wrapper.skia_renderer.window()),
-        );
+        if window_wrapper.skia_renderer.is_none() {
+            return;
+        }
+        let skia_renderer = window_wrapper.skia_renderer.as_ref().unwrap();
+        let vsync = window_wrapper.vsync.as_ref().unwrap();
+
+        let dt = Duration::from_secs_f32(vsync.get_refresh_rate(skia_renderer.window()));
 
         let now = Instant::now();
         let target_animation_time = now - self.animation_start;
@@ -210,16 +212,20 @@ impl UpdateLoop {
     }
 
     fn schedule_render(&mut self, skipped_frame: bool, window_wrapper: &mut WinitWindowWrapper) {
+        if window_wrapper.skia_renderer.is_none() {
+            return;
+        }
+        let skia_renderer = window_wrapper.skia_renderer.as_ref().unwrap();
+        let vsync = window_wrapper.vsync.as_mut().unwrap();
+
         // There's really no point in trying to render if the frame is skipped
         // (most likely due to the compositor being busy). The animated frame will
         // be rendered at an appropriate time anyway.
         if !skipped_frame {
             // When winit throttling is used, request a redraw and wait for the render event
             // Otherwise render immediately
-            if window_wrapper.vsync.uses_winit_throttling() {
-                window_wrapper
-                    .vsync
-                    .request_redraw(window_wrapper.skia_renderer.window());
+            if vsync.uses_winit_throttling() {
+                vsync.request_redraw(skia_renderer.window());
                 self.pending_render = true;
                 tracy_plot!("pending_render", self.pending_render as u8 as f64);
             } else {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -450,6 +450,15 @@ impl WinitWindowWrapper {
 
         let window_config = create_window(event_loop, maximized, &self.title);
         let window = &window_config.window;
+
+        // It's important that this is created before the window is resized, since it can change the padding and affect the size
+        #[cfg(target_os = "macos")]
+        {
+            self.macos_feature = {
+                let mtm = MainThreadMarker::new().expect("must be on the main thread");
+                Some(MacosWindowFeature::from_winit_window(window, mtm))
+            };
+        }
         let scale_factor = window.scale_factor();
         self.renderer
             .grid_renderer
@@ -541,14 +550,6 @@ impl WinitWindowWrapper {
             skia_renderer.as_ref(),
             proxy.clone(),
         ));
-
-        #[cfg(target_os = "macos")]
-        {
-            self.macos_feature = {
-                let mtm = MainThreadMarker::new().expect("must be on the main thread");
-                Some(MacosWindowFeature::from_winit_window(window, mtm))
-            };
-        }
 
         {
             tracy_zone!("set_visible");

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -444,6 +444,7 @@ impl WinitWindowWrapper {
         if self.ui_state != UIState::WaitingForWindowCreate {
             return;
         }
+        tracy_zone!("create_window");
 
         let maximized = matches!(self.initial_window_size, WindowSize::Maximized);
 
@@ -453,7 +454,6 @@ impl WinitWindowWrapper {
         let vsync_enabled = cmd_line_settings.vsync;
         let skia_renderer = create_skia_renderer(window, srgb, vsync_enabled);
         let window = skia_renderer.window();
-        window.request_redraw();
 
         let scale_factor = skia_renderer.window().scale_factor();
         self.renderer
@@ -477,6 +477,7 @@ impl WinitWindowWrapper {
             }
         };
         if !maximized {
+            tracy_zone!("request_inner_size");
             let _ = window.request_inner_size(size);
         }
 
@@ -548,7 +549,14 @@ impl WinitWindowWrapper {
             };
         }
 
-        window.set_visible(true);
+        {
+            tracy_zone!("set_visible");
+            window.set_visible(true);
+        }
+        {
+            tracy_zone!("request_redraw");
+            window.request_redraw();
+        }
 
         // Ensure that the window has the correct IME state
         self.set_ime(input_ime);

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -448,14 +448,9 @@ impl WinitWindowWrapper {
 
         let maximized = matches!(self.initial_window_size, WindowSize::Maximized);
 
-        let window = create_window(event_loop, maximized, &self.title);
-        let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
-        let srgb = cmd_line_settings.srgb;
-        let vsync_enabled = cmd_line_settings.vsync;
-        let skia_renderer = create_skia_renderer(window, srgb, vsync_enabled);
-        let window = skia_renderer.window();
-
-        let scale_factor = skia_renderer.window().scale_factor();
+        let window_config = create_window(event_loop, maximized, &self.title);
+        let window = &window_config.window;
+        let scale_factor = window.scale_factor();
         self.renderer
             .grid_renderer
             .handle_scale_factor_update(scale_factor);
@@ -505,6 +500,12 @@ impl WinitWindowWrapper {
             };
         }
         log::info!("Showing window size: {:#?}, maximized: {}", size, maximized);
+
+        let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
+        let srgb = cmd_line_settings.srgb;
+        let vsync_enabled = cmd_line_settings.vsync;
+        let skia_renderer = create_skia_renderer(window_config, srgb, vsync_enabled);
+        let window = skia_renderer.window();
 
         self.saved_inner_size = window.inner_size();
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -32,6 +32,7 @@ use super::macos::MacosWindowFeature;
 use icrate::Foundation::MainThreadMarker;
 
 use log::trace;
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use winit::{
     dpi,
     event::{Event, WindowEvent},
@@ -513,6 +514,12 @@ impl WinitWindowWrapper {
             };
         }
         log::info!("Showing window size: {:#?}, maximized: {}", size, maximized);
+        let is_wayland = matches!(window.raw_window_handle(), RawWindowHandle::Wayland(_));
+        // On Wayland we can show the window now, since internally it's only shown after the first rendering
+        // On the other platforms the window is shown after rendering to avoid flickering
+        if is_wayland {
+            window.set_visible(true);
+        }
 
         let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
         let srgb = cmd_line_settings.srgb;

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -548,6 +548,8 @@ impl WinitWindowWrapper {
             };
         }
 
+        window.set_visible(true);
+
         // Ensure that the window has the correct IME state
         self.set_ime(input_ime);
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -420,6 +420,10 @@ impl WinitWindowWrapper {
             vsync.wait_for_vsync();
         }
         skia_renderer.swap_buffers();
+        if self.ui_state == UIState::FirstFrame {
+            skia_renderer.window().set_visible(true);
+            self.ui_state = UIState::Showing;
+        }
         tracy_frame();
         tracy_gpu_collect();
     }
@@ -552,10 +556,6 @@ impl WinitWindowWrapper {
         ));
 
         {
-            tracy_zone!("set_visible");
-            window.set_visible(true);
-        }
-        {
             tracy_zone!("request_redraw");
             window.request_redraw();
         }
@@ -616,7 +616,6 @@ impl WinitWindowWrapper {
             return ShouldRender::Wait;
         } else if self.ui_state == UIState::FirstFrame {
             should_render = ShouldRender::Immediately;
-            self.ui_state = UIState::Showing;
         }
 
         // The skia renderer shuld always be created when this point is reached, since the < UIState::FirstFrame check will return true

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -15,14 +15,13 @@ use crate::{
     profiling::{tracy_frame, tracy_gpu_collect, tracy_gpu_zone, tracy_plot, tracy_zone},
     renderer::{
         create_skia_renderer, DrawCommand, Renderer, RendererSettingsChanged, SkiaRenderer, VSync,
-        WindowConfig,
     },
     settings::{
         clamped_grid_size, FontSettings, HotReloadConfigs, SettingsChanged, DEFAULT_GRID_SIZE,
         MIN_GRID_SIZE, SETTINGS,
     },
     units::{GridPos, GridRect, GridSize, PixelPos, PixelSize},
-    window::{ShouldRender, WindowSize},
+    window::{create_window, PhysicalSize, ShouldRender, WindowSize},
     CmdLineSettings,
 };
 
@@ -36,7 +35,7 @@ use log::trace;
 use winit::{
     dpi,
     event::{Event, WindowEvent},
-    event_loop::EventLoopProxy,
+    event_loop::{EventLoopProxy, EventLoopWindowTarget},
     window::{Fullscreen, Theme},
 };
 
@@ -52,9 +51,10 @@ pub fn set_background(background: &str) {
     send_ui(ParallelCommand::SetBackground(background.to_string()));
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, PartialOrd)]
 enum UIState {
     Initing, // Running init.vim/lua
+    WaitingForWindowCreate,
     FirstFrame,
     Showing, // No pending resizes
 }
@@ -62,7 +62,7 @@ enum UIState {
 pub struct WinitWindowWrapper {
     // Don't rearrange this, unless you have a good reason to do so
     // The destruction order has to be correct
-    pub skia_renderer: Box<dyn SkiaRenderer>,
+    pub skia_renderer: Option<Box<dyn SkiaRenderer>>,
     pub renderer: Renderer,
     keyboard_manager: KeyboardManager,
     mouse_manager: MouseManager,
@@ -71,7 +71,6 @@ pub struct WinitWindowWrapper {
     font_changed_last_frame: bool,
     saved_inner_size: dpi::PhysicalSize<u32>,
     saved_grid_size: Option<GridSize<u32>>,
-    ime_enabled: bool,
     ime_position: dpi::PhysicalPosition<i32>,
     requested_columns: Option<u32>,
     requested_lines: Option<u32>,
@@ -79,68 +78,21 @@ pub struct WinitWindowWrapper {
     window_padding: WindowPadding,
     initial_window_size: WindowSize,
     is_minimized: bool,
-    theme: Option<Theme>,
-    pub vsync: VSync,
+    pub vsync: Option<VSync>,
     #[cfg(target_os = "macos")]
-    pub macos_feature: MacosWindowFeature,
+    pub macos_feature: Option<MacosWindowFeature>,
 }
 
 impl WinitWindowWrapper {
     pub fn new(
-        window: WindowConfig,
         initial_window_size: WindowSize,
         initial_font_settings: Option<FontSettings>,
-        proxy: EventLoopProxy<UserEvent>,
     ) -> Self {
-        let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
-        let srgb = cmd_line_settings.srgb;
-        let vsync_enabled = cmd_line_settings.vsync;
-        let skia_renderer = create_skia_renderer(window, srgb, vsync_enabled);
-        let window = skia_renderer.window();
+        let saved_inner_size = Default::default();
+        let renderer = Renderer::new(1.0, initial_font_settings);
 
-        let scale_factor = skia_renderer.window().scale_factor();
-        let renderer = Renderer::new(scale_factor, initial_font_settings);
-        let saved_inner_size = window.inner_size();
-
-        log::info!(
-            "window created (scale_factor: {:.4}, font_dimensions: {:?})",
-            scale_factor,
-            renderer.grid_renderer.grid_scale.0,
-        );
-
-        let WindowSettings {
-            input_ime,
-            theme,
-            transparency,
-            window_blurred,
-            ..
-        } = SETTINGS.get::<WindowSettings>();
-
-        skia_renderer
-            .window()
-            .set_blur(window_blurred && transparency < 1.0);
-
-        match theme.as_str() {
-            "light" => set_background("light"),
-            "dark" => set_background("dark"),
-            "auto" => match window.theme() {
-                Some(Theme::Light) => set_background("light"),
-                Some(Theme::Dark) => set_background("dark"),
-                None => {}
-            },
-            _ => {}
-        }
-
-        let vsync = VSync::new(vsync_enabled, skia_renderer.as_ref(), proxy);
-
-        #[cfg(target_os = "macos")]
-        let macos_feature = {
-            let mtm = MainThreadMarker::new().expect("must be on the main thread");
-            MacosWindowFeature::from_winit_window(window, mtm)
-        };
-
-        let mut wrapper = WinitWindowWrapper {
-            skia_renderer,
+        Self {
+            skia_renderer: None,
             renderer,
             keyboard_manager: KeyboardManager::new(),
             mouse_manager: MouseManager::new(),
@@ -149,7 +101,6 @@ impl WinitWindowWrapper {
             font_changed_last_frame: false,
             saved_inner_size,
             saved_grid_size: None,
-            ime_enabled: input_ime,
             ime_position: dpi::PhysicalPosition::new(-1, -1),
             requested_columns: None,
             requested_lines: None,
@@ -162,23 +113,21 @@ impl WinitWindowWrapper {
             },
             initial_window_size,
             is_minimized: false,
-            theme: None,
-            vsync,
+            vsync: None,
             #[cfg(target_os = "macos")]
-            macos_feature,
-        };
-
-        wrapper.set_ime(input_ime);
-        wrapper
+            macos_feature: None,
+        }
     }
 
     pub fn toggle_fullscreen(&mut self) {
-        let window = self.skia_renderer.window();
-        if self.fullscreen {
-            window.set_fullscreen(None);
-        } else {
-            let handle = window.current_monitor();
-            window.set_fullscreen(Some(Fullscreen::Borderless(handle)));
+        if let Some(skia_renderer) = &self.skia_renderer {
+            let window = skia_renderer.window();
+            if self.fullscreen {
+                window.set_fullscreen(None);
+            } else {
+                let handle = window.current_monitor();
+                window.set_fullscreen(Some(Fullscreen::Borderless(handle)));
+            }
         }
 
         self.fullscreen = !self.fullscreen;
@@ -192,20 +141,24 @@ impl WinitWindowWrapper {
             settings::OptionAsMeta::Both => macos::OptionAsAlt::Both,
             settings::OptionAsMeta::None => macos::OptionAsAlt::None,
         };
-        if winit_option != self.skia_renderer.window().option_as_alt() {
-            self.skia_renderer.window().set_option_as_alt(winit_option);
+        let window = self.skia_renderer.as_ref().unwrap().window();
+        if winit_option != window.option_as_alt() {
+            window.set_option_as_alt(winit_option);
         }
     }
 
     pub fn minimize_window(&mut self) {
-        let window = self.skia_renderer.window();
+        if let Some(skia_renderer) = &self.skia_renderer {
+            let window = skia_renderer.window();
 
-        window.set_minimized(true);
+            window.set_minimized(true);
+        }
     }
 
     pub fn set_ime(&mut self, ime_enabled: bool) {
-        self.ime_enabled = ime_enabled;
-        self.skia_renderer.window().set_ime_allowed(ime_enabled);
+        if let Some(skia_renderer) = &self.skia_renderer {
+            skia_renderer.window().set_ime_allowed(ime_enabled);
+        }
     }
 
     pub fn handle_window_command(&mut self, command: WindowCommand) {
@@ -217,7 +170,9 @@ impl WinitWindowWrapper {
             }
             WindowCommand::ListAvailableFonts => self.send_font_names(),
             WindowCommand::FocusWindow => {
-                self.skia_renderer.window().focus_window();
+                if let Some(skia_renderer) = &self.skia_renderer {
+                    skia_renderer.window().focus_window();
+                }
             }
             WindowCommand::Minimize => {
                 self.minimize_window();
@@ -250,14 +205,14 @@ impl WinitWindowWrapper {
                 }
             }
             WindowSettingsChanged::InputIme(ime_enabled) => {
-                if self.ime_enabled != ime_enabled {
-                    self.set_ime(ime_enabled);
-                }
+                self.set_ime(ime_enabled);
             }
             WindowSettingsChanged::WindowBlurred(blur) => {
-                let WindowSettings { transparency, .. } = SETTINGS.get::<WindowSettings>();
-                let transparent = transparency < 1.0;
-                self.skia_renderer.window().set_blur(blur && transparent);
+                if let Some(skia_renderer) = &self.skia_renderer {
+                    let WindowSettings { transparency, .. } = SETTINGS.get::<WindowSettings>();
+                    let transparent = transparency < 1.0;
+                    skia_renderer.window().set_blur(blur && transparent);
+                }
             }
             #[cfg(target_os = "macos")]
             WindowSettingsChanged::InputMacosOptionKeyIsMeta(option) => {
@@ -276,13 +231,17 @@ impl WinitWindowWrapper {
             _ => {}
         };
         #[cfg(target_os = "macos")]
-        self.macos_feature.handle_settings_changed(changed_setting);
+        if let Some(macos_feature) = &self.macos_feature {
+            macos_feature.handle_settings_changed(changed_setting);
+        }
     }
 
     fn handle_render_settings_changed(&mut self, changed_setting: RendererSettingsChanged) {
         match changed_setting {
             RendererSettingsChanged::TextGamma(..) | RendererSettingsChanged::TextContrast(..) => {
-                self.skia_renderer.resize();
+                if let Some(skia_renderer) = &mut self.skia_renderer {
+                    skia_renderer.resize();
+                }
                 self.font_changed_last_frame = true;
             }
             _ => {}
@@ -291,12 +250,15 @@ impl WinitWindowWrapper {
 
     pub fn handle_title_changed(&mut self, new_title: String) {
         self.title = new_title;
-        self.skia_renderer.window().set_title(&self.title);
+        if let Some(skia_renderer) = &self.skia_renderer {
+            skia_renderer.window().set_title(&self.title);
+        }
     }
 
     pub fn handle_theme_changed(&mut self, new_theme: Option<Theme>) {
-        self.theme = new_theme;
-        self.skia_renderer.window().set_theme(self.theme);
+        if let Some(skia_renderer) = &self.skia_renderer {
+            skia_renderer.window().set_theme(new_theme);
+        }
     }
 
     pub fn send_font_names(&self) {
@@ -327,13 +289,7 @@ impl WinitWindowWrapper {
     /// the window should be rendered.
     pub fn handle_event(&mut self, event: Event<UserEvent>) -> bool {
         tracy_zone!("handle_event", 0);
-        self.keyboard_manager.handle_event(&event);
-        self.mouse_manager.handle_event(
-            &event,
-            &self.keyboard_manager,
-            &self.renderer,
-            self.skia_renderer.window(),
-        );
+
         let renderer_asks_to_be_rendered = self.renderer.handle_event(&event);
         let mut should_render = true;
         match event {
@@ -341,67 +297,10 @@ impl WinitWindowWrapper {
                 tracy_zone!("Resumed");
                 // No need to do anything, but handle the event so that should_render gets set
             }
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => {
-                tracy_zone!("CloseRequested");
-                self.handle_quit();
-            }
-            Event::WindowEvent {
-                event: WindowEvent::ScaleFactorChanged { scale_factor, .. },
-                ..
-            } => {
-                tracy_zone!("ScaleFactorChanged");
-                self.handle_scale_factor_update(scale_factor);
-            }
-            Event::WindowEvent {
-                event: WindowEvent::Resized { .. },
-                ..
-            } => {
-                self.skia_renderer.resize();
-                #[cfg(target_os = "macos")]
-                self.macos_feature.handle_size_changed();
-            }
-            Event::WindowEvent {
-                event: WindowEvent::DroppedFile(path),
-                ..
-            } => {
-                tracy_zone!("DroppedFile");
-                let file_path = path.into_os_string().into_string().unwrap();
-                send_ui(ParallelCommand::FileDrop(file_path));
-            }
-            Event::WindowEvent {
-                event: WindowEvent::Focused(focus),
-                ..
-            } => {
-                tracy_zone!("Focused");
-                if focus {
-                    self.handle_focus_gained();
-                } else {
-                    self.handle_focus_lost();
+            Event::WindowEvent { event, .. } => {
+                if !self.handle_window_event(event) {
+                    should_render = renderer_asks_to_be_rendered;
                 }
-            }
-            Event::WindowEvent {
-                event: WindowEvent::ThemeChanged(theme),
-                ..
-            } => {
-                tracy_zone!("ThemeChanged");
-                let settings = SETTINGS.get::<WindowSettings>();
-                if settings.theme.as_str() == "auto" {
-                    let background = match theme {
-                        Theme::Light => "light",
-                        Theme::Dark => "dark",
-                    };
-                    set_background(background);
-                }
-            }
-            Event::WindowEvent {
-                event: WindowEvent::Moved(_),
-                ..
-            } => {
-                tracy_zone!("Moved");
-                self.vsync.update(self.skia_renderer.window());
             }
             Event::UserEvent(UserEvent::DrawCommandBatch(batch)) => {
                 self.handle_draw_commands(batch);
@@ -420,9 +319,6 @@ impl WinitWindowWrapper {
             }
             _ => {
                 match event {
-                    Event::WindowEvent { .. } => {
-                        tracy_zone!("Unknown WindowEvent");
-                    }
                     Event::AboutToWait { .. } => {
                         tracy_zone!("AboutToWait");
                     }
@@ -439,22 +335,91 @@ impl WinitWindowWrapper {
                 should_render = renderer_asks_to_be_rendered;
             }
         }
-        self.ui_state != UIState::Initing && should_render
+        self.ui_state >= UIState::FirstFrame && should_render
+    }
+
+    fn handle_window_event(&mut self, event: WindowEvent) -> bool {
+        // The renderer and vsync should always be created when a window event is received
+        let skia_renderer = self.skia_renderer.as_mut().unwrap();
+        let vsync = self.vsync.as_mut().unwrap();
+
+        self.mouse_manager.handle_event(
+            &event,
+            &self.keyboard_manager,
+            &self.renderer,
+            skia_renderer.window(),
+        );
+        self.keyboard_manager.handle_event(&event);
+
+        match event {
+            WindowEvent::CloseRequested => {
+                tracy_zone!("CloseRequested");
+                self.handle_quit();
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                tracy_zone!("ScaleFactorChanged");
+                self.handle_scale_factor_update(scale_factor);
+            }
+            WindowEvent::Resized { .. } => {
+                skia_renderer.resize();
+                #[cfg(target_os = "macos")]
+                self.macos_feature.unwrap().handle_size_changed();
+            }
+            WindowEvent::DroppedFile(path) => {
+                tracy_zone!("DroppedFile");
+                let file_path = path.into_os_string().into_string().unwrap();
+                send_ui(ParallelCommand::FileDrop(file_path));
+            }
+            WindowEvent::Focused(focus) => {
+                tracy_zone!("Focused");
+                if focus {
+                    self.handle_focus_gained();
+                } else {
+                    self.handle_focus_lost();
+                }
+            }
+            WindowEvent::ThemeChanged(theme) => {
+                tracy_zone!("ThemeChanged");
+                let settings = SETTINGS.get::<WindowSettings>();
+                if settings.theme.as_str() == "auto" {
+                    let background = match theme {
+                        Theme::Light => "light",
+                        Theme::Dark => "dark",
+                    };
+                    set_background(background);
+                }
+            }
+            WindowEvent::Moved(_) => {
+                tracy_zone!("Moved");
+                vsync.update(skia_renderer.window());
+            }
+            _ => {
+                tracy_zone!("Unknown WindowEvent");
+                return false;
+            }
+        }
+        true
     }
 
     pub fn draw_frame(&mut self, dt: f32) {
         tracy_zone!("draw_frame");
+        if self.skia_renderer.is_none() {
+            return;
+        }
+        let skia_renderer = self.skia_renderer.as_mut().unwrap();
+        let vsync = self.vsync.as_mut().unwrap();
+
         if self.font_changed_last_frame {
             self.font_changed_last_frame = false;
             self.renderer.prepare_lines(true);
         }
-        self.renderer.draw_frame(self.skia_renderer.canvas(), dt);
-        self.skia_renderer.flush();
+        self.renderer.draw_frame(skia_renderer.canvas(), dt);
+        skia_renderer.flush();
         {
             tracy_gpu_zone!("wait for vsync");
-            self.vsync.wait_for_vsync();
+            vsync.wait_for_vsync();
         }
-        self.skia_renderer.swap_buffers();
+        skia_renderer.swap_buffers();
         tracy_frame();
         tracy_gpu_collect();
     }
@@ -471,6 +436,97 @@ impl WinitWindowWrapper {
         res
     }
 
+    pub fn try_create_window(
+        &mut self,
+        event_loop: &EventLoopWindowTarget<UserEvent>,
+        proxy: &EventLoopProxy<UserEvent>,
+    ) {
+        if self.ui_state != UIState::WaitingForWindowCreate {
+            return;
+        }
+
+        let mut maximized = false;
+        let mut size = PhysicalSize::default();
+        match self.initial_window_size {
+            WindowSize::Maximized => {
+                maximized = true;
+            }
+            WindowSize::Grid(grid_size) => {
+                let window_size = self.get_window_size_from_grid(&grid_size);
+                size = PhysicalSize::new(window_size.width, window_size.height);
+            }
+            WindowSize::NeovimGrid => {
+                let grid_size = self.renderer.get_grid_size();
+                let window_size = self.get_window_size_from_grid(&grid_size);
+                size = PhysicalSize::new(window_size.width, window_size.height);
+            }
+            WindowSize::Size(window_size) => {
+                size = window_size;
+            }
+        }
+        log::info!("Showing window size: {:#?}, maximized: {}", size, maximized);
+
+        let window = create_window(event_loop, &size, maximized, &self.title);
+        let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
+        let srgb = cmd_line_settings.srgb;
+        let vsync_enabled = cmd_line_settings.vsync;
+        let skia_renderer = create_skia_renderer(window, srgb, vsync_enabled);
+        let window = skia_renderer.window();
+        window.request_redraw();
+
+        let scale_factor = skia_renderer.window().scale_factor();
+        self.saved_inner_size = window.inner_size();
+
+        log::info!(
+            "window created (scale_factor: {:.4}, font_dimensions: {:?})",
+            scale_factor,
+            self.renderer.grid_renderer.grid_scale.0,
+        );
+
+        let WindowSettings {
+            input_ime,
+            theme,
+            transparency,
+            window_blurred,
+            ..
+        } = SETTINGS.get::<WindowSettings>();
+
+        skia_renderer
+            .window()
+            .set_blur(window_blurred && transparency < 1.0);
+
+        match theme.as_str() {
+            "light" => set_background("light"),
+            "dark" => set_background("dark"),
+            "auto" => match window.theme() {
+                Some(Theme::Light) => set_background("light"),
+                Some(Theme::Dark) => set_background("dark"),
+                None => {}
+            },
+            _ => {}
+        }
+
+        self.vsync = Some(VSync::new(
+            vsync_enabled,
+            skia_renderer.as_ref(),
+            proxy.clone(),
+        ));
+        self.skia_renderer = Some(skia_renderer);
+
+        #[cfg(target_os = "macos")]
+        {
+            self.macos_feature = {
+                let mtm = MainThreadMarker::new().expect("must be on the main thread");
+                Some(MacosWindowFeature::from_winit_window(window, mtm))
+            };
+        }
+
+        // Ensure that the window has the correct IME state
+        self.set_ime(input_ime);
+
+        self.ui_state = UIState::FirstFrame;
+    }
+
     fn handle_draw_commands(&mut self, batch: Vec<DrawCommand>) {
         tracy_zone!("handle_draw_commands");
         let handle_draw_commands_result = self.renderer.handle_draw_commands(batch);
@@ -479,33 +535,7 @@ impl WinitWindowWrapper {
 
         if self.ui_state == UIState::Initing && handle_draw_commands_result.should_show {
             log::info!("Showing the Window");
-            self.ui_state = UIState::FirstFrame;
-
-            match self.initial_window_size {
-                WindowSize::Maximized => {
-                    self.skia_renderer.window().set_visible(true);
-                    self.skia_renderer.window().set_maximized(true);
-                }
-                WindowSize::Grid(GridSize { width, height, .. }) => {
-                    self.requested_columns = Some(width);
-                    self.requested_lines = Some(height);
-                    log::info!("Showing window {width}, {height}");
-                    // The visibility is changed after the size is adjusted
-                }
-                WindowSize::NeovimGrid => {
-                    let grid_size = self.renderer.get_grid_size();
-                    self.requested_columns = Some(grid_size.width);
-                    self.requested_lines = Some(grid_size.height);
-                }
-                WindowSize::Size(..) => {
-                    self.requested_columns = None;
-                    self.requested_lines = None;
-                    self.skia_renderer.window().set_visible(true);
-                }
-            }
-
-            // Ensure that the window has the correct IME state
-            self.set_ime(self.ime_enabled);
+            self.ui_state = UIState::WaitingForWindowCreate;
         };
     }
 
@@ -515,45 +545,49 @@ impl WinitWindowWrapper {
         self.font_changed_last_frame = true;
     }
 
-    pub fn prepare_frame(&mut self) -> ShouldRender {
-        tracy_zone!("prepare_frame", 0);
-        let mut should_render = ShouldRender::Wait;
-
+    fn calculate_window_padding(&self) -> WindowPadding {
         let window_settings = SETTINGS.get::<WindowSettings>();
         #[cfg(not(target_os = "macos"))]
         let window_padding_top = window_settings.padding_top;
         #[cfg(target_os = "macos")]
         let window_padding_top =
             window_settings.padding_top + self.macos_feature.extra_titlebar_height_in_pixels();
-        let window_padding = WindowPadding {
+        WindowPadding {
             top: window_padding_top,
             left: window_settings.padding_left,
             right: window_settings.padding_right,
             bottom: window_settings.padding_bottom,
-        };
+        }
+    }
+
+    pub fn prepare_frame(&mut self) -> ShouldRender {
+        tracy_zone!("prepare_frame", 0);
+        let mut should_render = ShouldRender::Wait;
+
+        let window_padding = self.calculate_window_padding();
         let padding_changed = window_padding != self.window_padding;
 
         // Don't render until the UI is fully entered and the window is shown
-        if self.ui_state == UIState::Initing {
+        if self.ui_state < UIState::FirstFrame {
             return ShouldRender::Wait;
         } else if self.ui_state == UIState::FirstFrame {
             should_render = ShouldRender::Immediately;
             self.ui_state = UIState::Showing;
         }
 
+        // The skia renderer shuld always be created when this point is reached, since the < UIState::FirstFrame check will return true
+        let skia_renderer = self.skia_renderer.as_ref().unwrap();
+
         let resize_requested = self.requested_columns.is_some() || self.requested_lines.is_some();
         if resize_requested {
             // Resize requests (columns/lines) have priority over normal window sizing.
             // So, deal with them first and resize the window programmatically.
             // The new window size will then be processed in the following frame.
-            self.update_window_size_from_grid(&window_padding);
-
-            // Make the window Visible only after the size is adjusted
-            self.skia_renderer.window().set_visible(true);
-        } else if self.skia_renderer.window().is_minimized() != Some(true) {
+            self.update_window_size_from_grid();
+        } else if skia_renderer.window().is_minimized() != Some(true) {
             // NOTE: Only actually resize the grid when the window is not minimized
             // Some platforms return a zero size when that is the case, so we should not try to resize to that.
-            let new_size = self.skia_renderer.window().inner_size();
+            let new_size = skia_renderer.window().inner_size();
             if self.saved_inner_size != new_size || self.font_changed_last_frame || padding_changed
             {
                 self.window_padding = window_padding;
@@ -575,13 +609,30 @@ impl WinitWindowWrapper {
         self.renderer.get_grid_size()
     }
 
-    fn update_window_size_from_grid(&mut self, window_padding: &WindowPadding) {
-        let window = self.skia_renderer.window();
+    fn get_window_size_from_grid(&self, grid_size: &GridSize<u32>) -> PixelSize<u32> {
+        let window_padding = self.calculate_window_padding();
 
         let window_padding_size = PixelSize::new(
             window_padding.left + window_padding.right,
             window_padding.top + window_padding.bottom,
         );
+
+        let window_size = (grid_size.cast() * self.renderer.grid_renderer.grid_scale)
+            .floor()
+            .cast()
+            .cast_unit()
+            + window_padding_size;
+
+        log::info!(
+            "get_window_size_from_grid: Grid Size: {:?}, Window Size {:?}",
+            grid_size,
+            window_size
+        );
+        window_size
+    }
+
+    fn update_window_size_from_grid(&mut self) {
+        let window = self.skia_renderer.as_ref().unwrap().window();
 
         let grid_size = clamped_grid_size(&GridSize::new(
             self.requested_columns.take().unwrap_or(
@@ -593,18 +644,8 @@ impl WinitWindowWrapper {
                     .map_or(DEFAULT_GRID_SIZE.height, |v| v.height),
             ),
         ));
+        let new_size = self.get_window_size_from_grid(&grid_size);
 
-        let new_size = (grid_size.cast() * self.renderer.grid_renderer.grid_scale)
-            .floor()
-            .cast()
-            .cast_unit()
-            + window_padding_size;
-
-        log::info!(
-            "Resizing window based on grid. Grid Size: {:?}, Window Size {:?}",
-            grid_size,
-            new_size
-        );
         let new_size = winit::dpi::PhysicalSize {
             width: new_size.width,
             height: new_size.height,
@@ -657,6 +698,10 @@ impl WinitWindowWrapper {
     }
 
     fn update_ime_position(&mut self) {
+        if self.skia_renderer.is_none() {
+            return;
+        }
+        let skia_renderer = self.skia_renderer.as_ref().unwrap();
         let grid_scale = self.renderer.grid_renderer.grid_scale;
         let font_dimensions = grid_scale.0;
         let mut position = self.renderer.get_cursor_destination();
@@ -668,7 +713,7 @@ impl WinitWindowWrapper {
         };
         if position != self.ime_position {
             self.ime_position = position;
-            self.skia_renderer.window().set_ime_cursor_area(
+            skia_renderer.window().set_ime_cursor_area(
                 dpi::Position::Physical(position),
                 dpi::PhysicalSize::new(100, font_dimensions.height as u32),
             );
@@ -676,9 +721,16 @@ impl WinitWindowWrapper {
     }
 
     fn handle_scale_factor_update(&mut self, scale_factor: f64) {
+        if self.skia_renderer.is_none() {
+            return;
+        }
+        let skia_renderer = self.skia_renderer.as_mut().unwrap();
         #[cfg(target_os = "macos")]
-        self.macos_feature.handle_scale_factor_update(scale_factor);
+        self.macos_feature
+            .as_mut()
+            .unwrap()
+            .handle_scale_factor_update(scale_factor);
         self.renderer.handle_os_scale_factor_change(scale_factor);
-        self.skia_renderer.resize();
+        skia_renderer.resize();
     }
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Instead of creating a hidden window and then potentially resize and show it, we now create the windows inside the event loop with the correct size on demand. 

This fixes a few macOS issues, and also some flickering and bad animation when the window is created. It also probably fixes some issues with tiling window managers

* Fixes https://github.com/neovide/neovide/issues/2142
* Fixes https://github.com/neovide/neovide/issues/2554
* Fixes https://github.com/neovide/neovide/issues/2330
* Fixes https://github.com/neovide/neovide/issues/2087
* Fixes https://github.com/neovide/neovide/issues/1888
* Fixes https://github.com/neovide/neovide/issues/1806
* Fixes https://github.com/neovide/neovide/issues/1783
* Fixes https://github.com/neovide/neovide/issues/915

## Did this PR introduce a breaking change? 
- No
