### PR TITLE
fix: Unset ARGV0 to fix AppImage launch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,10 @@ fn main() -> NeovideExitCode {
         windows_fix_dpi();
     }
 
+    // This variable is set by the AppImage runtime and causes problems for child processes
+    #[cfg(target_os = "linux")]
+    env::remove_var("ARGV0");
+
     let event_loop = create_event_loop();
     clipboard::init(&event_loop);
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Unset `ARGV0` to fix AppImage

* fixes https://github.com/neovide/neovide/issues/2477

## Did this PR introduce a breaking change? 
- No
