### PR TITLE
feat: rename and deprecate `neovide_transparency` to `neovide_opacity`

### DIFF
--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -78,9 +78,17 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
                 Ok(Some(alias_name)) => {
                     let vim_alias_setting_name = format!("{prefix}{alias_name}");
                     quote! {
+                        fn alias_update(settings: &crate::settings::Settings, value: rmpv::Value) -> crate::settings::SettingsChanged {
+                            error_msg!(concat!(
+                                "neovide_", #vim_alias_setting_name, " has now been deprecated, ",
+                                "use neovide_", #vim_setting_name, " instead."
+                            ));
+                            update(settings, value)
+                        }
+
                         settings.set_setting_handlers(
                             crate::settings::SettingLocation::NeovideGlobal(#vim_alias_setting_name.to_owned()),
-                            update,
+                            alias_update,
                             reader,
                         );
                     }

--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -11,7 +11,7 @@ use syn::{
     parse_macro_input, Attribute, Data, DataStruct, DeriveInput, Error, Field, Ident, Lit, Meta,
 };
 
-#[proc_macro_derive(SettingGroup, attributes(setting_prefix, option))]
+#[proc_macro_derive(SettingGroup, attributes(setting_prefix, option, alias))]
 pub fn setting_group(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
     let prefix = setting_prefix(input.attrs.as_ref())
@@ -41,7 +41,7 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
         Some(ref ident) => {
             let vim_setting_name = format!("{prefix}{ident}");
 
-            let option_name = match option(field) {
+            let option_name = match get_attribute_value(field, "option") {
                 Ok(option_name) => option_name,
                 Err(error) => {
                     return error.to_compile_error();
@@ -73,6 +73,24 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
                 }
             };
 
+            // Add setting location from alias
+            let set_setting_handlers_alias = match get_attribute_value(field, "alias") {
+                Ok(Some(alias_name)) => {
+                    let vim_alias_setting_name = format!("{prefix}{alias_name}");
+                    quote! {
+                        settings.set_setting_handlers(
+                            crate::settings::SettingLocation::NeovideGlobal(#vim_alias_setting_name.to_owned()),
+                            update,
+                            reader,
+                        );
+                    }
+                },
+                Ok(None) => quote! {},
+                Err(error) => {
+                    return error.to_compile_error();
+                },
+            };
+
             quote! {{
                 fn update(settings: &crate::settings::Settings, value: rmpv::Value) -> crate::settings::SettingsChanged {
                     let mut s = settings.get::<#name>();
@@ -88,6 +106,8 @@ fn struct_stream(name: Ident, prefix: String, data: &DataStruct) -> TokenStream 
                     update,
                     reader,
                 );
+
+                #set_setting_handlers_alias
             }}
         }
         None => {
@@ -141,9 +161,9 @@ fn setting_prefix(attrs: &[Attribute]) -> Option<String> {
     None
 }
 
-fn option(field: &Field) -> Result<Option<String>, Error> {
+fn get_attribute_value(field: &Field, ident: &str) -> Result<Option<String>, Error> {
     for attr in field.attrs.iter() {
-        if !attr.path.is_ident("option") {
+        if !attr.path.is_ident(ident) {
             continue;
         }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -207,11 +207,11 @@ impl Renderer {
         let default_background = self.grid_renderer.get_default_background();
         let grid_scale = self.grid_renderer.grid_scale;
 
-        let transparency = SETTINGS.get::<WindowSettings>().transparency;
+        let opacity = SETTINGS.get::<WindowSettings>().opacity;
         let layer_grouping = SETTINGS
             .get::<RendererSettings>()
             .experimental_layer_grouping;
-        root_canvas.clear(default_background.with_a((255.0 * transparency) as u8));
+        root_canvas.clear(default_background.with_a((255.0 * opacity) as u8));
         root_canvas.save();
         root_canvas.reset_matrix();
 
@@ -288,7 +288,7 @@ impl Renderer {
             .map(|window| {
                 window.draw(
                     root_canvas,
-                    default_background.with_a((255.0 * transparency) as u8),
+                    default_background.with_a((255.0 * opacity) as u8),
                     grid_scale,
                 )
             })
@@ -300,7 +300,7 @@ impl Renderer {
                 layer.draw(
                     root_canvas,
                     &settings,
-                    default_background.with_a((255.0 * transparency) as u8),
+                    default_background.with_a((255.0 * opacity) as u8),
                     grid_scale,
                 )
             })

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -107,7 +107,14 @@ impl Settings {
     }
 
     pub async fn read_initial_values(&self, nvim: &Neovim<NeovimWriter>) -> Result<()> {
-        let keys: Vec<SettingLocation> = self.updaters.read().keys().cloned().collect();
+        let deprecated_settings = ["transparency".to_owned()];
+        let keys: Vec<SettingLocation> = self
+            .updaters
+            .read()
+            .keys()
+            .filter(|key| !matches!(key, SettingLocation::NeovideGlobal(name) if deprecated_settings.contains(name)))
+            .cloned()
+            .collect();
 
         for location in keys {
             match &location {

--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -230,14 +230,14 @@ impl MacosWindowFeature {
         let WindowSettings {
             background_color,
             show_border,
-            transparency,
+            opacity,
             ..
         } = SETTINGS.get::<WindowSettings>();
         match background_color.parse::<Color>() {
             Ok(color) => {
                 self.update_ns_background_legacy(color, show_border, ignore_deprecation_warning)
             }
-            _ => self.update_ns_background(transparency, show_border),
+            _ => self.update_ns_background(opacity, show_border),
         }
     }
 
@@ -251,8 +251,8 @@ impl MacosWindowFeature {
                 log::info!("show_border changed to {}", show_border);
                 self.update_background(true);
             }
-            WindowSettingsChanged::Transparency(transparency) => {
-                log::info!("transparency changed to {}", transparency);
+            WindowSettingsChanged::Opacity(opacity) => {
+                log::info!("opacity changed to {}", opacity);
                 self.update_background(true);
             }
             WindowSettingsChanged::WindowBlurred(window_blurred) => {

--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -180,7 +180,7 @@ impl MacosWindowFeature {
     pub fn display_deprecation_warning(&self) {
         error_msg!(concat!(
             "neovide_background_color has now been deprecated. ",
-            "Use neovide_transparency instead if you want to get a transparent window titlebar. ",
+            "Use neovide_opacity instead if you want to get a transparent window titlebar. ",
             "Please check https://neovide.dev/configuration.html#background-color-deprecated-currently-macos-only for more information.",
         ));
     }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -7,7 +7,7 @@ use crate::settings::*;
 pub struct WindowSettings {
     pub refresh_rate: u64,
     pub refresh_rate_idle: u64,
-    pub transparency: f32,
+    pub opacity: f32,
     pub window_blurred: bool,
     pub scale_factor: f32,
     pub fullscreen: bool,
@@ -42,7 +42,7 @@ pub struct WindowSettings {
 impl Default for WindowSettings {
     fn default() -> Self {
         Self {
-            transparency: 1.0,
+            opacity: 1.0,
             window_blurred: false,
             scale_factor: 1.0,
             fullscreen: false,

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,6 +1,7 @@
 #[cfg(target_os = "macos")]
 use {log::error, rmpv::Value};
 
+use crate::error_msg;
 use crate::settings::*;
 
 #[derive(Clone, SettingGroup, PartialEq)]

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -7,6 +7,7 @@ use crate::settings::*;
 pub struct WindowSettings {
     pub refresh_rate: u64,
     pub refresh_rate_idle: u64,
+    #[alias = "transparency"]
     pub opacity: f32,
     pub window_blurred: bool,
     pub scale_factor: f32,

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -222,9 +222,9 @@ impl WinitWindowWrapper {
             }
             WindowSettingsChanged::WindowBlurred(blur) => {
                 if let Some(skia_renderer) = &self.skia_renderer {
-                    let WindowSettings { transparency, .. } = SETTINGS.get::<WindowSettings>();
-                    let transparent = transparency < 1.0;
-                    skia_renderer.window().set_blur(blur && transparent);
+                    let WindowSettings { opacity, .. } = SETTINGS.get::<WindowSettings>();
+                    let opacity = opacity < 1.0;
+                    skia_renderer.window().set_blur(blur && opacity);
                 }
             }
             #[cfg(target_os = "macos")]
@@ -450,7 +450,7 @@ impl WinitWindowWrapper {
         let WindowSettings {
             input_ime,
             theme,
-            transparency,
+            opacity,
             window_blurred,
             fullscreen,
             #[cfg(target_os = "macos")]
@@ -541,7 +541,7 @@ impl WinitWindowWrapper {
             self.renderer.grid_renderer.grid_scale
         );
 
-        window.set_blur(window_blurred && transparency < 1.0);
+        window.set_blur(window_blurred && opacity < 1.0);
         if fullscreen {
             let handle = window.current_monitor();
             window.set_fullscreen(Some(Fullscreen::Borderless(handle)));

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -194,14 +194,14 @@ background color instead.
 
 This configuration is deprecated now and might be removed in the future. In
 [#2168](https://github.com/neovide/neovide/issues/2168), we have made Neovide control the title bar
-color itself. The color of title bar now honors [`neovide_transparency`](#transparency). If you want
-a transparent title bar, setting `neovide_transparency` is sufficient.
+color itself. The color of title bar now honors [`neovide_opacity`](#transparency). If you want
+a transparent title bar, setting `neovide_opacity` is sufficient.
 
 VimScript:
 
 ```vim
-" g:neovide_transparency should be 0 if you want to unify transparency of content and title bar.
-let g:neovide_transparency = 0.0
+" g:neovide_opacity should be 0 if you want to unify transparency of content and title bar.
+let g:neovide_opacity = 0.0
 let g:transparency = 0.8
 let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:transparency))
 ```
@@ -213,8 +213,8 @@ Lua:
 local alpha = function()
   return string.format("%x", math.floor(255 * vim.g.transparency or 0.8))
 end
--- g:neovide_transparency should be 0 if you want to unify transparency of content and title bar.
-vim.g.neovide_transparency = 0.0
+-- g:neovide_opacity should be 0 if you want to unify transparency of content and title bar.
+vim.g.neovide_opacity = 0.0
 vim.g.transparency = 0.8
 vim.g.neovide_background_color = "#0f1117" .. alpha()
 ```
@@ -228,7 +228,7 @@ Setting `g:neovide_background_color` to a value that can be parsed by
 [csscolorparser-rs](https://github.com/mazznoer/csscolorparser-rs) will set the color of the whole
 window to that value.
 
-Note that `g:neovide_transparency` should be 0 if you want to unify transparency of content and
+Note that `g:neovide_opacity` should be 0 if you want to unify transparency of content and
 title bar.
 
 #### Window Blur (Currently macOS only)
@@ -249,7 +249,7 @@ vim.g.neovide_window_blurred = true
 
 Setting `g:neovide_window_blurred` toggles the window blur state.
 
-The blurred level respects the `g:neovide_transparency` value between 0.0 and 1.0.
+The blurred level respects the `g:neovide_opacity` value between 0.0 and 1.0.
 
 #### Floating Blur Amount
 
@@ -306,18 +306,18 @@ The other variables configure the shadow in various ways:
 VimScript:
 
 ```vim
-let g:neovide_transparency = 0.8
+let g:neovide_opacity = 0.8
 ```
 
 Lua:
 
 ```lua
-vim.g.neovide_transparency = 0.8
+vim.g.neovide_opacity = 0.8
 ```
 
 ![Transparency](assets/Transparency.png)
 
-Setting `g:neovide_transparency` to a value between 0.0 and 1.0 will set the opacity of the window
+Setting `g:neovide_opacity` to a value between 0.0 and 1.0 will set the opacity of the window
 to that value.
 
 #### Show Border (Currently macOS only)

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -76,14 +76,14 @@ VimScript:
 
 ```vim
 " Set transparency and background color (title bar color)
-let g:neovide_transparency=0.0
-let g:neovide_transparency_point=0.8
-let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:neovide_transparency_point))
+let g:neovide_opacity=0.0
+let g:neovide_opacity_point=0.8
+let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:neovide_opacity_point))
 
 " Add keybinds to change transparency
 function! ChangeTransparency(delta)
-  let g:neovide_transparency_point = g:neovide_transparency_point + a:delta
-  let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:neovide_transparency_point))
+  let g:neovide_opacity_point = g:neovide_opacity_point + a:delta
+  let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:neovide_opacity_point))
 endfunction
 noremap <expr><D-]> ChangeTransparency(0.01)
 noremap <expr><D-[> ChangeTransparency(-0.01)
@@ -94,15 +94,15 @@ Lua:
 ```lua
 -- Helper function for transparency formatting
 local alpha = function()
-  return string.format("%x", math.floor(255 * vim.g.neovide_transparency_point or 0.8))
+  return string.format("%x", math.floor(255 * vim.g.neovide_opacity_point or 0.8))
 end
 -- Set transparency and background color (title bar color)
-vim.g.neovide_transparency = 0.0
-vim.g.neovide_transparency_point = 0.8
+vim.g.neovide_opacity = 0.0
+vim.g.neovide_opacity_point = 0.8
 vim.g.neovide_background_color = "#0f1117" .. alpha()
 -- Add keybinds to change transparency
 local change_transparency = function(delta)
-  vim.g.neovide_transparency_point = vim.g.neovide_transparency_point + delta
+  vim.g.neovide_opacity_point = vim.g.neovide_opacity_point + delta
   vim.g.neovide_background_color = "#0f1117" .. alpha()
 end
 vim.keymap.set({ "n", "v", "o" }, "<D-]>", function()


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

Rename `neovide_transparency` to `neovide_opacity`. 
Changes to `neovide_transparency` will update `WindowSettings::opacity`. 

- Update all documentation and references to use `neovide_opacity`. 
- Rename `WindowSettings` transparency to opacity for consistency. 
- Add `alias` attribute to the `SettingGroup` macro.
- ~Update the test `test_read_initial_values` with alias.~
  Test removed since aliases are excluded from `read_initial_values` to not trigger deprecation message at startup.
- Add deprecation message for settings with alias attribute. 
  `Error: neovide_transparency has now been deprecated, use neovide_opacity instead.`
                                                                                                                        
~I don't know if a deprecation message is needed and how to properly handle `neovide_transparency` deprecation, let me know.~

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

Feel free to edit or request any changes

Close  #2701