### PR TITLE
fix: Fix the remote clipboard support

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -49,9 +49,13 @@ if args.register_clipboard and not vim.g.neovide_no_custom_clipboard then
             ["+"] = get_clipboard("+"),
             ["*"] = get_clipboard("*"),
         },
-        cache_enabled = 0
+        cache_enabled = false
     }
+    vim.g.loaded_clipboard_provider = nil
+    vim.cmd.runtime("autoload/provider/clipboard.vim")
 end
+
+
 
 if args.register_right_click then
     vim.api.nvim_create_user_command("NeovideRegisterRightClick", function()

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -27,15 +27,15 @@ local function rpcrequest(method, ...)
 end
 
 local function set_clipboard(register)
-    return function(lines, regtype)
+    return function(lines)
         rpcrequest("neovide.set_clipboard", lines)
     end
 end
 
 local function get_clipboard(register)
     return function()
-        return rpcrequest("neovide.get_clipboard", register)
-    end
+        return rpcrequest("neovide.get_clipboard")
+   end
 end
 
 if args.register_clipboard and not vim.g.neovide_no_custom_clipboard then

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -28,13 +28,13 @@ end
 
 local function set_clipboard(register)
     return function(lines)
-        rpcrequest("neovide.set_clipboard", lines)
+        rpcrequest("neovide.set_clipboard", lines, register)
     end
 end
 
 local function get_clipboard(register)
     return function()
-        return rpcrequest("neovide.get_clipboard")
+        return rpcrequest("neovide.get_clipboard", register)
    end
 end
 

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -57,10 +57,10 @@ impl Handler for NeovimHandler {
                         s.next().map(String::from)
                     });
 
-                get_clipboard_contents(endline_type.as_deref())
+                get_clipboard_contents(endline_type.as_deref(), &arguments[0])
                     .map_err(|_| Value::from("cannot get clipboard contents"))
             }
-            "neovide.set_clipboard" => set_clipboard_contents(&arguments[0])
+            "neovide.set_clipboard" => set_clipboard_contents(&arguments[0], &arguments[1])
                 .map_err(|_| Value::from("cannot set clipboard contents")),
             "neovide.quit" => {
                 let error_code = arguments[0]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -2,7 +2,10 @@ use std::error::Error;
 use std::sync::OnceLock;
 
 #[cfg(target_os = "linux")]
-use copypasta::wayland_clipboard;
+use copypasta::{
+    wayland_clipboard,
+    x11_clipboard::{Primary as X11SelectionClipboard, X11ClipboardContext},
+};
 use copypasta::{ClipboardContext, ClipboardProvider};
 use parking_lot::Mutex;
 use raw_window_handle::HasRawDisplayHandle;
@@ -14,24 +17,60 @@ use crate::window::UserEvent;
 
 type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync + 'static>>;
 
-static CLIPBOARD: OnceLock<Mutex<Box<dyn ClipboardProvider>>> = OnceLock::new();
+pub struct Clipboard {
+    clipboard: Box<dyn ClipboardProvider>,
+    #[cfg(target_os = "linux")]
+    selection: Box<dyn ClipboardProvider>,
+}
+
+static CLIPBOARD: OnceLock<Mutex<Clipboard>> = OnceLock::new();
 
 pub fn init(event_loop: &EventLoop<UserEvent>) {
     CLIPBOARD
         .set(Mutex::new(match event_loop.raw_display_handle() {
             #[cfg(target_os = "linux")]
             RawDisplayHandle::Wayland(WaylandDisplayHandle { display, .. }) => unsafe {
-                Box::new(wayland_clipboard::create_clipboards_from_external(display).1)
+                let clipboards = wayland_clipboard::create_clipboards_from_external(display);
+                Clipboard {
+                    clipboard: Box::new(clipboards.1),
+                    selection: Box::new(clipboards.0),
+                }
             },
-            _ => Box::new(ClipboardContext::new().unwrap()),
+            #[cfg(target_os = "linux")]
+            _ => Clipboard {
+                clipboard: Box::new(ClipboardContext::new().unwrap()),
+                selection: Box::new(X11ClipboardContext::<X11SelectionClipboard>::new().unwrap()),
+            },
+            #[cfg(not(target_os = "linux"))]
+            _ => Clipboard {
+                clipboard: Box::new(ClipboardContext::new().unwrap()),
+            },
         }))
         .ok();
 }
 
-pub fn get_contents() -> Result<String> {
-    CLIPBOARD.get().unwrap().lock().get_contents()
+pub fn get_contents(register: &str) -> Result<String> {
+    match register {
+        #[cfg(target_os = "linux")]
+        "*" => CLIPBOARD.get().unwrap().lock().selection.get_contents(),
+        _ => CLIPBOARD.get().unwrap().lock().clipboard.get_contents(),
+    }
 }
 
-pub fn set_contents(lines: String) -> Result<()> {
-    CLIPBOARD.get().unwrap().lock().set_contents(lines)
+pub fn set_contents(lines: String, register: &str) -> Result<()> {
+    match register {
+        #[cfg(target_os = "linux")]
+        "*" => CLIPBOARD
+            .get()
+            .unwrap()
+            .lock()
+            .selection
+            .set_contents(lines),
+        _ => CLIPBOARD
+            .get()
+            .unwrap()
+            .lock()
+            .clipboard
+            .set_contents(lines),
+    }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -30,10 +30,11 @@ pub fn init(event_loop: &EventLoop<UserEvent>) {
         .set(Mutex::new(match event_loop.raw_display_handle() {
             #[cfg(target_os = "linux")]
             RawDisplayHandle::Wayland(WaylandDisplayHandle { display, .. }) => unsafe {
-                let clipboards = wayland_clipboard::create_clipboards_from_external(display);
+                let (selection, clipboard) =
+                    wayland_clipboard::create_clipboards_from_external(display);
                 Clipboard {
-                    clipboard: Box::new(clipboards.1),
-                    selection: Box::new(clipboards.0),
+                    clipboard: Box::new(clipboard),
+                    selection: Box::new(selection),
                 }
             },
             #[cfg(target_os = "linux")]

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -248,7 +248,7 @@ impl State {
                         true
                     }
                     "y" => {
-                        let _ = clipboard::set_contents(message.to_string());
+                        let _ = clipboard::set_contents(message.to_string(), "+");
                         true
                     }
                     _ => false,


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* The clipboard provider is now properly reloaded after setting up the clipboard. 
* This also adds support for the selection register `*` on Linux

* Fixes https://github.com/neovide/neovide/issues/2613

## Did this PR introduce a breaking change? 
- No
