### PR TITLE
fix: Broken IME enable and popup position

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -293,6 +293,9 @@ impl WinitWindowWrapper {
     /// the window should be rendered.
     pub fn handle_event(&mut self, event: Event<UserEvent>) -> bool {
         tracy_zone!("handle_event", 0);
+        let window_settings = SETTINGS.get::<WindowSettings>();
+        // For some some reason we have to set the ime every frame, otherwise it won't apply
+        self.set_ime(window_settings.input_ime);
 
         let renderer_asks_to_be_rendered = self.renderer.handle_event(&event);
         let mut should_render = true;


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The IME enable state, is now called before each event is processed. For some reason it does not apply properly otherwise. That's also what was done before Neovide 0.13. 

The position is also fixed, it used the grid position instead of the physical position before. I also fixed the one line offset bug, and a bug where the position is incorrect when starting the editing.

* Fixes https://github.com/neovide/neovide/issues/2567
* Fixes https://github.com/neovide/neovide/issues/2566
* Fixes https://github.com/neovide/neovide/issues/2178

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
