### PR TITLE
fix: emulate Neovim layer drawing

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -209,7 +209,7 @@ pub enum RedrawEvent {
         anchor_column: f64,
         #[allow(unused)]
         focusable: bool,
-        sort_order: Option<u64>,
+        z_index: u64,
     },
     #[allow(unused)]
     WindowExternalPosition {
@@ -677,8 +677,8 @@ fn parse_window_anchor(value: Value) -> Result<WindowAnchor> {
 }
 
 fn parse_win_float_pos(win_float_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let ([grid, _window, anchor, anchor_grid, anchor_row, anchor_column, focusable], [sort_order]) =
-        extract_values_with_optional(win_float_pos_arguments)?;
+    let [grid, _window, anchor, anchor_grid, anchor_row, anchor_column, focusable, z_index] =
+        extract_values(win_float_pos_arguments)?;
 
     Ok(RedrawEvent::WindowFloatPosition {
         grid: parse_u64(grid)?,
@@ -687,7 +687,7 @@ fn parse_win_float_pos(win_float_pos_arguments: Vec<Value>) -> Result<RedrawEven
         anchor_row: parse_f64(anchor_row)?,
         anchor_column: parse_f64(anchor_column)?,
         focusable: parse_bool(focusable)?,
-        sort_order: sort_order.map(parse_u64).transpose()?,
+        z_index: parse_u64(z_index)?,
     })
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -290,7 +290,6 @@ impl Renderer {
             .map(|window| {
                 window.draw(
                     root_canvas,
-                    &settings,
                     default_background.with_a((255.0 * transparency) as u8),
                     grid_scale,
                 )

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -245,19 +245,15 @@ impl Renderer {
             for window in floating_windows {
                 let zindex = window.anchor_info.as_ref().unwrap().sort_order;
                 log::debug!("zindex: {}, base: {}", zindex, base_zindex);
-                if layer_grouping {
-                    // Group floating windows by consecutive z indices
-                    if zindex - last_zindex > 1 && !current_windows.is_empty() {
+                if !current_windows.is_empty() && zindex !=last_zindex {
+                    // Group floating windows by consecutive z indices if layer_grouping is enabled,
+                    // Otherwise group all windows inside a single layer
+                    if true || !layer_grouping || zindex - last_zindex > 1 {
                         for windows in group_windows(current_windows, grid_scale) {
                             floating_layers.push(FloatingLayer { windows });
                         }
                         current_windows = vec![];
                     }
-                } else {
-                    for windows in group_windows(current_windows, grid_scale) {
-                        floating_layers.push(FloatingLayer { windows });
-                    }
-                    current_windows = vec![];
                 }
 
                 if current_windows.is_empty() {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -243,12 +243,12 @@ impl Renderer {
             let mut current_windows = vec![];
 
             for window in floating_windows {
-                let zindex = window.anchor_info.as_ref().unwrap().sort_order;
+                let zindex = window.anchor_info.as_ref().unwrap().sort_order.z_index;
                 log::debug!("zindex: {}, base: {}", zindex, base_zindex);
-                if !current_windows.is_empty() && zindex !=last_zindex {
+                if !current_windows.is_empty() && zindex != last_zindex {
                     // Group floating windows by consecutive z indices if layer_grouping is enabled,
                     // Otherwise group all windows inside a single layer
-                    if true || !layer_grouping || zindex - last_zindex > 1 {
+                    if !layer_grouping || zindex - last_zindex > 1 {
                         for windows in group_windows(current_windows, grid_scale) {
                             floating_layers.push(FloatingLayer { windows });
                         }
@@ -276,7 +276,7 @@ impl Renderer {
                     layer
                         .windows
                         .iter()
-                        .map(|w| (w.id, w.anchor_info.as_ref().unwrap().sort_order))
+                        .map(|w| (w.id, w.anchor_info.as_ref().unwrap().sort_order.clone()))
                         .collect_vec()
                 );
             }
@@ -494,31 +494,9 @@ impl Renderer {
 
 /// Defines how floating windows are sorted.
 fn floating_sort(window_a: &&mut RenderedWindow, window_b: &&mut RenderedWindow) -> Ordering {
-    // First, compare floating order
-    let mut ord = window_a
-        .anchor_info
-        .as_ref()
-        .unwrap()
-        .sort_order
-        .partial_cmp(&window_b.anchor_info.as_ref().unwrap().sort_order)
-        .unwrap();
-    if ord == Ordering::Equal {
-        // if equal, compare grid pos x
-        ord = window_a
-            .grid_current_position
-            .x
-            .partial_cmp(&window_b.grid_current_position.x)
-            .unwrap();
-        if ord == Ordering::Equal {
-            // if equal, compare grid pos z
-            ord = window_a
-                .grid_current_position
-                .y
-                .partial_cmp(&window_b.grid_current_position.y)
-                .unwrap();
-        }
-    }
-    ord
+    let orda = &window_a.anchor_info.as_ref().unwrap().sort_order;
+    let ordb = &window_b.anchor_info.as_ref().unwrap().sort_order;
+    orda.cmp(ordb)
 }
 
 pub enum WindowConfigType {

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -3,7 +3,7 @@ use skia_safe::{
     canvas::SaveLayerRec,
     image_filters::blur,
     utils::shadow_utils::{draw_shadow, ShadowFlags},
-    BlendMode, Canvas, ClipOp, Color, Contains, Paint, Path, PathOp, Point3, Rect,
+    BlendMode, Canvas, ClipOp, Color, Paint, Path, PathOp, Point3, Rect,
 };
 
 use crate::units::{to_skia_rect, GridScale, PixelRect};
@@ -82,23 +82,12 @@ impl<'w> FloatingLayer<'w> {
             .map(|window| window.pixel_region(grid_scale))
             .collect::<Vec<_>>();
 
-        // TODO: Get rid of this
-        let blend = self.uniform_background_blend();
-
-        self.windows.iter_mut().for_each(|window| {
-            window.update_blend(blend);
-        });
-
         let mut ret = vec![];
 
         (0..self.windows.len()).for_each(|i| {
             let window = &mut self.windows[i];
             window.draw_background_surface(root_canvas, regions[i], grid_scale);
-        });
-        (0..self.windows.len()).for_each(|i| {
-            let window = &mut self.windows[i];
             window.draw_foreground_surface(root_canvas, regions[i], grid_scale);
-
             ret.push(WindowDrawDetails {
                 id: window.id,
                 region: regions[i],
@@ -110,14 +99,6 @@ impl<'w> FloatingLayer<'w> {
         root_canvas.restore();
 
         ret
-    }
-
-    pub fn uniform_background_blend(&self) -> u8 {
-        self.windows
-            .iter()
-            .filter_map(|window| window.get_smallest_blend_value())
-            .min()
-            .unwrap_or(0)
     }
 
     fn _draw_shadow(&self, root_canvas: &Canvas, path: &Path, settings: &RendererSettings) {

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -82,6 +82,7 @@ impl<'w> FloatingLayer<'w> {
             .map(|window| window.pixel_region(grid_scale))
             .collect::<Vec<_>>();
 
+        // TODO: Get rid of this
         let blend = self.uniform_background_blend();
 
         self.windows.iter_mut().for_each(|window| {

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -161,18 +161,15 @@ fn get_window_group(windows: &mut Vec<LayerWindow>, index: usize) -> usize {
     windows[index].group
 }
 
-fn rect_contains(a: &Rect, b: &Rect) -> bool {
-    Rect::contains(a, b) || Rect::contains(b, a)
-}
-
 fn group_windows_with_regions(windows: &mut Vec<LayerWindow>, regions: &[PixelRect<f32>]) {
+    // intersects does not consider touching regions as intersection, so extend the box by one
+    // pixel before doing the test.
+    let epsilon = 1.0;
     for i in 0..windows.len() {
         for j in i + 1..windows.len() {
             let group_i = get_window_group(windows, i);
             let group_j = get_window_group(windows, j);
-            if group_i != group_j
-                && rect_contains(&to_skia_rect(&regions[i]), &to_skia_rect(&regions[j]))
-            {
+            if group_i != group_j && regions[i].inflate(epsilon, epsilon).intersects(&regions[j]) {
                 let new_group = group_i.min(group_j);
                 if group_i != group_j {
                     windows[group_i].group = new_group;

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -1,9 +1,7 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use skia_safe::{
-    canvas::SaveLayerRec,
-    utils::shadow_utils::{draw_shadow, ShadowFlags},
-    BlendMode, Canvas, ClipOp, Color, Matrix, Paint, Path, Picture, PictureRecorder, Point3, Rect,
+    canvas::SaveLayerRec, BlendMode, Canvas, Color, Matrix, Paint, Picture, PictureRecorder, Rect,
 };
 
 use crate::{
@@ -286,42 +284,11 @@ impl RenderedWindow {
     pub fn draw(
         &mut self,
         root_canvas: &Canvas,
-        settings: &RendererSettings,
         default_background: Color,
         grid_scale: GridScale,
     ) -> WindowDrawDetails {
         let pixel_region_box = self.pixel_region(grid_scale);
         let pixel_region = to_skia_rect(&pixel_region_box);
-
-        if self.anchor_info.is_some() && settings.floating_shadow {
-            root_canvas.save();
-            let shadow_path = Path::rect(pixel_region, None);
-            // We clip using the Difference op to make sure that the shadow isn't rendered inside
-            // the window itself.
-            root_canvas.clip_path(&shadow_path, Some(ClipOp::Difference), None);
-            // The light angle is specified in degrees from the vertical, so we first convert them
-            // to radians and then use sin/cos to get the y and z components of the light
-            let light_angle_radians = settings.light_angle_degrees.to_radians();
-            draw_shadow(
-                root_canvas,
-                &shadow_path,
-                // Specifies how far from the root canvas the shadow casting rect is. We just use
-                // the z component here to set it a constant distance away.
-                Point3::new(0., 0., settings.floating_z_height),
-                // Because we use the DIRECTIONAL_LIGHT shadow flag, this specifies the angle that
-                // the light is coming from.
-                Point3::new(0., -light_angle_radians.sin(), light_angle_radians.cos()),
-                // This is roughly equal to the apparent radius of the light .
-                5.,
-                Color::from_argb((0.03 * 255.) as u8, 0, 0, 0),
-                Color::from_argb((0.35 * 255.) as u8, 0, 0, 0),
-                // Directional Light flag is necessary to make the shadow render consistently
-                // across various sizes of floating windows. It effects how the light direction is
-                // processed.
-                Some(ShadowFlags::DIRECTIONAL_LIGHT),
-            );
-            root_canvas.restore();
-        }
 
         root_canvas.save();
         root_canvas.clip_rect(pixel_region, None, Some(false));

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -8,7 +8,7 @@ use skia_safe::{
 
 use crate::{
     cmd_line::CmdLineSettings,
-    editor::{AnchorInfo, Style, WindowType},
+    editor::{AnchorInfo, SortOrder, Style, WindowType},
     profiling::{tracy_plot, tracy_zone},
     renderer::{animation_utils::*, GridRenderer, RendererSettings},
     settings::SETTINGS,
@@ -63,6 +63,7 @@ pub enum WindowDrawCommand {
         left: u64,
         right: u64,
     },
+    SortOrder(SortOrder),
 }
 
 #[derive(Clone)]
@@ -505,6 +506,11 @@ impl RenderedWindow {
             }
             WindowDrawCommand::ViewportMargins { top, bottom, .. } => {
                 self.viewport_margins = ViewportMargins { top, bottom }
+            }
+            WindowDrawCommand::SortOrder(sort_order) => {
+                if let Some(anchor_info) = self.anchor_info.as_mut() {
+                    anchor_info.sort_order = sort_order;
+                }
             }
             _ => {}
         };


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The layer groups are now drawing using the same order and blending as the terminal mode Neovim. There's no blending between the windows, a window on the top (inside the same group), always overwrites the window below it. This makes the sort ordering important, but the UI protocol does not provide us all the information directly, so it has been reverse engineered from the Neovim source code. And the order is the following:
1. Z-index
2. Creation order, actually the first call to `win_float_pos` for a window. This order is reset when the window is hidden.

Furthermore, each time a `grid_cursor_goto` event is received, that window is moved to the top in its z-index.

The `neovide_experimental_layer_grouping` option has also been fixed. It didn't work as intended before. Even if this current algorithm works well, it's still needed for some elements, like NUI popups, used by `noice.nvim` for example. I think this can be fixed in the plugin itself, there's probably no need for it to use separate layers for the borders.

Some code has also been deleted, like the blur rendering in the codepath for rendering root windows. And the transparency calculation has been simplified, since most of the custom code is no longer needed.


I have been testing this with many different plugins, and the only problems I have seen are the ones using `nui.nvim`, ad mentioned before. Even this telescope bug https://github.com/nvim-telescope/telescope.nvim/issues/2603 is now fixed  @A-Lamia

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
