### PR TITLE
fix: Another attempt to fix the IME not geting properly enabled

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -460,6 +460,16 @@ impl WinitWindowWrapper {
         let window_config = create_window(event_loop, maximized, &self.title);
         let window = &window_config.window;
 
+        let WindowSettings {
+            input_ime,
+            theme,
+            transparency,
+            window_blurred,
+            ..
+        } = SETTINGS.get::<WindowSettings>();
+
+        window.set_ime_allowed(input_ime);
+
         // It's important that this is created before the window is resized, since it can change the padding and affect the size
         #[cfg(target_os = "macos")]
         {
@@ -538,14 +548,6 @@ impl WinitWindowWrapper {
             self.renderer.grid_renderer.grid_scale.0,
         );
 
-        let WindowSettings {
-            input_ime,
-            theme,
-            transparency,
-            window_blurred,
-            ..
-        } = SETTINGS.get::<WindowSettings>();
-
         window.set_blur(window_blurred && transparency < 1.0);
 
         match theme.as_str() {
@@ -569,9 +571,6 @@ impl WinitWindowWrapper {
             tracy_zone!("request_redraw");
             window.request_redraw();
         }
-
-        // Ensure that the window has the correct IME state
-        self.set_ime(input_ime);
 
         self.ui_state = UIState::FirstFrame;
         self.skia_renderer = Some(skia_renderer);


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The previous attempt of this fix was in:
* https://github.com/neovide/neovide/pull/2571

But it turned out that, the fix caused fcitx to crash all the time, so this fixes it in the correct way, I hope.

NOTE: When I first made this fix, it seemed like it was stil possible to make it go into the wrong state if it was enabled without moving the cursor. But after that I have attempted to repeat it 10s of times without luck, so it's either very random, when it did happen, maybe every other try, and then basically never. Or more likely, fcitx was in some bad state due to my earlier attempts, and therefore caused the problems.

If this happens however, it would be good to capture a log with `WAYLAND_DEBUG=1 neovide`. If there is a problem, then it's probably because of some race condition when setting the area immediately after the IME has been enabled, and the wayland log might capture that.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
