### PR TITLE
fix: Unset ARGV0 on startup

### DIFF
--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -76,6 +76,8 @@ impl Config {
     }
 
     fn write_to_env(&self) {
+        // This variable is set by the AppImage runtime and causes probles for child processes
+        env::remove_var("ARGV0");
         if let Some(wsl) = self.wsl {
             env::set_var("NEOVIDE_WSL", wsl.to_string());
         }


### PR DESCRIPTION
This should close #2477 with child processes run from zsh having the wrong argv[0].

Strictly speaking this could be put behind an appimage feature flag which then AppImage could be built with, but for something this small it didn't really feel necessary. I figured it would be best to remove the env variable the same place all the other env manipulation is done, but if somewhere else makes more sense I'm happy to move it.

I have yet to actually build and test an appimage with this change.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
