### PR TITLE
feat: add normal opacity

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -209,7 +209,12 @@ impl Renderer {
 
     pub fn draw_frame(&mut self, root_canvas: &Canvas, dt: f32) {
         tracy_zone!("renderer_draw_frame");
-        let opacity = SETTINGS.get::<WindowSettings>().transparency;
+        let window_settings = SETTINGS.get::<WindowSettings>();
+        let opacity = if window_settings.normal_opacity < 1.0 {
+            window_settings.normal_opacity
+        } else {
+            window_settings.transparency
+        };
         let default_background = self.grid_renderer.get_default_background(opacity);
         let grid_scale = self.grid_renderer.grid_scale;
 

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -8,6 +8,7 @@ pub struct WindowSettings {
     pub refresh_rate: u64,
     pub refresh_rate_idle: u64,
     pub transparency: f32,
+    pub normal_opacity: f32,
     pub window_blurred: bool,
     pub scale_factor: f32,
     pub fullscreen: bool,
@@ -48,6 +49,7 @@ impl Default for WindowSettings {
     fn default() -> Self {
         Self {
             transparency: 1.0,
+            normal_opacity: 1.0,
             window_blurred: false,
             scale_factor: 1.0,
             fullscreen: false,

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -239,7 +239,7 @@ impl WinitWindowWrapper {
                     skia_renderer.window().set_blur(blur && transparent);
                 }
             }
-            WindowSettingsChanged::Transparency(..) => {
+            WindowSettingsChanged::Transparency(..) | WindowSettingsChanged::NormalOpacity(..) => {
                 self.renderer.prepare_lines(true);
             }
             #[cfg(target_os = "windows")]

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -352,12 +352,14 @@ VimScript:
 
 ```vim
 let g:neovide_transparency = 0.8
+let g:neovide_normal_opacity = 0.8
 ```
 
 Lua:
 
 ```lua
 vim.g.neovide_transparency = 0.8
+vim.g.neovide_normal_opacity = 0.8
 ```
 
 **Unreleased yet.**
@@ -366,6 +368,9 @@ vim.g.neovide_transparency = 0.8
 
 Setting `g:neovide_transparency` to a value between 0.0 and 1.0 will set the opacity of the window
 to that value.
+
+`g:neovide_normal_opacity` sets the opacity for the normal background color.
+Set it to 1 to disable.
 
 #### Show Border (Currently macOS only)
 


### PR DESCRIPTION
This feature adds the `neovide_text_background_opacity` setting and also changes how default background rendering is currently performed.

Additionally, this change _might_ solve some issues mentioned in https://github.com/neovide/neovide/issues/2471.

### Changes
- [x] Add `text_background_opacity` setting (name inspired by wezterm)
- [x] Update rendering to achieve identical background rendering for both floating and non-floating windows
- [x] Update rendering so all non-default backgrounds are opaque by default (but configurable)
- [x] Add documentation (updated `Transparency.png`)

### Comparison
Side by side comparison with white desktop wallpaper and dark background.
```
neovide_transparency: 0.75
neovide_text_background_opacity: 0.75
no-multigrid: false
```
![neovide_white_background_comparison](https://github.com/user-attachments/assets/225d4e06-185e-4db8-98da-4ea1d82faed5)

### Notes
- Using `vim.o.winblend = 0`  for the default background on floating windows with multigrid enabled. 
  - In this case, the floating background is `default * transparency`, which is neither fully opaque (as it should be) nor transparent (as it behaves in kitty/wezterm or without multigrid). 
    Current workaround to achieve transparency is to set use this kind of configuration and configure plugins as well
    ```lua 
    local neovide_multi_grid = os.getenv('NEOVIDE_NO_MULTIGRID') == 'false' 
    vim.o.pumblend = neovide_multi_grid and 100 or 0 
    vim.o.winblend = neovide_multi_grid and 100 or 0 
    ```
- A solution similar to https://github.com/neovide/neovide/issues/1508#issuecomment-1514365398 to use an epsilon value could also be used

I tested with a few colorschemes but I may have missed some configurations.

>[!Note]
> This is just a proposal
> Feel free to ask for or make changes
> Or reject this solution if it does not suit your rendering preferences for Neovide
> Also, let me know if you prefer not to add this setting and instead use the solution described in https://github.com/neovide/neovide/issues/2702 

> [!WARNING]
> I have not performed any tests on MacOS.

I am currently using this branch now, and it's great to be able to read the background color with multigrid in transparent floating windows (especially with telescope and similar plugins).

## What kind of change does this PR introduce?
- Fix
- Feature

## Did this PR introduce a breaking change?
- Yes
  - Set non-default background opacity to 1.
  - Change the way blend is performed (floating and non-floating window opacity now behave the same).