### PR TITLE
fix: A smal tweak to how the baseline offset and underline position is calculated

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -317,7 +317,7 @@ impl CursorRenderer {
         canvas.save();
         canvas.clip_path(&path, None, Some(false));
 
-        let y_adjustment = grid_renderer.shaper.y_adjustment();
+        let baseline_offset = grid_renderer.shaper.baseline_offset();
         let style = &self.cursor.grid_cell.1;
         let coarse_style = style.as_ref().map(|style| style.into()).unwrap_or_default();
 
@@ -326,7 +326,7 @@ impl CursorRenderer {
         for blob in blobs.iter() {
             canvas.draw_text_blob(
                 blob,
-                (self.destination.x, self.destination.y + y_adjustment),
+                (self.destination.x, self.destination.y + baseline_offset),
                 &paint,
             );
         }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -219,7 +219,7 @@ impl CachingShaper {
         self.metrics().stroke_size
     }
 
-    pub fn y_adjustment(&mut self) -> f32 {
+    pub fn baseline_offset(&mut self) -> f32 {
         let metrics = self.metrics();
         metrics.ascent + metrics.leading + self.linespace / 2.
     }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -212,7 +212,7 @@ impl CachingShaper {
 
     pub fn underline_position(&mut self) -> f32 {
         let metrics = self.metrics();
-        metrics.ascent - metrics.underline_offset + self.linespace / 2.
+        self.baseline_offset() - metrics.underline_offset
     }
 
     pub fn stroke_size(&mut self) -> f32 {

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -221,7 +221,11 @@ impl CachingShaper {
 
     pub fn baseline_offset(&mut self) -> f32 {
         let metrics = self.metrics();
-        metrics.ascent + metrics.leading + self.linespace / 2.
+        // NOTE: leading is also called linegap and should be equally distributed on the top and
+        // bottom, so it's centered like our linespace settings. That's how it works on the web,
+        // but some desktop applications only use the top according to:
+        // https://googlefonts.github.io/gf-guide/metrics.html#8-linegap-values-must-be-0
+        metrics.ascent + (metrics.leading + self.linespace) / 2.0
     }
 
     fn build_clusters(

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -197,7 +197,7 @@ impl GridRenderer {
         let trimmed = trimmed.trim_end();
         let adjustment = PixelVec::new(
             leading_spaces as f32 * self.grid_scale.0.width,
-            self.shaper.y_adjustment(),
+            self.shaper.baseline_offset(),
         );
 
         if !trimmed.is_empty() {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* Rename `y_adjustment` to `baseline_offset`
* The `leading/linegap` is now distributed equally on top and bottom, like for the `linespace` setting
* The underline offset is relative to the `baseline_offset`

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
