### PR TITLE
fix: Position underline correctly with linespace >0

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -212,7 +212,7 @@ impl CachingShaper {
 
     pub fn underline_position(&mut self) -> f32 {
         let metrics = self.metrics();
-        metrics.ascent - metrics.underline_offset
+        metrics.ascent - metrics.underline_offset + self.linespace / 2.
     }
 
     pub fn stroke_size(&mut self) -> f32 {


### PR DESCRIPTION
Fixes neovide/neovide#2600

## Before
<img width="194" alt="image" src="https://github.com/neovide/neovide/assets/9437625/8b9e0664-9016-4dd2-9d3b-36a42c1fb23d">
<img width="191" alt="image" src="https://github.com/neovide/neovide/assets/9437625/c942afca-b386-4ed5-81e2-cbfe4be12aa4">

## After
<img width="195" alt="image" src="https://github.com/neovide/neovide/assets/9437625/7f6e8af2-a286-486f-bc14-d2185ee3b310">
<img width="190" alt="image" src="https://github.com/neovide/neovide/assets/9437625/6275f89d-93cb-4b57-a5c7-d62a7407e09a">


## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change?
- No
