### PR TITLE
chore: update objc2 and remove icrate. also some refactor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,31 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
-name = "block2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
-dependencies = [
- "block-sys",
- "objc2 0.4.1",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
 ]
 
 [[package]]
@@ -1008,7 +989,7 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading",
- "objc2 0.5.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "once_cell",
@@ -1117,16 +1098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2 0.3.0",
- "objc2 0.4.1",
 ]
 
 [[package]]
@@ -1469,7 +1440,6 @@ dependencies = [
  "glamour",
  "glutin",
  "glutin-winit",
- "icrate",
  "image",
  "indoc",
  "itertools 0.13.0",
@@ -1480,7 +1450,9 @@ dependencies = [
  "notify-debouncer-full",
  "num",
  "nvim-rs",
- "objc2 0.4.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "parking_lot",
  "rand 0.8.5",
  "raw-window-handle",
@@ -1717,22 +1689,12 @@ checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
-dependencies = [
- "objc-sys",
- "objc2-encode 3.0.0",
-]
-
-[[package]]
-name = "objc2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
- "objc2-encode 4.0.3",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -1742,9 +1704,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
+ "block2",
  "libc",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation",
@@ -1758,8 +1720,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-core-location",
  "objc2-foundation",
 ]
@@ -1770,8 +1732,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -1782,8 +1744,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -1793,8 +1755,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -1805,17 +1767,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-contacts",
  "objc2-foundation",
 ]
-
-[[package]]
-name = "objc2-encode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc2-encode"
@@ -1830,10 +1786,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
+ "block2",
  "dispatch",
  "libc",
- "objc2 0.5.2",
+ "objc2",
 ]
 
 [[package]]
@@ -1842,8 +1798,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
 ]
@@ -1855,8 +1811,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -1867,8 +1823,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -1879,7 +1835,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -1890,8 +1846,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
@@ -1910,8 +1866,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -1922,8 +1878,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.6.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-core-location",
  "objc2-foundation",
 ]
@@ -3560,7 +3516,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.6.0",
- "block2 0.5.1",
+ "block2",
  "bytemuck",
  "calloop",
  "cfg_aliases",
@@ -3573,7 +3529,7 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2 0.5.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "objc2-ui-kit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,24 +106,9 @@ windows-registry = "0.2.0"
 skia-safe = { version = "0.75.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-icrate = { version = "0.0.4", features = [
-    "apple",
-    "Foundation",
-    "Foundation_NSThread",
-    "Foundation_NSProcessInfo",
-    "AppKit",
-    "AppKit_NSColor",
-    "AppKit_NSEvent",
-    "AppKit_NSView",
-    "AppKit_NSWindow",
-    "AppKit_NSViewController",
-    "AppKit_NSMenu",
-    "AppKit_NSMenuItem",
-    "AppKit_NSOpenPanel",
-    "AppKit_NSScreen",
-    "Foundation_NSArray",
-] }
-objc2 = "0.4.1"
+objc2 = "0.5.2"
+objc2-foundation = { version = "0.2.2" }
+objc2-app-kit = { version = "0.2.2", features = [ "NSLayoutConstraint" ] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1.12"

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -35,7 +35,7 @@ use winit::{
 pub use super::vsync::VSyncWinDwm;
 
 #[cfg(target_os = "macos")]
-pub use super::vsync::VSyncMacos;
+pub use super::vsync::VSyncMacosDisplayLink;
 
 use super::{RendererSettings, SkiaRenderer, VSync, WindowConfig, WindowConfigType};
 
@@ -205,7 +205,7 @@ impl SkiaRenderer for OpenGLSkiaRenderer {
 
         #[cfg(target_os = "macos")]
         {
-            VSync::Macos(VSyncMacos::new(self.window(), proxy))
+            VSync::MacosDisplayLink(VSyncMacosDisplayLink::new(self.window(), proxy))
         }
     }
 

--- a/src/renderer/vsync/mod.rs
+++ b/src/renderer/vsync/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "macos")]
 mod macos_display_link;
 #[cfg(target_os = "macos")]
-mod vsync_macos;
+mod vsync_macos_display_link;
 mod vsync_timer;
 #[cfg(target_os = "windows")]
 mod vsync_win_dwm;
@@ -21,7 +21,7 @@ pub use vsync_win_dwm::VSyncWinDwm;
 pub use vsync_win_swap_chain::VSyncWinSwapChain;
 
 #[cfg(target_os = "macos")]
-pub use vsync_macos::VSyncMacos;
+pub use vsync_macos_display_link::VSyncMacosDisplayLink;
 
 #[allow(dead_code)]
 pub enum VSync {
@@ -33,7 +33,7 @@ pub enum VSync {
     #[cfg(target_os = "windows")]
     WindowsSwapChain(VSyncWinSwapChain),
     #[cfg(target_os = "macos")]
-    Macos(VSyncMacos),
+    MacosDisplayLink(VSyncMacosDisplayLink),
 }
 
 impl VSync {
@@ -57,7 +57,7 @@ impl VSync {
             #[cfg(target_os = "windows")]
             VSync::WindowsSwapChain(vsync) => vsync.wait_for_vsync(),
             #[cfg(target_os = "macos")]
-            VSync::Macos(vsync) => vsync.wait_for_vsync(),
+            VSync::MacosDisplayLink(vsync) => vsync.wait_for_vsync(),
             _ => {}
         }
     }
@@ -70,7 +70,7 @@ impl VSync {
         );
 
         #[cfg(target_os = "macos")]
-        return matches!(self, VSync::WinitThrottling() | VSync::Macos(..));
+        return matches!(self, VSync::WinitThrottling() | VSync::MacosDisplayLink(..));
 
         #[cfg(target_os = "linux")]
         return matches!(self, VSync::WinitThrottling());
@@ -79,7 +79,7 @@ impl VSync {
     pub fn update(&mut self, #[allow(unused_variables)] window: &Window) {
         match self {
             #[cfg(target_os = "macos")]
-            VSync::Macos(vsync) => vsync.update(window),
+            VSync::MacosDisplayLink(vsync) => vsync.update(window),
             _ => {}
         }
     }
@@ -109,7 +109,7 @@ impl VSync {
             #[cfg(target_os = "windows")]
             VSync::WindowsSwapChain(vsync) => vsync.request_redraw(),
             #[cfg(target_os = "macos")]
-            VSync::Macos(vsync) => vsync.request_redraw(),
+            VSync::MacosDisplayLink(vsync) => vsync.request_redraw(),
             _ => {}
         }
     }

--- a/src/renderer/vsync/vsync_macos_display_link.rs
+++ b/src/renderer/vsync/vsync_macos_display_link.rs
@@ -26,17 +26,17 @@ fn vsync_macos_display_link_callback(
     }
 }
 
-pub struct VSyncMacos {
+pub struct VSyncMacosDisplayLink {
     old_display: core_video::CGDirectDisplayID,
     display_link: Option<MacosDisplayLink<VSyncMacosDisplayLinkUserData>>,
     proxy: EventLoopProxy<UserEvent>,
     redraw_requested: Arc<AtomicBool>,
 }
 
-impl VSyncMacos {
-    pub fn new(window: &Window, proxy: EventLoopProxy<UserEvent>) -> VSyncMacos {
+impl VSyncMacosDisplayLink {
+    pub fn new(window: &Window, proxy: EventLoopProxy<UserEvent>) -> VSyncMacosDisplayLink {
         let redraw_requested = AtomicBool::new(false).into();
-        let mut vsync = VSyncMacos {
+        let mut vsync = VSyncMacosDisplayLink {
             old_display: 0,
             display_link: None,
             proxy,

--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -1,18 +1,16 @@
-use icrate::{
-    AppKit::{
-        NSApplication, NSColor, NSEvent, NSEventModifierFlagCommand, NSEventModifierFlagControl,
-        NSEventModifierFlagOption, NSMenu, NSMenuItem, NSView, NSViewMinYMargin,
-        NSViewWidthSizable, NSWindow, NSWindowStyleMaskFullScreen, NSWindowStyleMaskTitled,
-        NSWindowTabbingModeDisallowed,
-    },
-    Foundation::{MainThreadMarker, NSObject, NSPoint, NSProcessInfo, NSRect, NSSize, NSString},
-};
 use objc2::{
-    declare_class, msg_send_id,
-    mutability::InteriorMutable,
-    rc::Id,
-    runtime::{AnyClass, AnyObject},
-    sel, ClassType,
+    declare_class, msg_send, msg_send_id, mutability,
+    rc::{autoreleasepool, Retained},
+    runtime::{AnyClass, AnyObject, ClassBuilder},
+    sel, ClassType, DeclaredClass,
+};
+use objc2_app_kit::{
+    NSApplication, NSAutoresizingMaskOptions, NSColor, NSEvent, NSEventModifierFlags, NSMenu,
+    NSMenuItem, NSView, NSWindow, NSWindowStyleMask, NSWindowTabbingMode,
+};
+use objc2_foundation::{
+    ns_string, MainThreadMarker, NSArray, NSObject, NSPoint, NSProcessInfo, NSRect, NSSize,
+    NSString,
 };
 
 use csscolorparser::Color;
@@ -24,6 +22,9 @@ use crate::{cmd_line::CmdLineSettings, error_msg, frame::Frame, settings::SETTIN
 
 use super::{WindowSettings, WindowSettingsChanged};
 
+#[derive(Clone)]
+struct TitlebarClickHandlerIvars {}
+
 declare_class!(
     // A view to simulate the double-click-to-zoom effect for `--frame transparency`.
     #[derive(Debug)]
@@ -31,8 +32,12 @@ declare_class!(
 
     unsafe impl ClassType for TitlebarClickHandler {
         type Super = NSView;
-        type Mutability = InteriorMutable;
+        type Mutability = mutability::MainThreadOnly;
         const NAME: &'static str = "TitlebarClickHandler";
+    }
+
+    impl DeclaredClass for TitlebarClickHandler {
+        type Ivars = TitlebarClickHandlerIvars;
     }
 
     unsafe impl TitlebarClickHandler {
@@ -46,46 +51,57 @@ declare_class!(
 );
 
 impl TitlebarClickHandler {
-    pub fn new(_mtm: MainThreadMarker) -> Id<TitlebarClickHandler> {
-        unsafe { msg_send_id![Self::alloc(), init] }
+    fn new(mtm: MainThreadMarker) -> Retained<TitlebarClickHandler> {
+        unsafe { msg_send_id![mtm.alloc(), init] }
     }
 }
 
-lazy_static! {
-    // This height is in dpi-independent length, convert it to pixel length by multiplying it with scale factor.
-    static ref TITLEBAR_HEIGHT: f64 = MacosWindowFeature::titlebar_height();
+pub fn get_ns_window(window: &Window) -> Retained<NSWindow> {
+    match window
+        .window_handle()
+        .expect("Failed to fetch window handle")
+        .as_raw()
+    {
+        RawWindowHandle::AppKit(handle) => {
+            let ns_view: Retained<NSView> = unsafe {
+                Retained::retain(handle.ns_view.as_ptr().cast())
+                    .expect("Failed to get NSView instance.")
+            };
+            ns_view
+                .window()
+                .expect("NSView was not installed in a window")
+        }
+        _ => panic!("Not an AppKit window"),
+    }
 }
 
 #[derive(Debug)]
 pub struct MacosWindowFeature {
-    ns_window: Id<NSWindow>,
-    titlebar_click_handler: Option<Id<TitlebarClickHandler>>,
+    ns_window: Retained<NSWindow>,
+    system_titlebar_height: f64,
+    titlebar_click_handler: Option<Retained<TitlebarClickHandler>>,
     // Extra titlebar height in --frame transparency. 0 in other cases.
     extra_titlebar_height_in_pixel: u32,
     is_fullscreen: bool,
+    menu: Option<Menu>,
 }
 
 impl MacosWindowFeature {
-    pub fn from_winit_window(window: &Window, mtm: MainThreadMarker) -> MacosWindowFeature {
-        let ns_window = match window.window_handle().unwrap().as_raw() {
-            RawWindowHandle::AppKit(handle) => unsafe {
-                let ns_view = handle.ns_view.as_ptr();
-                let ns_view: Id<NSView> = Id::retain(ns_view.cast()).unwrap();
-                ns_view
-                    .window()
-                    .expect("view was not installed in a window")
-            },
-            _ => panic!("Not an appkit window."),
-        };
+    pub fn from_winit_window(window: &Window) -> MacosWindowFeature {
+        let mtm =
+            MainThreadMarker::new().expect("MacosWindowFeature must be created in main thread.");
+
+        let system_titlebar_height = Self::system_titlebar_height(mtm);
+
+        let ns_window = get_ns_window(window);
+
         // Disallow tabbing mode to prevent the window from being tabbed.
-        unsafe {
-            ns_window.setTabbingMode(NSWindowTabbingModeDisallowed);
-        }
+        ns_window.setTabbingMode(NSWindowTabbingMode::Disallowed);
 
         let mut extra_titlebar_height_in_pixel: u32 = 0;
 
         let frame = SETTINGS.get::<CmdLineSettings>().frame;
-        let titlebar_click_handler: Option<Id<TitlebarClickHandler>> = match frame {
+        let titlebar_click_handler: Option<Retained<TitlebarClickHandler>> = match frame {
             Frame::Transparent => unsafe {
                 let titlebar_click_handler = TitlebarClickHandler::new(mtm);
 
@@ -96,71 +112,82 @@ impl MacosWindowFeature {
                 // Set the initial size of titlebar_click_handler.
                 let content_view_size = content_view.frame().size;
                 titlebar_click_handler.setFrame(NSRect::new(
-                    NSPoint::new(0., content_view_size.height - *TITLEBAR_HEIGHT),
-                    NSSize::new(content_view_size.width, *TITLEBAR_HEIGHT),
+                    NSPoint::new(0., content_view_size.height - system_titlebar_height),
+                    NSSize::new(content_view_size.width, system_titlebar_height),
                 ));
 
                 // Setup auto layout for titlebar_click_handler.
-                titlebar_click_handler.setAutoresizingMask(NSViewWidthSizable | NSViewMinYMargin);
+                titlebar_click_handler.setAutoresizingMask(
+                    NSAutoresizingMaskOptions::NSViewWidthSizable
+                        | NSAutoresizingMaskOptions::NSViewMinYMargin,
+                );
                 titlebar_click_handler.setTranslatesAutoresizingMaskIntoConstraints(true);
 
                 extra_titlebar_height_in_pixel =
-                    Self::titlebar_height_in_pixel(window.scale_factor());
+                    Self::titlebar_height_in_pixel(system_titlebar_height, window.scale_factor());
 
                 Some(titlebar_click_handler)
             },
             _ => None,
         };
 
-        let is_fullscreen = unsafe { ns_window.styleMask() } & NSWindowStyleMaskFullScreen != 0;
+        let is_fullscreen = ns_window
+            .styleMask()
+            .contains(NSWindowStyleMask::FullScreen);
 
         let macos_window_feature = MacosWindowFeature {
             ns_window,
+            system_titlebar_height,
             titlebar_click_handler,
             extra_titlebar_height_in_pixel,
             is_fullscreen,
+            menu: None,
         };
 
         macos_window_feature.update_background(true);
+
+        register_file_handler(mtm);
 
         macos_window_feature
     }
 
     // Used to calculate the value of TITLEBAR_HEIGHT, aka, titlebar height in dpi-independent length.
-    fn titlebar_height() -> f64 {
+    fn system_titlebar_height(mtm: MainThreadMarker) -> f64 {
         // Do a test to calculate this.
-        unsafe {
-            let mock_content_rect = NSRect::new(NSPoint::new(100., 100.), NSSize::new(100., 100.));
-            let frame_rect = NSWindow::frameRectForContentRect_styleMask(
+        let mock_content_rect = NSRect::new(NSPoint::new(100., 100.), NSSize::new(100., 100.));
+        let frame_rect = unsafe {
+            NSWindow::frameRectForContentRect_styleMask(
                 mock_content_rect,
-                NSWindowStyleMaskTitled,
-            );
-            frame_rect.size.height - mock_content_rect.size.height
-        }
+                NSWindowStyleMask::Titled,
+                mtm,
+            )
+        };
+        frame_rect.size.height - mock_content_rect.size.height
     }
 
-    fn titlebar_height_in_pixel(scale_factor: f64) -> u32 {
-        (*TITLEBAR_HEIGHT * scale_factor) as u32
+    fn titlebar_height_in_pixel(system_titlebar_height: f64, scale_factor: f64) -> u32 {
+        (system_titlebar_height * scale_factor) as u32
     }
 
     pub fn handle_scale_factor_update(&mut self, scale_factor: f64) {
         // If 0, there needs no extra height.
         if self.extra_titlebar_height_in_pixel != 0 {
-            self.extra_titlebar_height_in_pixel = Self::titlebar_height_in_pixel(scale_factor);
+            self.extra_titlebar_height_in_pixel =
+                Self::titlebar_height_in_pixel(self.system_titlebar_height, scale_factor);
         }
     }
 
     fn set_titlebar_click_handler_visible(&self, visible: bool) {
         if let Some(titlebar_click_handler) = &self.titlebar_click_handler {
-            unsafe {
-                titlebar_click_handler.setHidden(!visible);
-            }
+            titlebar_click_handler.setHidden(!visible);
         }
     }
 
     pub fn handle_size_changed(&mut self) {
-        let is_fullscreen =
-            unsafe { self.ns_window.styleMask() } & NSWindowStyleMaskFullScreen != 0;
+        let is_fullscreen = self
+            .ns_window
+            .styleMask()
+            .contains(NSWindowStyleMask::FullScreen);
         if is_fullscreen != self.is_fullscreen {
             self.is_fullscreen = is_fullscreen;
             self.set_titlebar_click_handler_visible(!is_fullscreen);
@@ -177,7 +204,7 @@ impl MacosWindowFeature {
     }
 
     /// Print a deprecation warning for `neovide_background_color`
-    pub fn display_deprecation_warning(&self) {
+    fn display_deprecation_warning(&self) {
         error_msg!(concat!(
             "neovide_background_color has now been deprecated. ",
             "Use neovide_transparency instead if you want to get a transparent window titlebar. ",
@@ -262,15 +289,30 @@ impl MacosWindowFeature {
             _ => {}
         }
     }
+
+    pub fn ensure_menu_added(&mut self) {
+        let mtm = MainThreadMarker::new().expect("Menu must be created on the main thread");
+        if self.menu.is_none() {
+            self.menu = Some(Menu::new(mtm));
+        }
+    }
 }
 
+#[derive(Clone)]
+struct QuitHandlerIvars {}
+
 declare_class!(
+    #[derive(Debug)]
     struct QuitHandler;
 
     unsafe impl ClassType for QuitHandler {
         type Super = NSObject;
-        type Mutability = InteriorMutable;
+        type Mutability = mutability::MainThreadOnly;
         const NAME: &'static str = "QuitHandler";
+    }
+
+    impl DeclaredClass for QuitHandler {
+        type Ivars = QuitHandlerIvars;
     }
 
     unsafe impl QuitHandler {
@@ -282,76 +324,71 @@ declare_class!(
 );
 
 impl QuitHandler {
-    pub fn new(_mtm: MainThreadMarker) -> Id<QuitHandler> {
-        unsafe { msg_send_id![Self::alloc(), init] }
+    fn new(mtm: MainThreadMarker) -> Retained<QuitHandler> {
+        unsafe { msg_send_id![mtm.alloc(), init] }
     }
 }
 
-pub struct Menu {
-    menu_added: bool,
-    quit_handler: Id<QuitHandler>,
+#[derive(Debug)]
+struct Menu {
+    quit_handler: Retained<QuitHandler>,
 }
 
 impl Menu {
-    pub fn new(mtm: MainThreadMarker) -> Self {
-        Menu {
-            menu_added: false,
+    fn new(mtm: MainThreadMarker) -> Self {
+        let menu = Menu {
             quit_handler: QuitHandler::new(mtm),
-        }
-    }
-    pub fn ensure_menu_added(&mut self) {
-        if !self.menu_added {
-            self.add_menus();
-            self.menu_added = true;
-        }
+        };
+        menu.add_menus(mtm);
+        menu
     }
 
-    fn add_app_menu(&self) -> Id<NSMenu> {
+    fn add_app_menu(&self, mtm: MainThreadMarker) -> Retained<NSMenu> {
         unsafe {
-            let app_menu = NSMenu::new();
+            let app_menu = NSMenu::new(mtm);
             let process_name = NSProcessInfo::processInfo().processName();
-            let about_item = NSMenuItem::new();
-            about_item
-                .setTitle(&NSString::from_str("About ").stringByAppendingString(&process_name));
+            let about_item = NSMenuItem::new(mtm);
+            about_item.setTitle(&ns_string!("About ").stringByAppendingString(&process_name));
             about_item.setAction(Some(sel!(orderFrontStandardAboutPanel:)));
             app_menu.addItem(&about_item);
 
-            let services_item = NSMenuItem::new();
-            let services_menu = NSMenu::new();
-            services_item.setTitle(&NSString::from_str("Services"));
+            let services_item = NSMenuItem::new(mtm);
+            let services_menu = NSMenu::new(mtm);
+            services_item.setTitle(ns_string!("Services"));
             services_item.setSubmenu(Some(&services_menu));
             app_menu.addItem(&services_item);
 
-            let sep = NSMenuItem::separatorItem();
+            let sep = NSMenuItem::separatorItem(mtm);
             app_menu.addItem(&sep);
 
             // application window operations
-            let hide_item = NSMenuItem::new();
-            hide_item.setTitle(&NSString::from_str("Hide ").stringByAppendingString(&process_name));
-            hide_item.setKeyEquivalent(&NSString::from_str("h"));
+            let hide_item = NSMenuItem::new(mtm);
+            hide_item.setTitle(&ns_string!("Hide ").stringByAppendingString(&process_name));
+            hide_item.setKeyEquivalent(ns_string!("h"));
             hide_item.setAction(Some(sel!(hide:)));
             app_menu.addItem(&hide_item);
 
-            let hide_others_item = NSMenuItem::new();
-            hide_others_item.setTitle(&NSString::from_str("Hide Others"));
-            hide_others_item.setKeyEquivalent(&NSString::from_str("h"));
+            let hide_others_item = NSMenuItem::new(mtm);
+            hide_others_item.setTitle(ns_string!("Hide Others"));
+            hide_others_item.setKeyEquivalent(ns_string!("h"));
             hide_others_item.setKeyEquivalentModifierMask(
-                NSEventModifierFlagOption | NSEventModifierFlagCommand,
+                NSEventModifierFlags::NSEventModifierFlagOption
+                    | NSEventModifierFlags::NSEventModifierFlagCommand,
             );
             hide_others_item.setAction(Some(sel!(hideOtherApplications:)));
             app_menu.addItem(&hide_others_item);
 
-            let show_all_item = NSMenuItem::new();
-            show_all_item.setTitle(&NSString::from_str("Show All"));
+            let show_all_item = NSMenuItem::new(mtm);
+            show_all_item.setTitle(ns_string!("Show All"));
             show_all_item.setAction(Some(sel!(unhideAllApplications:)));
 
             // quit
-            let sep = NSMenuItem::separatorItem();
+            let sep = NSMenuItem::separatorItem(mtm);
             app_menu.addItem(&sep);
 
-            let quit_item = NSMenuItem::new();
-            quit_item.setTitle(&NSString::from_str("Quit ").stringByAppendingString(&process_name));
-            quit_item.setKeyEquivalent(&NSString::from_str("q"));
+            let quit_item = NSMenuItem::new(mtm);
+            quit_item.setTitle(&ns_string!("Quit ").stringByAppendingString(&process_name));
+            quit_item.setKeyEquivalent(ns_string!("q"));
             quit_item.setAction(Some(sel!(quit:)));
             quit_item.setTarget(Some(&self.quit_handler));
             app_menu.addItem(&quit_item);
@@ -360,48 +397,47 @@ impl Menu {
         }
     }
 
-    fn add_menus(&self) {
-        let app = unsafe { NSApplication::sharedApplication() };
+    fn add_menus(&self, mtm: MainThreadMarker) {
+        let app = NSApplication::sharedApplication(mtm);
 
-        let main_menu = unsafe { NSMenu::new() };
+        let main_menu = NSMenu::new(mtm);
 
         unsafe {
-            let app_menu = self.add_app_menu();
-            let app_menu_item = NSMenuItem::new();
+            let app_menu = self.add_app_menu(mtm);
+            let app_menu_item = NSMenuItem::new(mtm);
             app_menu_item.setSubmenu(Some(&app_menu));
-            if let Some(services_menu) = app_menu.itemWithTitle(&NSString::from_str("Services")) {
+            if let Some(services_menu) = app_menu.itemWithTitle(ns_string!("Services")) {
                 app.setServicesMenu(services_menu.submenu().as_deref());
             }
             main_menu.addItem(&app_menu_item);
 
-            let win_menu = self.add_window_menu();
-            let win_menu_item = NSMenuItem::new();
+            let win_menu = self.add_window_menu(mtm);
+            let win_menu_item = NSMenuItem::new(mtm);
             win_menu_item.setSubmenu(Some(&win_menu));
             main_menu.addItem(&win_menu_item);
             app.setWindowsMenu(Some(&win_menu));
         }
-
-        unsafe { app.setMainMenu(Some(&main_menu)) };
+        app.setMainMenu(Some(&main_menu));
     }
 
-    fn add_window_menu(&self) -> Id<NSMenu> {
-        let menu_title = NSString::from_str("Window");
+    fn add_window_menu(&self, mtm: MainThreadMarker) -> Retained<NSMenu> {
         unsafe {
-            let menu = NSMenu::new();
-            menu.setTitle(&menu_title);
+            let menu = NSMenu::new(mtm);
+            menu.setTitle(ns_string!("Window"));
 
-            let full_screen_item = NSMenuItem::new();
-            full_screen_item.setTitle(&NSString::from_str("Enter Full Screen"));
-            full_screen_item.setKeyEquivalent(&NSString::from_str("f"));
+            let full_screen_item = NSMenuItem::new(mtm);
+            full_screen_item.setTitle(ns_string!("Enter Full Screen"));
+            full_screen_item.setKeyEquivalent(ns_string!("f"));
             full_screen_item.setAction(Some(sel!(toggleFullScreen:)));
             full_screen_item.setKeyEquivalentModifierMask(
-                NSEventModifierFlagControl | NSEventModifierFlagCommand,
+                NSEventModifierFlags::NSEventModifierFlagControl
+                    | NSEventModifierFlags::NSEventModifierFlagCommand,
             );
             menu.addItem(&full_screen_item);
 
-            let min_item = NSMenuItem::new();
-            min_item.setTitle(&NSString::from_str("Minimize"));
-            min_item.setKeyEquivalent(&NSString::from_str("m"));
+            let min_item = NSMenuItem::new(mtm);
+            min_item.setTitle(ns_string!("Minimize"));
+            min_item.setKeyEquivalent(ns_string!("m"));
             min_item.setAction(Some(sel!(performMiniaturize:)));
             menu.addItem(&min_item);
             menu
@@ -409,14 +445,12 @@ impl Menu {
     }
 }
 
-pub fn register_file_handler() {
-    use objc2::rc::autoreleasepool;
-
-    extern "C" fn handle_open_files(
+fn register_file_handler(mtm: MainThreadMarker) {
+    unsafe extern "C" fn handle_open_files(
         _this: &mut AnyObject,
         _sel: objc2::runtime::Sel,
         _sender: &objc2::runtime::AnyObject,
-        files: &mut icrate::Foundation::NSArray<icrate::Foundation::NSString>,
+        files: &mut NSArray<NSString>,
     ) {
         autoreleasepool(|pool| {
             for file in files.iter() {
@@ -427,10 +461,7 @@ pub fn register_file_handler() {
     }
 
     unsafe {
-        use objc2::declare::ClassBuilder;
-        use objc2::msg_send;
-
-        let app = NSApplication::sharedApplication();
+        let app = NSApplication::sharedApplication(mtm);
         let delegate = app.delegate().unwrap();
 
         // Find out class of the NSApplicationDelegate
@@ -448,7 +479,7 @@ pub fn register_file_handler() {
         //  * our class is a subclass
         //  * no new ivars
         //  * overriden methods are compatible with old (we implement protocol method)
-        let delegate_obj = Id::cast::<AnyObject>(delegate);
+        let delegate_obj = Retained::cast::<AnyObject>(delegate);
         AnyObject::set_class(&delegate_obj, class);
     }
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -6,7 +6,7 @@ mod update_loop;
 mod window_wrapper;
 
 #[cfg(target_os = "macos")]
-mod macos;
+pub mod macos;
 
 #[cfg(target_os = "linux")]
 use std::env;
@@ -119,8 +119,6 @@ pub fn create_event_loop() -> EventLoop<UserEvent> {
     #[cfg(target_os = "macos")]
     builder.with_default_menu(false);
     let event_loop = builder.build().expect("Failed to create winit event loop");
-    #[cfg(target_os = "macos")]
-    crate::window::macos::register_file_handler();
     #[allow(clippy::let_and_return)]
     event_loop
 }

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -6,9 +6,6 @@ use winit::{
     event_loop::{ActiveEventLoop, ControlFlow, EventLoopProxy},
 };
 
-#[cfg(target_os = "macos")]
-use icrate::Foundation::MainThreadMarker;
-
 use super::{save_window_size, CmdLineSettings, UserEvent, WindowSettings, WinitWindowWrapper};
 use crate::{
     profiling::{tracy_plot, tracy_zone},
@@ -16,9 +13,6 @@ use crate::{
     settings::SETTINGS,
     FontSettings, WindowSize,
 };
-
-#[cfg(target_os = "macos")]
-use super::macos::Menu;
 
 enum FocusedState {
     Focused,
@@ -92,9 +86,6 @@ pub struct UpdateLoop {
     window_wrapper: WinitWindowWrapper,
     create_window_allowed: bool,
     proxy: EventLoopProxy<UserEvent>,
-
-    #[cfg(target_os = "macos")]
-    menu: Menu,
 }
 
 impl UpdateLoop {
@@ -112,12 +103,6 @@ impl UpdateLoop {
         let pending_draw_commands = Vec::new();
         let animation_start = Instant::now();
         let animation_time = Duration::from_millis(0);
-
-        #[cfg(target_os = "macos")]
-        let menu = {
-            let mtm = MainThreadMarker::new().expect("must be on the main thread");
-            Menu::new(mtm)
-        };
 
         let cmd_line_settings = SETTINGS.get::<CmdLineSettings>();
         let idle = cmd_line_settings.idle;
@@ -139,9 +124,6 @@ impl UpdateLoop {
             window_wrapper,
             create_window_allowed: false,
             proxy,
-
-            #[cfg(target_os = "macos")]
-            menu,
         }
     }
 
@@ -351,7 +333,11 @@ impl ApplicationHandler<UserEvent> for UpdateLoop {
                     FocusedState::UnfocusedNotDrawn
                 };
                 #[cfg(target_os = "macos")]
-                self.menu.ensure_menu_added();
+                self.window_wrapper
+                    .macos_feature
+                    .as_mut()
+                    .expect("MacosWindowFeature should already be created here.")
+                    .ensure_menu_added();
             }
             _ => {}
         }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -28,9 +28,6 @@ use crate::{
 #[cfg(target_os = "macos")]
 use super::macos::MacosWindowFeature;
 
-#[cfg(target_os = "macos")]
-use icrate::Foundation::MainThreadMarker;
-
 use log::trace;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::{
@@ -463,10 +460,7 @@ impl WinitWindowWrapper {
         // It's important that this is created before the window is resized, since it can change the padding and affect the size
         #[cfg(target_os = "macos")]
         {
-            self.macos_feature = {
-                let mtm = MainThreadMarker::new().expect("must be on the main thread");
-                Some(MacosWindowFeature::from_winit_window(window, mtm))
-            };
+            self.macos_feature = Some(MacosWindowFeature::from_winit_window(window));
         }
 
         let scale_factor = window.scale_factor();


### PR DESCRIPTION
This pr does following 2 major things:

- Upgrade `objc2` and remove `icrate`, since `icrate` is deprecated and migrated to `objc2-*`. Related structs and  functions are updated to the new ones.
- Try to move as much as possible macOS specific code into `macos.rs`.
  - Menu creation.
  - File handler.

MacOS part improvement
- Rename `vsync_macos` -> `vsync_macos_display_link`. So we can create another one like Metal vsync on macOS, just like how it is done on Windows.
- Getting `NSWindow` from winit `Window` logic is extracted out into a function, because it is used both in `macos.rs` and `macos_display_link.rs`.
- Main thread related improvement
  - Improve `MainThreadMarker` creation. It is now only created and checked after entering macOS-specific code from common codes, instead of being created in common code and passed to macOS-specific code. It will then be used until getting out from macOS-specific code.
  - Objective-C classes `TitlebarClickHandler` and `QuitHandler` declared in rust are now marked as `mutability::MainThreadOnly` as it should be. 
  - Titlebar height is now calculated during `MacosWindowFeature` initialization. This makes it more safe because it can be ensured to run on main thread.
- `unsafe` is added to function `handle_open_files`, which will be passed to Objective-C. Otherwise, there is an error when compiled on nightly rust.
- `Id` -> `Retained`, `NSString::from_str` -> `ns_string!`, new Mask style is used.
- `pub` in some places has been modified. Redundant `unsafe` is removed. `use` statements are moved to the top of the file.

Now there are only following border api between `MacosWindowFeature` and common codes:
- `from_winit_window`: creation of MacosWindowFeature.
- `handle_scale_factor_update`: update scale factor and re-calculate titlebar height.
- `handle_size_changed`: listen to fullscreen-toggled event and show/hide titlebar click handler.
- `extra_titlebar_height_in_pixels`: calculate proper top-padding.
- `handle_settings_changed`: settings change event handler.
- `ensure_menu_added`: create menus in WindowEvent::Focused, though I'm not sure if it is necessary to create it there rather than create at window creation. But I prefer to leaving it there.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Dependency update.
- Codestyle
- Refactor

## Did this PR introduce a breaking change? 
No
