### PR TITLE
neovide_scale_factor minor fix

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -469,8 +469,7 @@ impl WinitWindowWrapper {
         }
 
         let scale_factor = window.scale_factor();
-        self.renderer
-            .handle_os_scale_factor_change(scale_factor);
+        self.renderer.handle_os_scale_factor_change(scale_factor);
 
         let mut size = PhysicalSize::default();
         match self.initial_window_size {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -470,8 +470,7 @@ impl WinitWindowWrapper {
 
         let scale_factor = window.scale_factor();
         self.renderer
-            .grid_renderer
-            .handle_scale_factor_update(scale_factor);
+            .handle_os_scale_factor_change(scale_factor);
 
         let mut size = PhysicalSize::default();
         match self.initial_window_size {


### PR DESCRIPTION
With the recent commit neovide_scale_factor got broken. This change will resolve the issue. 
Thanks @fredizzimo 

Issue:
left is compiled from source now and right is neovide 0.13 version.
![image](https://github.com/neovide/neovide/assets/21097695/dbb2be4f-1c94-4c33-94bf-f7467a7243a1)
