### PR TITLE
fix: Neovide --version and Neovide --help

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ windows = { version = "0.56.0", features = [
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
     "Win32_Security",
+    "Win32_System_Console",
     "Win32_System_Performance",
     "Win32_System_Threading",
     "Win32_UI_HiDpi",

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -9,6 +9,9 @@ use itertools::Itertools;
 use log::error;
 use winit::{error::EventLoopError, event_loop::EventLoop};
 
+#[cfg(target_os = "windows")]
+use crate::windows_attach_to_console;
+
 use crate::{
     bridge::{send_ui, ParallelCommand},
     running_tracker::RUNNING_TRACKER,
@@ -65,28 +68,23 @@ This is the error that caused the crash. In case you don't know what to do with 
 }
 
 fn handle_terminal_startup_errors(err: Error) -> i32 {
-    if let Some(clap_error) = err.downcast_ref::<ClapError>() {
-        let _ = clap_error.print();
-        clap_error.exit_code()
-    } else {
-        eprintln!("{}", &format_and_log_error_message(err));
-        1
-    }
+    eprintln!("{}", &format_and_log_error_message(err));
+    1
 }
 
 fn handle_gui_startup_errors(err: Error, event_loop: EventLoop<UserEvent>) -> i32 {
-    if let Some(clap_error) = err.downcast_ref::<ClapError>() {
-        let text = clap_error.render().to_string();
-        show_error_window(&text, event_loop);
-        clap_error.exit_code()
-    } else {
-        show_error_window(&format_and_log_error_message(err), event_loop);
-        1
-    }
+    show_error_window(&format_and_log_error_message(err), event_loop);
+    1
 }
 
 pub fn handle_startup_errors(err: Error, event_loop: EventLoop<UserEvent>) -> i32 {
-    if stdout().is_terminal() {
+    // Command line output is always printed to the stdout/stderr
+    if let Some(clap_error) = err.downcast_ref::<ClapError>() {
+        #[cfg(target_os = "windows")]
+        windows_attach_to_console();
+        let _ = clap_error.print();
+        clap_error.exit_code()
+    } else if stdout().is_terminal() {
         handle_terminal_startup_errors(err)
     } else {
         handle_gui_startup_errors(err, event_loop)

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,11 @@ fn setup(
     //
     // The Window event loop sends UICommand to the bridge, which forwards them to Neovim. It also
     // reads `DrawCommand`, `SettingChanged`, and `WindowCommand` from the other components.
+
+    SETTINGS.register::<WindowSettings>();
+    SETTINGS.register::<RendererSettings>();
+    SETTINGS.register::<CursorSettings>();
+
     let config = Config::init();
     Config::watch_config_file(config.clone(), proxy.clone());
 
@@ -188,9 +193,6 @@ fn setup(
 
     trace!("Neovide version: {}", crate_version!());
 
-    SETTINGS.register::<WindowSettings>();
-    SETTINGS.register::<RendererSettings>();
-    SETTINGS.register::<CursorSettings>();
     let window_settings = load_last_window_settings().ok();
     let window_size = determine_window_size(window_settings.as_ref());
     let grid_size = match window_size {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,11 +91,11 @@ fn main() -> NeovideExitCode {
     }
 
     let event_loop = create_event_loop();
+    clipboard::init(&event_loop);
 
     match setup(event_loop.create_proxy()) {
         Err(err) => handle_startup_errors(err, event_loop).into(),
         Ok((window_size, font_settings, _runtime)) => {
-            clipboard::init(&event_loop);
             main_loop(window_size, font_settings, event_loop).into()
         }
     }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,13 +1,12 @@
 #[cfg(target_os = "macos")]
 use {log::error, rmpv::Value};
 
-use crate::{cmd_line::CmdLineSettings, settings::*};
+use crate::settings::*;
 
 #[derive(Clone, SettingGroup, PartialEq)]
 pub struct WindowSettings {
     pub refresh_rate: u64,
     pub refresh_rate_idle: u64,
-    pub idle: bool,
     pub transparency: f32,
     pub window_blurred: bool,
     pub scale_factor: f32,
@@ -50,7 +49,6 @@ impl Default for WindowSettings {
             iso_layout: false,
             refresh_rate: 60,
             refresh_rate_idle: 5,
-            idle: SETTINGS.get::<CmdLineSettings>().idle,
             remember_window_size: true,
             remember_window_position: true,
             hide_mouse_when_typing: false,

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -1,5 +1,6 @@
-use windows::Win32::UI::HiDpi::{
-    SetProcessDpiAwarenessContext, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+use windows::Win32::{
+    System::Console::{AttachConsole, ATTACH_PARENT_PROCESS},
+    UI::HiDpi::{SetProcessDpiAwarenessContext, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2},
 };
 use windows_registry::{Result, CURRENT_USER};
 
@@ -76,5 +77,12 @@ pub fn windows_fix_dpi() {
     unsafe {
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
             .expect("Failed to set DPI awareness!");
+    }
+}
+
+pub fn windows_attach_to_console() {
+    // Attach to parent console tip found here: https://github.com/rust-lang/rust/issues/67159#issuecomment-987882771
+    unsafe {
+        AttachConsole(ATTACH_PARENT_PROCESS).ok();
     }
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
1. Fixes crash when the GUI error message window is shown and the command line parsing fails.
2. Fixes yanking from the GUI error message window, when it's shown before the clipboard has been initialized
3. The errors/messages are always printed to stdout/stdout when they originate from the command line parsing. After that they are either shown in the console or the GUI window depending on if a TTY is attached or not. 

* Fixes https://github.com/neovide/neovide/issues/2572
* Fixes https://github.com/neovide/neovide/issues/2204

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
