### PR TITLE
Remove Snap store from installation.md

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -140,16 +140,6 @@ Just add `neovide` from nixpkgs to your `environment.systemPackages` in `configu
 environment.systemPackages = with pkgs; [neovide];
 ```
 
-### Snap
-
-Neovide is also available in the Snap Store. You can install it using the command below.
-
-```sh
-snap install neovide
-```
-
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-white.svg)](https://snapcraft.io/neovide)
-
 ### Linux Source
 
 1. Install necessary dependencies (adjust for your preferred package manager, probably most of this


### PR DESCRIPTION
Removes Snap store install option from the website (at least until the snap version stops being broken)

See #1149

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Documentation

## Did this PR introduce a breaking change? 
- No
