### PR TITLE
fix: Force Neovide to exit, even if the IO streams are not closed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use std::env::{self, args};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::panic::{set_hook, PanicInfo};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use time::macros::format_description;
 use time::OffsetDateTime;
 use winit::event_loop::EventLoopProxy;
@@ -99,11 +99,18 @@ fn main() -> NeovideExitCode {
 
     match setup(event_loop.create_proxy()) {
         Err(err) => handle_startup_errors(err, event_loop).into(),
-        Ok((window_size, font_settings, _runtime)) => {
+        Ok((window_size, font_settings, runtime)) => {
             let mut update_loop =
                 UpdateLoop::new(window_size, font_settings, event_loop.create_proxy());
 
-            event_loop.run_app(&mut update_loop).into()
+            let res = event_loop.run_app(&mut update_loop).into();
+            // Wait a little bit more and force Nevoim to exit after that.
+            // This should not be required, but Neovim through libuv spawns childprocesses that inherits all the handles
+            // This means that the stdio and stderr handles are not properly closed, so the nvim-rs
+            // read will hang forever, waiting for more data to read.
+            // See https://github.com/neovide/neovide/issues/2182 (which includes links to libuv issues)
+            runtime.runtime.shutdown_timeout(Duration::from_millis(500));
+            res
         }
     }
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* fixes https://github.com/neovide/neovide/issues/2182 (but probably not completely)

Neovim through libuv spawns child processes that inherits all the handles. This means that the stdio and stderr handles are not properly closed, so the nvim-rs read will hang forever, waiting for more data to read. To deal with that the Tokio runtime is forced to shutdown after a timeout.

The timeout for waiting for the streams to close has also been reduced to avoid having a too long shutdown delay.

Also see these libuv issues:
* https://github.com/libuv/libuv/pull/3856
* https://github.com/libuv/libuv/issues/1490


## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
