### PR TITLE
fix: drag and drop files on application icon in Dock to open not work.

### DIFF
--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -146,8 +146,6 @@ impl MacosWindowFeature {
 
         macos_window_feature.update_background(true);
 
-        register_file_handler(mtm);
-
         macos_window_feature
     }
 
@@ -445,7 +443,7 @@ impl Menu {
     }
 }
 
-fn register_file_handler(mtm: MainThreadMarker) {
+pub fn register_file_handler() {
     unsafe extern "C" fn handle_open_files(
         _this: &mut AnyObject,
         _sel: objc2::runtime::Sel,
@@ -459,6 +457,8 @@ fn register_file_handler(mtm: MainThreadMarker) {
             }
         });
     }
+
+    let mtm = MainThreadMarker::new().expect("File handler must be registered on main thread.");
 
     unsafe {
         let app = NSApplication::sharedApplication(mtm);

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -29,6 +29,9 @@ use winit::platform::windows::WindowAttributesExtWindows;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::EventLoopBuilderExtMacOS;
 
+#[cfg(target_os = "macos")]
+use macos::register_file_handler;
+
 use image::{load_from_memory, GenericImageView, Pixel};
 use keyboard_manager::KeyboardManager;
 use mouse_manager::MouseManager;
@@ -119,6 +122,8 @@ pub fn create_event_loop() -> EventLoop<UserEvent> {
     #[cfg(target_os = "macos")]
     builder.with_default_menu(false);
     let event_loop = builder.build().expect("Failed to create winit event loop");
+    #[cfg(target_os = "macos")]
+    register_file_handler();
     #[allow(clippy::let_and_return)]
     event_loop
 }


### PR DESCRIPTION
fix #2776

The problem is caused by registering `NSApplicationDelegate` too late. This wrong behavior is introduced in #2768 (8ed544) by mistake. So we have to revert this part and move the registering right after creating event loop.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
