### PR TITLE
fix(wgpu)!: Load and use the fonts from the config instead of hardcoded ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -120,33 +120,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -364,7 +364,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -512,7 +512,7 @@ checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -520,6 +520,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -646,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -656,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -668,21 +674,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
@@ -706,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "com"
@@ -801,19 +807,6 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
@@ -821,7 +814,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -838,25 +831,13 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "19.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
-dependencies = [
- "core-foundation",
- "core-graphics 0.22.3",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-text"
 version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation",
- "core-graphics 0.23.2",
- "foreign-types 0.5.0",
+ "core-graphics",
+ "foreign-types",
  "libc",
 ]
 
@@ -913,16 +894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68523903c8ae5aacfa32a0d9ae60cadeb764e1da14ee0d26b1f3089f13a54636"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,7 +930,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -982,16 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,17 +962,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1028,7 +978,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1232,41 +1182,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-ord"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
-
-[[package]]
 name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
-
-[[package]]
-name = "font-kit"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0504fc23a34d36352540ae5eedcec2623c86607a4efe25494ca9641845c5a50"
-dependencies = [
- "bitflags 2.6.0",
- "byteorder",
- "core-foundation",
- "core-graphics 0.22.3",
- "core-text 19.2.0",
- "dirs-next",
- "dwrote",
- "float-ord",
- "freetype",
- "lazy_static",
- "libc",
- "log",
- "pathfinder_geometry",
- "pathfinder_simd",
- "walkdir",
- "winapi",
- "yeslogic-fontconfig-sys",
-]
 
 [[package]]
 name = "font-types"
@@ -1293,7 +1212,7 @@ version = "0.1.0"
 source = "git+https://github.com/linebender/parley?rev=5b60803d1256ab821f79eaa06721a3112de7202a#5b60803d1256ab821f79eaa06721a3112de7202a"
 dependencies = [
  "core-foundation",
- "core-text 20.1.0",
+ "core-text",
  "dwrote",
  "fontconfig-cache-parser",
  "hashbrown",
@@ -1311,21 +1230,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1336,41 +1246,14 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "freetype"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a440748e063798e4893ceb877151e84acef9bea9a8c6800645cf3f1b3a7806e"
-dependencies = [
- "freetype-sys",
- "libc",
-]
-
-[[package]]
-name = "freetype-sys"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "fsevent-sys"
@@ -1482,7 +1365,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1519,16 +1402,15 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186014d53bc231d0090ef8d6f03e0920c54d85a5ed22f4f2f74315ec56cf83fb"
+checksum = "979f00864edc7516466d6b3157706e06c032f22715700ddd878228a91d02bc56"
 dependencies = [
- "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.54.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1864,12 +1746,12 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
 dependencies = [
  "bytemuck",
- "byteorder",
+ "byteorder-lite",
  "num-traits",
  "png",
  "zune-core",
@@ -1943,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1986,9 +1868,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -2273,7 +2155,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -2299,6 +2181,18 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2393,7 +2287,6 @@ dependencies = [
  "objc2 0.4.1",
  "palette",
  "parking_lot",
- "parley",
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
@@ -2406,11 +2299,10 @@ dependencies = [
  "shlex",
  "spin_sleep",
  "strum",
- "swash",
  "time",
  "tokio",
  "tokio-util",
- "toml 0.8.15",
+ "toml 0.8.16",
  "tracy-client-sys 0.22.2",
  "unicode-segmentation",
  "vide",
@@ -2446,7 +2338,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -2556,16 +2448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,7 +2465,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2853,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -2927,7 +2809,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2991,25 +2873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pathfinder_geometry"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
-dependencies = [
- "log",
- "pathfinder_simd",
-]
-
-[[package]]
-name = "pathfinder_simd"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf45976c56919841273f2a0fc684c28437e2f304e264557d9c72be5d5a718be"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "peniko"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,7 +2918,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3084,7 +2947,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3222,7 +3085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3462,7 +3325,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.71",
+ "syn 2.0.72",
  "walkdir",
 ]
 
@@ -3487,15 +3350,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -3547,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4465c22496331e20eb047ff46e7366455bc01c0c02015c4a376de0b2cd3a1af"
+checksum = "1fadf67e3cf23f8b11a6c8c48a16cb2437381503615acd91094ec7b4686a5a53"
 dependencies = [
  "sdd",
 ]
@@ -3592,12 +3446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85f05a494052771fc5bd0619742363b5e24e5ad72ab3111ec2e27925b8edc5f3"
 
 [[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-
-[[package]]
 name = "serde"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,7 +3462,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3630,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -3659,7 +3507,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3905,7 +3753,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3938,9 +3786,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3973,7 +3821,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4053,21 +3901,20 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes 1.6.1",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4083,13 +3930,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4117,21 +3964,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit 0.22.17",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
@@ -4149,15 +3996,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.16"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.14",
+ "winnow 0.6.16",
 ]
 
 [[package]]
@@ -4294,20 +4141,19 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vide"
 version = "0.1.0"
-source = "git+https://github.com/neovide/vide#721b2ca876c7fbdbb95f6e9adb6bb52c6c6af968"
+source = "git+https://github.com/neovide/vide?rev=d89bd709a5d0896deef8456c3a89d77cbf51b448#d89bd709a5d0896deef8456c3a89d77cbf51b448"
 dependencies = [
  "base64",
  "bytemuck",
  "codespan-reporting",
  "etagere",
- "font-kit",
  "futures 0.3.30",
  "futures-intrusive",
  "glam",
@@ -4327,7 +4173,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smol",
- "swash",
  "termcolor",
  "thread_local",
  "wgpu",
@@ -4384,7 +4229,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -4418,7 +4263,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4764,21 +4609,21 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
  "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -4793,23 +4638,26 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result 0.1.2",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -4821,7 +4669,18 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4832,7 +4691,18 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5095,7 +4965,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "concurrent-queue",
  "core-foundation",
- "core-graphics 0.23.2",
+ "core-graphics",
  "cursor-icon",
  "dpi",
  "js-sys",
@@ -5143,9 +5013,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.14"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374ec40a2d767a3c1b4972d9475ecd557356637be906f2cb3f7fe17a6eb5e22f"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]
@@ -5275,18 +5145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
 
 [[package]]
-name = "yeslogic-fontconfig-sys"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb6b23999a8b1a997bf47c7bb4d19ad4029c3327bb3386ebe0a5ff584b33c7a"
-dependencies = [
- "cstr",
- "dlib",
- "once_cell",
- "pkg-config",
-]
-
-[[package]]
 name = "zeno"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5309,7 +5167,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5320,9 +5178,9 @@ checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
+checksum = "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ num = "0.4.1"
 nvim-rs = { version = "0.7.0", features = ["use_tokio"] }
 palette = "0.7.6"
 parking_lot = "0.12.0"
-parley = { git = "https://github.com/linebender/parley", rev="5b60803d1256ab821f79eaa06721a3112de7202a" }
 rand = "0.8.5"
 raw-window-handle = "0.6.0"
 rmpv = "1.0.0"
@@ -62,7 +61,6 @@ serde_json = "1.0.79"
 shlex = "1.1.0"
 spin_sleep = "1.1.1"
 strum = { version = "0.26.2", features = ["derive"] }
-swash = { version = "0.1.8", default-features = false }
 time = { version = "0.3.34", features = ["macros", "formatting"] }
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
@@ -75,7 +73,7 @@ tracy-client-sys = { version = "0.22.0", optional = true, default-features = fal
     "fibers",
 ] }
 unicode-segmentation = "1.9.0"
-vide = { git = "https://github.com/neovide/vide" }
+vide = { git = "https://github.com/neovide/vide", rev="d89bd709a5d0896deef8456c3a89d77cbf51b448" }
 which = "6.0.1"
 winit = { version = "=0.30.3", features = ["serde"] }
 xdg = "2.4.1"

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -1,55 +1,67 @@
-use log::{debug, error};
+use std::fmt::{Display, Formatter};
 
-use parley::style::{FontStack, StyleProperty};
-use vide::Shaper;
+use itertools::Itertools;
+use log::{debug, info};
+
+use palette::Srgba;
+use vide::{
+    parley::{
+        context::RangedBuilder,
+        style::{FontFamily, FontStack, FontStyle, FontWeight, StyleProperty},
+        Layout,
+    },
+    Shaper,
+};
 
 use crate::{error_msg, profiling::tracy_zone, renderer::fonts::font_options::*, units::PixelSize};
 
-/*
-#[derive(new, Clone, Hash, PartialEq, Eq, Debug)]
-struct ShapeKey {
-    pub text: String,
-    pub style: CoarseStyle,
+#[derive(Debug, Clone)]
+struct FontInfo {
+    width: f32,
+    height: f32,
 }
-*/
 
 pub struct CachingShaper {
     options: FontOptions,
     scale_factor: f32,
+    linespace: f32,
     pub shaper: Shaper,
+    font_info: Option<FontInfo>,
+}
+
+#[derive(Debug, Default, Hash, PartialEq, Eq, Clone)]
+pub struct FontKey {
+    // TODO(smolck): Could make these private and add constructor method(s)?
+    // Would theoretically make things safer I guess, but not sure . . .
+    pub font_desc: Option<FontDescription>,
+    pub hinting: FontHinting,
+    pub edging: FontEdging,
+}
+
+impl Display for FontKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "FontKey {{ font_desc: {:?}, hinting: {:?}, edging: {:?} }}",
+            self.font_desc, self.hinting, self.edging
+        )
+    }
 }
 
 impl CachingShaper {
     pub fn new(scale_factor: f32) -> Self {
         let options = FontOptions::default();
-        let font_size = options.size * scale_factor;
-        let mut shaper = Shaper::new();
-        shaper.push_default(StyleProperty::FontStack(FontStack::Source(
-            "FiraCode Nerd Font",
-        )));
-        shaper.push_default(StyleProperty::FontSize(font_size));
-        Self {
-            options,
+        let shaper = Shaper::new();
+        let mut ret = Self {
+            options: options.clone(),
             scale_factor,
+            linespace: 0.0,
             shaper,
-        }
+            font_info: None,
+        };
+        ret.update_font_options(options);
+        ret
     }
-
-    /*
-    fn current_font_pair(&mut self) -> Arc<FontPair> {
-        self.font_loader
-            .get_or_load(&FontKey {
-                font_desc: self.options.primary_font(),
-                hinting: self.options.hinting.clone(),
-                edging: self.options.edging.clone(),
-            })
-            .unwrap_or_else(|| {
-                self.font_loader
-                    .get_or_load(&FontKey::default())
-                    .expect("Could not load default font")
-            })
-    }
-    */
 
     pub fn current_size(&self) -> f32 {
         let min_font_size = 1.0;
@@ -59,7 +71,7 @@ impl CachingShaper {
     pub fn update_scale_factor(&mut self, scale_factor: f32) {
         debug!("scale_factor changed: {:.2}", scale_factor);
         self.scale_factor = scale_factor;
-        self.reset_font_loader();
+        self.reset();
     }
 
     pub fn update_font(&mut self, guifont_setting: &str) {
@@ -79,21 +91,20 @@ impl CachingShaper {
     pub fn update_font_options(&mut self, options: FontOptions) {
         debug!("Updating font options: {:?}", options);
 
-        /*
         let keys = options
             .possible_fonts()
-            .iter()
-            .map(|desc| FontKey {
-                font_desc: Some(desc.clone()),
-                hinting: options.hinting.clone(),
-                edging: options.edging.clone(),
-            })
+            .into_iter()
             .unique()
             .collect::<Vec<_>>();
 
         let failed_fonts = keys
             .iter()
-            .filter(|key| self.font_loader.get_or_load(key).is_none())
+            .filter(|font_desc| {
+                self.shaper
+                    .font_collection()
+                    .family_by_name(&font_desc.family)
+                    .is_none()
+            })
             .collect_vec();
 
         if !failed_fonts.is_empty() {
@@ -108,119 +119,108 @@ impl CachingShaper {
         if failed_fonts.len() != keys.len() {
             debug!("Font updated to: {:?}", options);
             self.options = options;
-            self.reset_font_loader();
+            self.reset();
         }
-        */
     }
 
     pub fn update_linespace(&mut self, linespace: f32) {
         debug!("Updating linespace: {}", linespace);
-
-        let font_height = self.font_base_dimensions().height;
-        let impossible_linespace = font_height + linespace <= 0.0;
-
-        if !impossible_linespace {
-            debug!("Linespace updated to: {linespace}");
-            //self.linespace = linespace;
-            self.reset_font_loader();
-        } else {
-            let reason = if impossible_linespace {
-                "Linespace too negative, would make font invisible"
-            } else {
-                "Font not found"
-            };
-            error!("Linespace can't be updated to {linespace} due to: {reason}");
-        }
+        self.linespace = linespace;
     }
 
-    fn reset_font_loader(&mut self) {
-        tracy_zone!("reset_font_loader");
-        /*
+    fn reset(&mut self) {
         self.font_info = None;
-        let font_size = self.current_size();
 
-        self.font_loader = FontLoader::new(font_size);
-        let (_, font_width) = self.info();
-        info!(
-            "Reset Font Loader: font_size: {:.2}px, font_width: {:.2}px",
-            font_size, font_width
-        );
-
-        self.blob_cache.clear();
-        */
+        info!("Reset Font Loader -> font_info {:#?}", self.info());
     }
 
-    pub fn font_names(&self) -> Vec<String> {
-        //self.font_loader.font_names()
-        Vec::new()
+    pub fn font_names(&mut self) -> Vec<String> {
+        self.shaper
+            .font_collection()
+            .family_names()
+            .map(|name| name.to_string())
+            .sorted()
+            .collect_vec()
     }
 
-    /*
-    fn info(&mut self) -> (Metrics, f32) {
-        if let Some(info) = self.font_info {
-            return info;
+    fn info(&mut self) -> FontInfo {
+        if let Some(info) = &self.font_info {
+            return info.clone();
         }
+        tracy_zone!("Caculate font info");
 
-        let font_pair = self.current_font_pair();
-        let size = self.current_size();
-        let mut shaper = self
-            .shape_context
-            .builder(font_pair.swash_font.as_ref())
-            .size(size)
-            .build();
-        shaper.add_str("M");
-        let metrics = shaper.metrics();
-        let mut advance = metrics.average_width;
-        shaper.shape_with(|cluster| {
-            advance = cluster
-                .glyphs
-                .first()
-                .map_or(metrics.average_width, |g| g.advance);
+        self.shaper.clear_defaults();
+
+        let font_size = self.current_size();
+        self.shaper.push_default(StyleProperty::FontSize(font_size));
+
+        let layout = self.shaper.layout_with("M", |builder| {
+            if let Some(font_desc) = self.options.primary_font() {
+                builder.push_default(&StyleProperty::FontStack(FontStack::Source(
+                    &font_desc.family,
+                )));
+            }
         });
-        self.font_info = Some((metrics, advance));
-        (metrics, advance)
+        FontInfo {
+            width: layout.width(),
+            height: layout.height(),
+        }
     }
 
-    fn metrics(&mut self) -> Metrics {
-        tracy_zone!("font_metrics");
-        self.info().0
+    fn clamped_linespace(&mut self) -> f32 {
+        let info = self.info();
+        // Only allow half the font height of negative linespace
+        (self.linespace * self.scale_factor).max(-info.height / 2.0)
     }
-    */
 
     pub fn font_base_dimensions(&mut self) -> PixelSize<f32> {
-        /*
-        let (metrics, glyph_advance) = self.info();
+        let info = self.info();
 
-        let bare_font_height = metrics.ascent + metrics.descent + metrics.leading;
-        // assuming that linespace is checked on receive for validity
-        let font_height = (bare_font_height + self.linespace).ceil();
-        let font_width = glyph_advance + self.options.width;
+        // The height is always divisible by pixels for better hinting and font clarity
+        let font_height = (info.height + self.clamped_linespace()).ceil();
+        let font_width = info.width;
 
         (font_width, font_height).into()
-        */
-
-        (11.487181, 23.0).into()
     }
-
-    /*
-    pub fn underline_position(&mut self) -> f32 {
-        self.baseline_offset()
-    }
-
-    pub fn stroke_size(&mut self) -> f32 {
-        1.0
-    }
-    */
 
     pub fn baseline_offset(&mut self) -> f32 {
-        /*
-        let metrics = self.metrics();
-        NOTE: leading is also called linegap and should be equally distributed on the top and
-        bottom, so it's centered like our linespace settings. That's how it works on the web,
-        but some desktop applications only use the top according to:
-        https://googlefonts.github.io/gf-guide/metrics.html#8-linegap-values-must-be-0
-        metrics.ascent + (metrics.leading + self.linespace) / 2.0
-        */
+        // The baseline_offset is always rounded to pixels for better hinting and clarity
+        (self.clamped_linespace() / 2.0).round()
+    }
+
+    #[allow(unused)]
+    pub fn underline_position(&mut self) -> f32 {
+        // TODO: Fix this
         0.0
+    }
+
+    #[allow(unused)]
+    pub fn stroke_size(&mut self) -> f32 {
+        // TODO: Fix this
+        1.0
+    }
+
+    pub fn layout_with<'a>(
+        &'a mut self,
+        text: &'a str,
+        style: &CoarseStyle,
+        build: impl FnOnce(&mut RangedBuilder<'a, Srgba, &'a str>),
+    ) -> Layout<Srgba> {
+        self.shaper.layout_with(text, |builder| {
+            let font_list = self.options.font_list(*style);
+            let fonts = font_list
+                .iter()
+                .map(|font_desc| FontFamily::Named(&font_desc.family))
+                .collect_vec();
+
+            if style.bold {
+                builder.push_default(&StyleProperty::FontWeight(FontWeight::BOLD));
+            }
+            if style.italic {
+                builder.push_default(&StyleProperty::FontStyle(FontStyle::Italic));
+            }
+            builder.push_default(&StyleProperty::FontStack(FontStack::List(&fonts)));
+            build(builder);
+        })
     }
 }

--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -40,8 +40,8 @@ pub struct FontFeature(pub String, pub u16);
 // TODO: could be made a bitfield sometime?
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct CoarseStyle {
-    bold: bool,
-    italic: bool,
+    pub bold: bool,
+    pub italic: bool,
 }
 
 // TODO: Remove
@@ -69,19 +69,6 @@ impl CoarseStyle {
             })
     }
 }
-
-/*
-impl From<CoarseStyle> for FontStyle {
-    fn from(CoarseStyle { bold, italic }: CoarseStyle) -> Self {
-        match (bold, italic) {
-            (true, true) => FontStyle::bold_italic(),
-            (true, false) => FontStyle::bold(),
-            (false, true) => FontStyle::italic(),
-            (false, false) => FontStyle::normal(),
-        }
-    }
-}
-*/
 
 impl From<&editor::Style> for CoarseStyle {
     fn from(fine_style: &editor::Style) -> Self {
@@ -332,11 +319,6 @@ impl FontHinting {
 
 pub fn points_to_pixels(value: f32) -> f32 {
     // Fonts in neovim are using points, not pixels.
-    //
-    // Skia docs is incorrectly stating it uses points, but uses pixels:
-    // https://api.skia.org/classSkFont.html#a7e28a156a517d01bc608c14c761346bf
-    // https://github.com/mono/SkiaSharp/issues/1147#issuecomment-587421201
-    //
     // So, we need to convert points to pixels.
     //
     // In reality, this depends on DPI/PPI of monitor, but here we only care about converting
@@ -353,51 +335,6 @@ pub fn points_to_pixels(value: f32) -> f32 {
     log::info!("point_to_pixels {value} -> {pixels}");
     pixels
 }
-
-/*
-impl FontDescription {
-    pub fn as_family_and_font_style(&self) -> (&str, FontStyle) {
-        // support font weights:
-        // Thin, ExtraLight, Light, Normal, Medium, SemiBold, Bold, ExtraBold, Black, ExtraBlack
-        // W{weight}
-        // support font slants:
-        // Upright, Italic, Oblique
-
-        let style = if let Some(style) = &self.style {
-            let mut weight = Weight::NORMAL;
-            let mut slant = Slant::Upright;
-
-            for part in style.split_whitespace() {
-                match part {
-                    "Thin" => weight = Weight::THIN,
-                    "ExtraLight" => weight = Weight::EXTRA_LIGHT,
-                    "Light" => weight = Weight::LIGHT,
-                    "Normal" => weight = Weight::NORMAL,
-                    "Medium" => weight = Weight::MEDIUM,
-                    "SemiBold" => weight = Weight::SEMI_BOLD,
-                    "Bold" => weight = Weight::BOLD,
-                    "ExtraBold" => weight = Weight::EXTRA_BOLD,
-                    "Black" => weight = Weight::BLACK,
-                    "ExtraBlack" => weight = Weight::EXTRA_BLACK,
-                    "Italic" => slant = Slant::Italic,
-                    "Oblique" => slant = Slant::Oblique,
-                    _ => {
-                        if let Some(rest) = part.strip_prefix('W') {
-                            if let Ok(weight_value) = rest.parse::<i32>() {
-                                weight = Weight::from(weight_value);
-                            }
-                        }
-                    }
-                }
-            }
-            FontStyle::new(weight, Width::NORMAL, slant)
-        } else {
-            FontStyle::default()
-        };
-        (self.family.as_str(), style)
-    }
-}
-*/
 
 impl fmt::Display for FontDescription {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use log::trace;
 
 use palette::{named, Hsv, IntoColor, Srgba, WithAlpha};
-use parley::style::StyleProperty;
-use vide::{Layer, Quad, Scene};
+use vide::{parley::style::StyleProperty, Layer, Quad, Scene};
 
 use crate::{
     editor::{Colors, Style},
@@ -52,7 +51,7 @@ impl GridRenderer {
         }
     }
 
-    pub fn font_names(&self) -> Vec<String> {
+    pub fn font_names(&mut self) -> Vec<String> {
         self.shaper.font_names()
     }
 
@@ -196,7 +195,7 @@ impl GridRenderer {
         if !trimmed.is_empty() {
             tracy_zone!("draw_text_blob");
             let pos = pos + adjustment;
-            let layout = self.shaper.shaper.layout_with(trimmed, |builder| {
+            let layout = self.shaper.layout_with(trimmed, &style.into(), |builder| {
                 builder.push_default(&StyleProperty::Brush(color));
             });
             scene.add_text_layout(layout, pos.cast());

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -182,7 +182,7 @@ impl Renderer {
         self.cursor_renderer.handle_event(event)
     }
 
-    pub fn font_names(&self) -> Vec<String> {
+    pub fn font_names(&mut self) -> Vec<String> {
         self.grid_renderer.font_names()
     }
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -266,7 +266,7 @@ impl WinitWindowWrapper {
         }
     }
 
-    pub fn send_font_names(&self) {
+    pub fn send_font_names(&mut self) {
         let font_names = self.renderer.font_names();
         send_ui(ParallelCommand::DisplayAvailableFonts(font_names));
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Load and use the fonts from the config instead of hardcoded ones

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, the linespacing is now multiplied by the scale factor as it should be.

