### PR TITLE
chore: Fix reviewdog installation on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macOS-12, ubuntu-latest]
+        os: [win22/20240514.3, macOS-12, ubuntu-latest]
         toolchain: [stable, nightly]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The reviewdog installation started to fail after the 20240603.1.1 windows image update

## Did this PR introduce a breaking change? 
- No
