### PR TITLE
fix: Don't use login shell on macOS if `$TERM` is set

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -49,6 +49,16 @@ fn build_login_cmd_args(command: &str, args: &[&str]) -> (String, Vec<String>) {
 
     use crate::error_handling::ResultPanicExplanation;
 
+    // If $TERM is set, we assume user is running from a terminal, and we shouldn't
+    // re-initialize the environment.
+    // See https://github.com/neovide/neovide/issues/2584
+    if env::var_os("TERM").is_some() {
+        return (
+            command.to_string(),
+            args.iter().map(|s| s.to_string()).collect(),
+        );
+    }
+
     let user = env::var("USER").unwrap_or_explained_panic("USER environment variable not found");
     let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
 


### PR DESCRIPTION
If we assume that having `$TERM` set means the user is in an interactive terminal session, we can simply run the nvim command directly instead of wrapping it in `/usr/bin/login`, preserving their environment variables. Testing locally, this does work: the simple `PATH="/foobar:$PATH" neovide` test I used in the bug report works again.

Note that this is different from the [pre-0.13 behaviour](https://github.com/neovide/neovide/blob/71e9fa49fcb393662ee03e42968724b91cde8e62/src/bridge/command.rs#L192-L194), which would still spawn a shell but just not provide `-l`. This just executes `nvim` directly. That's what I think @fredizzimo is suggesting in [this comment](https://github.com/neovide/neovide/issues/2584#issuecomment-2125654862), but I don't know if spawning a shell has effects other than setting environment variables that we'd still need.

I did notice when testing locally that if I launch the app bundle (a release build) from Finder, its cwd is `/`, which would seem to be a regression of #2407, however it does the same thing on `main`, so I don't think it's related to my change.

Fixes #2584

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
