### PR TITLE
fix: Remove some logspam

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -29,6 +29,7 @@ use winit::{
 
 use crate::{
     bridge::EditorMode,
+    cmd_line::CmdLineSettings,
     editor::{Cursor, Style},
     profiling::{tracy_create_gpu_context, tracy_named_frame, tracy_zone},
     renderer::rendered_layer::{group_windows, FloatingLayer},
@@ -49,9 +50,6 @@ use skia_safe::graphics::{
 
 #[cfg(feature = "gpu_profiling")]
 use crate::profiling::GpuCtx;
-
-#[cfg(target_os = "windows")]
-use crate::CmdLineSettings;
 
 use cursor_renderer::CursorRenderer;
 pub use fonts::caching_shaper::CachingShaper;
@@ -445,10 +443,14 @@ impl Renderer {
                             warn!("ViewportMargins recieved before window was initialized");
                         }
                         _ => {
-                            error!(
-                                "WindowDrawCommand: {:?} sent for uninitialized grid {}",
-                                command, grid_id
-                            );
+                            let settings = SETTINGS.get::<CmdLineSettings>();
+                            // Ignore the errors when not using multigrid, since Neovim wrongly sends some of these
+                            if !settings.no_multi_grid {
+                                error!(
+                                    "WindowDrawCommand: {:?} sent for uninitialized grid {}",
+                                    command, grid_id
+                                );
+                            }
                         }
                     },
                 }

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -671,7 +671,6 @@ impl RenderedWindow {
     }
 
     pub fn prepare_lines(&mut self, grid_renderer: &mut GridRenderer, force: bool) {
-        log::trace!("prepare_lines force: {force}");
         let scroll_offset_lines = self.scroll_animation.position.floor() as isize;
         let height = self.grid_size.height as isize;
         if height == 0 {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* Remove the error log for WindowCommand sent to uninitialized grid when multigrid is disabled. 
  * Fixes https://github.com/neovide/neovide/issues/2576
* Remove unnecessary `prepare_lines` message 

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
