### PR TITLE
chore: Remove obsolete `--no-fork` arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,6 @@ fn maybe_disown() {
             .stdin(process::Stdio::null())
             .stdout(process::Stdio::null())
             .stderr(process::Stdio::null())
-            .arg("--no-fork")
             .args(env::args().skip(1))
             .spawn()
             .is_ok());

--- a/website/docs/editing-with-external-tools.md
+++ b/website/docs/editing-with-external-tools.md
@@ -11,7 +11,7 @@ your own responsibility._
 In your configuration file:
 
 ```yaml
-editor: "neovide --no-fork"
+editor: "neovide"
 ```
 
 ...as `jrnl` saves & removes the temporary file as soon as the main process exits, which happens

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -83,7 +83,7 @@ be very fast. If not, it will build Neovide first. You have to specify
 
     ```sh
     cd [neovide-source-dir]
-    cargo run --profile profiling --features profiling -- --no-fork [neovide-arguments...]
+    cargo run --profile profiling --features profiling -- [neovide-arguments...]
     ```
 
     Now do whatever leads to performance issue in Neovide and exit.


### PR DESCRIPTION
I noticed that my neovide call looks like this in the process list:

```
> ps ax | grep -E '[n]eovide'
 134800 pts/2    Sl     0:00 /usr/bin/neovide --no-fork --fork
```

I'm using `--fork` argument, why there's --no-fork?

@fredizzimo probably you forgot to remove this?

I removed this arg, and it works as expected. Also, cleaned up docs.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
