### PR TITLE
fix: neovide not starting maximized with X11 (#2657)

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -140,7 +140,7 @@ pub fn create_window(event_loop: &ActiveEventLoop, maximized: bool, title: &str)
         .with_window_icon(Some(icon))
         .with_maximized(maximized)
         .with_transparent(true)
-        .with_visible(false);
+        .with_visible(true);
 
     #[cfg(target_os = "windows")]
     let window_attributes = if !cmd_line_settings.opengl {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

---

Tested using LMDE 6 with Cinnamon and X11