### PR TITLE
fix: Fix underline rendering

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -214,6 +214,10 @@ impl CachingShaper {
         metrics.ascent - metrics.underline_offset
     }
 
+    pub fn stroke_size(&mut self) -> f32 {
+        self.metrics().stroke_size
+    }
+
     pub fn y_adjustment(&mut self) -> f32 {
         let metrics = self.metrics();
         metrics.ascent + metrics.leading + self.linespace / 2.

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -210,7 +210,8 @@ impl CachingShaper {
     }
 
     pub fn underline_position(&mut self) -> f32 {
-        self.metrics().underline_offset
+        let metrics = self.metrics();
+        metrics.ascent - metrics.underline_offset
     }
 
     pub fn y_adjustment(&mut self) -> f32 {

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -164,9 +164,9 @@ impl GridRenderer {
         let region = self.compute_text_region(clip_position, cell_width + 2);
 
         if let Some(underline_style) = style.underline {
-            let line_position = self.grid_scale.0.height + self.shaper.underline_position();
-            let p1 = pos + PixelVec::new(0.0, line_position);
-            let p2 = pos + PixelVec::new(width, line_position);
+            let underline_position = self.shaper.underline_position();
+            let p1 = pos + PixelVec::new(0.0, underline_position);
+            let p2 = pos + PixelVec::new(width, underline_position);
 
             self.draw_underline(canvas, style, underline_style, p1, p2);
             drawn = true;

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -164,11 +164,12 @@ impl GridRenderer {
         let region = self.compute_text_region(clip_position, cell_width + 2);
 
         if let Some(underline_style) = style.underline {
+            let stroke_size = self.shaper.stroke_size();
             let underline_position = self.shaper.underline_position();
             let p1 = pos + PixelVec::new(0.0, underline_position);
             let p2 = pos + PixelVec::new(width, underline_position);
 
-            self.draw_underline(canvas, style, underline_style, p1, p2);
+            self.draw_underline(canvas, style, underline_style, stroke_size, p1, p2);
             drawn = true;
         }
 
@@ -231,6 +232,7 @@ impl GridRenderer {
         canvas: &Canvas,
         style: &Arc<Style>,
         underline_style: UnderlineStyle,
+        stroke_size: f32,
         p1: PixelPos<f32>,
         p2: PixelPos<f32>,
     ) {
@@ -243,7 +245,11 @@ impl GridRenderer {
         let underline_stroke_scale = SETTINGS.get::<RendererSettings>().underline_stroke_scale;
         // If the stroke width is less than one, clamp it to one otherwise we get nasty aliasing
         // issues
-        let stroke_width = (self.shaper.current_size() * underline_stroke_scale / 10.).max(1.);
+        let stroke_width = (stroke_size * underline_stroke_scale).max(1.);
+
+        // offset y by width / 2 to align the *top* of the underline with p1 and p2
+        let p1 = p1 + PixelVec::new(0., stroke_width / 2.);
+        let p2 = p2 + PixelVec::new(0., stroke_width / 2.);
 
         underline_paint
             .set_color(style.special(&self.default_style.colors).to_color())

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -164,7 +164,7 @@ impl GridRenderer {
         let region = self.compute_text_region(clip_position, cell_width + 2);
 
         if let Some(underline_style) = style.underline {
-            let line_position = self.grid_scale.0.height - self.shaper.underline_position();
+            let line_position = self.grid_scale.0.height + self.shaper.underline_position();
             let p1 = pos + PixelVec::new(0.0, line_position);
             let p2 = pos + PixelVec::new(width, line_position);
 
@@ -238,7 +238,7 @@ impl GridRenderer {
         canvas.save();
 
         let mut underline_paint = Paint::default();
-        underline_paint.set_anti_alias(false);
+        underline_paint.set_anti_alias(true);
         underline_paint.set_blend_mode(BlendMode::SrcOver);
         let underline_stroke_scale = SETTINGS.get::<RendererSettings>().underline_stroke_scale;
         // If the stroke width is less than one, clamp it to one otherwise we get nasty aliasing
@@ -257,16 +257,15 @@ impl GridRenderer {
             UnderlineStyle::UnderDouble => {
                 underline_paint.set_path_effect(None);
                 canvas.draw_line(to_skia_point(p1), to_skia_point(p2), &underline_paint);
-                let p1 = (p1.x, p1.y - 2.);
-                let p2 = (p2.x, p2.y - 2.);
+                let p1 = (p1.x, p1.y + 2. * stroke_width);
+                let p2 = (p2.x, p2.y + 2. * stroke_width);
                 canvas.draw_line(p1, p2, &underline_paint);
             }
             UnderlineStyle::UnderCurl => {
-                let p1 = (p1.x, p1.y - 3. + stroke_width);
-                let p2 = (p2.x, p2.y - 3. + stroke_width);
+                let p1 = (p1.x, p1.y + stroke_width);
+                let p2 = (p2.x, p2.y + stroke_width);
                 underline_paint
                     .set_path_effect(None)
-                    .set_anti_alias(true)
                     .set_style(skia_safe::paint::Style::Stroke);
                 let mut path = Path::default();
                 path.move_to(p1);

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -269,13 +269,13 @@ impl GridRenderer {
                     .set_style(skia_safe::paint::Style::Stroke);
                 let mut path = Path::default();
                 path.move_to(p1);
-                let mut i = p1.0;
                 let mut sin = -2. * stroke_width;
-                let increment = self.grid_scale.0.width / 2.;
-                while i < p2.0 {
+                let dx = self.grid_scale.0.width / 2.;
+                let count = ((p2.0 - p1.0) / dx).round();
+                let dy = (p2.1 - p1.1) / count;
+                for _ in 0..(count as i32) {
                     sin *= -1.;
-                    i += increment;
-                    path.quad_to((i - (increment / 2.), p1.1 + sin), (i, p1.1));
+                    path.r_quad_to((dx / 2., sin), (dx, dy));
                 }
                 canvas.draw_path(&path, &underline_paint);
             }


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

Figured fixing #2561 would be fairly straightforward, so I took a stab at it. The core issue was the sign flip in `src/renderer/grid_renderer.rs:167` - `self.shaper.underline_position()` returns a negative number so subtracting it from the final underline position was offsetting the underline in the wrong direction. From what I can tell, the reason why it wasn't causing an issue before 6b04db543f68d03a1cd6e1ad4b3370732f9e1a0a was because `self.shaper.underline_position()` was usually just returning zero due to lost precision from all the float -> int conversions everywhere.

I also had to tweak the positioning of the other underline types, since those were based off of the previous incorrect positioning. I enabled anti-aliasing for all underline types because without it the bottom line of the double underline was appearing super thick for me. I couldn't see any negative effects of that change on any of the other underline types.  


## Did this PR introduce a breaking change? 
- No

Fixes #2561
