### PR TITLE
Run Clippy directly instead of reviewdog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,16 +53,6 @@ jobs:
       - name: Show toolchain info
         run: cargo --version --verbose
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install neovim
         uses: rhysd/action-setup-vim@v1
         with:
@@ -73,6 +63,8 @@ jobs:
 
       - name: Install cargo-nextest
         run: cargo binstall -y cargo-nextest
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
         env:
@@ -110,18 +102,10 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Show toolchain info
         run: cargo --version --verbose
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
@@ -149,15 +133,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v4
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          toolchain: stable
 
       - name: Install dependencies
         run: |
@@ -182,6 +161,8 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          components: clippy
 
       - name: Show toolchain info
         run: cargo --version --verbose
@@ -93,24 +92,40 @@ jobs:
           path: |
             test-results-${{ matrix.os }}-${{ matrix.toolchain }}
 
+  clippy:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macOS-12, ubuntu-latest]
+        toolchain: [stable, nightly]
+    runs-on: ${{ matrix.os }}
 
-      - name: Install Sarif
-        run: cargo binstall -y clippy-sarif sarif-fmt
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Setup Reviewdog
-        uses: reviewdog/action-setup@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          reviewdog_version: latest
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
+
+      - name: Show toolchain info
+        run: cargo --version --verbose
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --message-format=json | clippy-sarif | tee clippy.sarif | sarif-fmt
-        continue-on-error: true
-
-      - name: Run Clippy Reviewdog
-        run: cat clippy.sarif | reviewdog -f=sarif -name=clippy -reporter=github-check -filter-mode=file -fail-on-error=true -level=warning
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy --all-targets -- -D warnings
+        continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
   event-upload:
     needs: test
@@ -123,7 +138,7 @@ jobs:
           path: ${{ github.event_path }}
 
   build-deploy:
-    needs: test
+    needs: [test, clippy]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,15 +138,18 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install Cargo Binstall
+        uses: cargo-bins/cargo-binstall@main
+
       - name: Install dependencies
         run: |
           if [[ $RUNNER_OS == "Windows" ]]; then
-            if ! which cargo-wix; then cargo install cargo-wix; fi
+            if ! which cargo-wix; then cargo binstall -y cargo-wix; fi
 
           elif [[ $RUNNER_OS == "macOS" ]]; then
             rustup target add x86_64-apple-darwin
             rustup target add aarch64-apple-darwin
-            if ! which cargo-bundle; then cargo install cargo-bundle; fi
+            if ! which cargo-bundle; then cargo binstall -y cargo-bundle; fi
 
           elif [[ $RUNNER_OS == "Linux" ]]; then
             sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
     uses: ./.github/workflows/lint-app.yml
 
   test:
-    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +84,6 @@ jobs:
             test-results-${{ matrix.os }}-${{ matrix.toolchain }}
 
   clippy:
-    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +120,6 @@ jobs:
           path: ${{ github.event_path }}
 
   build-deploy:
-    needs: [test, clippy]
     strategy:
       fail-fast: false
       matrix:

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,8 +3,6 @@ mod ring_buffer;
 mod test;
 
 pub use ring_buffer::*;
-#[cfg(test)]
-pub use test::*;
 
 #[cfg(not(target_os = "windows"))]
 pub fn is_tty() -> bool {

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -69,51 +69,6 @@ pub fn ascii_to_points(ascii: &str) -> Vec<Point> {
         .collect()
 }
 
-pub fn assert_points_eq(actual: Vec<Point>, expected_ascii: &str) {
-    let expected = ascii_to_points(expected_ascii);
-    if expected.len() != actual.len() || expected.iter().zip(actual.iter()).any(|(a, b)| a != b) {
-        let actual_ascii = points_to_ascii(actual);
-        panic!(
-            indoc! {"
-                Points do not match
-                Expected:
-                {}
-                Actual:
-                {}
-            "},
-            expected_ascii, actual_ascii
-        );
-    }
-}
-
-pub fn points_to_ascii(points: Vec<Point>) -> String {
-    if points
-        .iter()
-        .any(|point| point.x.fract() != 0.0 || point.y.fract() != 0.)
-    {
-        panic!("Points must be integers to render as ascii");
-    }
-
-    let line_width = points.iter().map(|p| p.x as usize).max().unwrap() + 1;
-    let line_count = points.iter().map(|p| p.y as usize).max().unwrap() + 1;
-    let mut ascii = vec![vec![' '; line_width]; line_count];
-    let numbers_big_enough = points.len() <= 9;
-    let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    for (index, p) in points.iter().enumerate() {
-        let char = if numbers_big_enough {
-            std::char::from_digit(index as u32, 10).unwrap()
-        } else {
-            chars.chars().nth(index).expect("Too many points")
-        };
-        ascii[p.y as usize][p.x as usize] = char;
-    }
-    ascii
-        .iter()
-        .map(|line| line.iter().collect::<String>())
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 #[test]
 fn ascii_to_rect_works() {
     // Single rect


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* Reviewdog stopped working from because of a Github runner update. Additionally, the output was quite confusing, so this replaces it by a standard job running `clippy`. With a proper failure when there are errors.

  Note, due to https://github.com/actions/runner/issues/2347, all errors from the nightly build are ignored. It would be preferable to just generate a warning instead of a failure, but the Github actions do not support that. We also don't want to fail pull requests due to new Clippy warnings included in the nightly toolchain (which might even be false positives due to the unstable toolchain). My plan is to introduce a nightly build at some point, which actually fails the Clippy step, so that the maintainers can fix the Clippy warnings, before the next stable Rust release.  
* This PR also fixes the CI caching by using [Rust Cache Action](https://github.com/marketplace/actions/rust-cache), rather than the generic Gtihub cache action.
* Some unused functions were also deleted to fix the CI builds.
* Finally, all the jobs are run in parallel to speed up the CI.

## Did this PR introduce a breaking change? 
- No
