### PR TITLE
Detach prompt

### DIFF
--- a/src/bridge/exit_handler.lua
+++ b/src/bridge/exit_handler.lua
@@ -1,0 +1,30 @@
+local function quit(confirm)
+    if confirm then
+        vim.cmd("confirm qa")
+    else
+        vim.cmd("qa!")
+    end
+end
+
+local function detach_handler(is_remote)
+    if is_remote then
+        local detach = vim.g.neovide_detach_on_quit or "prompt"
+        local c
+        if detach == "always_quit" then
+            c = 2
+        elseif detach == "always_detach" then
+            c = 1
+        else
+            c = vim.fn.confirm("Closing remote connection.", "&Detach\n&Quit\n&Cancel", 1)
+        end
+
+        if c == 1 then
+            vim.fn.chanclose(vim.g.neovide_channel_id)
+        elseif c == 2 then
+            quit(vim.g.neovide_confirm_quit or false)
+        end
+    else
+        quit(vim.g.neovide_confirm_quit or false)
+    end
+end
+return detach_handler(...)

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -7,9 +7,10 @@ use nvim_rs::{call_args, error::CallError, rpc::model::IntoVal, Neovim, Value};
 use strum::AsRefStr;
 use tokio::sync::mpsc::unbounded_channel;
 
-use super::show_error_message;
+use super::{show_error_message, SETTINGS};
 use crate::{
     bridge::NeovimWriter,
+    cmd_line::CmdLineSettings,
     profiling::{tracy_dynamic_zone, tracy_fiber_enter, tracy_fiber_leave},
     LoggingSender,
 };
@@ -178,14 +179,19 @@ impl ParallelCommand {
         // for failure is when neovim has already quit, and a command, for example mouse move is
         // being sent
         let result = match self {
-            ParallelCommand::Quit => nvim
-                .command(
-                    "if get(g:, 'neovide_confirm_quit', 0) == 1 | confirm qa | else | qa! | endif",
-                )
-                .await
+            ParallelCommand::Quit => {
                 // Ignore all errors, since neovim exits immediately before the response is sent.
                 // We could an RPC notify instead of request, but nvim-rs does currently not support it.
-                .or(Ok(())),
+                let _ = nvim
+                    .exec_lua(
+                        include_str!("exit_handler.lua"),
+                        vec![Value::Boolean(
+                            SETTINGS.get::<CmdLineSettings>().server.is_some(),
+                        )],
+                    )
+                    .await;
+                Ok(())
+            }
             ParallelCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)
                 .await

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -551,6 +551,26 @@ vim.g.neovide_confirm_quit = true
 If set to `true`, quitting while having unsaved changes will require confirmation. Enabled by
 default.
 
+#### Detach On Quit
+
+Possible values are `always_quit`, `always_detach`, or `prompt`. Set to `prompt` by default.
+
+VimScript:
+
+```vim
+let g:neovide_detach_on_quit = 'always_quit'
+```
+
+Lua:
+
+```lua
+vim.g.neovide_detach_on_quit = 'always_quit'
+```
+
+This option changes the closing behavior of Neovide when it's used to connect to a remote Neovim
+instance. It does this by switching between detaching from the remote instance and quitting Neovim
+entirely.
+
 #### Fullscreen
 
 VimScript:


### PR DESCRIPTION
This adds functionality to detach the Neovide instance from a remote Neovim instance without fully closing Neovim. Functionality can be configured by the user, which is detailed in the documentation changes.

Comments and suggestions are always welcome, especially in regards to which option should be default.

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
