### PR TITLE
fix: C-Space was not mappable on Windows

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -301,7 +301,7 @@ fn get_special_key(key_event: &KeyEvent) -> Option<&str> {
         NamedKey::Space => {
             // Space can finish a dead key sequence, so treat space as a special key only when
             // that doesn't happen.
-            if key_event.text == Some(" ".into()) || key_event.text == None {
+            if key_event.text == Some(" ".into()) || key_event.text.is_none() {
                 Some("Space")
             } else {
                 None

--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -301,7 +301,7 @@ fn get_special_key(key_event: &KeyEvent) -> Option<&str> {
         NamedKey::Space => {
             // Space can finish a dead key sequence, so treat space as a special key only when
             // that doesn't happen.
-            if key_event.text == Some(" ".into()) {
+            if key_event.text == Some(" ".into()) || key_event.text == None {
                 Some("Space")
             } else {
                 None


### PR DESCRIPTION
Fixes https://github.com/neovide/neovide/issues/2669

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

I had this keymap that wasn’t working before the change and works with it
```
vim.keymap.set('n', '<C-Space>', '<cmd>echomsg "Test!"<CR>')
```