### PR TITLE
refactor: remove unnecessary casting to `usize`

### DIFF
--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -96,7 +96,7 @@ pub fn points_to_ascii(points: Vec<Point>) -> String {
 
     let line_width = points.iter().map(|p| p.x as usize).max().unwrap() + 1;
     let line_count = points.iter().map(|p| p.y as usize).max().unwrap() + 1;
-    let mut ascii = vec![vec![' '; line_width as usize]; line_count as usize];
+    let mut ascii = vec![vec![' '; line_width]; line_count];
     let numbers_big_enough = points.len() <= 9;
     let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     for (index, p) in points.iter().enumerate() {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Refactor

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No