### PR TITLE
feat: add set transparent color function

### DIFF
--- a/.nvim-dap.lua
+++ b/.nvim-dap.lua
@@ -1,14 +1,13 @@
-local dap = require('dap')
+local dap = require("dap")
 
 dap.adapters.rust = {
-    type = 'server',
+    type = "server",
     port = "${port}",
     executable = {
-        command = 'codelldb.cmd',
+        command = "codelldb.cmd",
         args = { "--port", "${port}" },
-    }
+    },
 }
-
 
 dap.configurations.rust = {
     {

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -67,6 +67,28 @@ vim.api.nvim_create_user_command("NeovideFocus", function()
     rpcnotify("neovide.focus_window")
 end, {})
 
+---@class neovide.ColorOpacity
+---@field disable? boolean
+---@field base_opacity? number
+---@field multiplier? number
+---@field applies_to_foreground? boolean
+local neovide_color_opacity = {
+    disable = false,
+    base_opacity = 0.0,
+    multiplier = 1.0,
+    applies_to_foreground = true,
+}
+
+---Apply opacity to a color
+---@param color_index number
+---@param opts neovide.ColorOpacity
+function _G.neovide_set_transparent_color(color_index, opts)
+    if type(opts) == "table" then
+        opts = vim.tbl_deep_extend("force", neovide_color_opacity, opts)
+        rpcnotify("neovide.set_transparent_color", color_index, opts)
+    end
+end
+
 vim.api.nvim_exec(
     [[
 function! WatchGlobal(variable, callback)

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -10,7 +10,6 @@
 ---@type Args
 local args = ...
 
-
 vim.g.neovide_channel_id = args.neovide_channel_id
 vim.g.neovide_version = args.neovide_version
 
@@ -35,7 +34,7 @@ end
 local function get_clipboard(register)
     return function()
         return rpcrequest("neovide.get_clipboard", register)
-   end
+    end
 end
 
 if args.register_clipboard and not vim.g.neovide_no_custom_clipboard then
@@ -49,13 +48,11 @@ if args.register_clipboard and not vim.g.neovide_no_custom_clipboard then
             ["+"] = get_clipboard("+"),
             ["*"] = get_clipboard("*"),
         },
-        cache_enabled = false
+        cache_enabled = false,
     }
     vim.g.loaded_clipboard_provider = nil
     vim.cmd.runtime("autoload/provider/clipboard.vim")
 end
-
-
 
 if args.register_right_click then
     vim.api.nvim_create_user_command("NeovideRegisterRightClick", function()
@@ -70,27 +67,30 @@ vim.api.nvim_create_user_command("NeovideFocus", function()
     rpcnotify("neovide.focus_window")
 end, {})
 
-vim.api.nvim_exec([[
+vim.api.nvim_exec(
+    [[
 function! WatchGlobal(variable, callback)
     call dictwatcheradd(g:, a:variable, a:callback)
 endfunction
-]], false)
+]],
+    false
+)
 
-for _,global_variable_setting in ipairs(args.global_variable_settings) do
+for _, global_variable_setting in ipairs(args.global_variable_settings) do
     local callback = function()
         rpcnotify("setting_changed", global_variable_setting, vim.g["neovide_" .. global_variable_setting])
     end
     vim.fn.WatchGlobal("neovide_" .. global_variable_setting, callback)
 end
 
-for _,option_setting in ipairs(args.option_settings) do
+for _, option_setting in ipairs(args.option_settings) do
     vim.api.nvim_create_autocmd({ "OptionSet" }, {
         pattern = option_setting,
         once = false,
         nested = true,
         callback = function()
             rpcnotify("option_changed", option_setting, vim.o[option_setting])
-        end
+        end,
     })
 end
 
@@ -100,12 +100,12 @@ vim.api.nvim_create_autocmd({ "VimEnter" }, {
     once = true,
     nested = true,
     callback = function()
-        for _,option_setting in ipairs(args.option_settings) do
+        for _, option_setting in ipairs(args.option_settings) do
             if option_setting ~= "lines" and option_setting ~= "columns" then
                 rpcnotify("option_changed", option_setting, vim.o[option_setting])
             end
         end
-    end
+    end,
 })
 
 -- Create auto command for retrieving exit code from neovim on quit.
@@ -115,5 +115,5 @@ vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
     nested = true,
     callback = function()
         rpcrequest("neovide.quit", vim.v.exiting)
-    end
+    end,
 })

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -9,7 +9,7 @@ use rmpv::Value;
 use skia_safe::Color4f;
 use strum::AsRefStr;
 
-use crate::editor::{Colors, CursorMode, CursorShape, Style, UnderlineStyle};
+use crate::editor::{ColorOpacity, Colors, CursorMode, CursorShape, Style, UnderlineStyle};
 
 #[derive(Clone, Debug)]
 pub enum ParseError {
@@ -59,6 +59,31 @@ pub struct GridLineCell {
 }
 
 pub type StyledContent = Vec<(u64, String)>;
+
+impl ColorOpacity {
+    pub fn parse(arguments: Value) -> Result<ColorOpacity> {
+        let attributes = parse_map(arguments)?;
+        let mut color_opacity = ColorOpacity::default();
+        for (key, value) in attributes {
+            match parse_string(key)?.as_str() {
+                "disable" => {
+                    color_opacity.disable = parse_bool(value)?;
+                }
+                "base_opacity" => {
+                    color_opacity.base_opacity = parse_f64(value)? as f32;
+                }
+                "multiplier" => {
+                    color_opacity.multiplier = parse_f64(value)? as f32;
+                }
+                "applies_to_foreground" => {
+                    color_opacity.applies_to_foreground = parse_bool(value)?;
+                }
+                key => debug!("Ignored style attribute: {}", key),
+            }
+        }
+        Ok(color_opacity)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub enum MessageKind {
@@ -167,6 +192,10 @@ pub enum RedrawEvent {
     HighlightAttributesDefine {
         id: u64,
         style: Style,
+    },
+    ColorOpacitySet {
+        color: u64,
+        color_opacity: ColorOpacity,
     },
     GridLine {
         grid: u64,
@@ -869,6 +898,16 @@ fn parse_msg_history_show(msg_history_show_arguments: Vec<Value>) -> Result<Redr
             .into_iter()
             .map(parse_msg_history_entry)
             .collect::<Result<_>>()?,
+    })
+}
+
+pub fn parse_transparent_color(transparent_color_arguments: Vec<Value>) -> Result<RedrawEvent> {
+    let [color_index, opts] = extract_values(transparent_color_arguments)?;
+    let color_opacity = ColorOpacity::parse(opts)?;
+
+    Ok(RedrawEvent::ColorOpacitySet {
+        color: parse_u64(color_index)?,
+        color_opacity,
     })
 }
 

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -197,6 +197,9 @@ pub enum RedrawEvent {
         color: u64,
         color_opacity: ColorOpacity,
     },
+    OpacityChanged {
+        opacity: f32,
+    },
     GridLine {
         grid: u64,
         row: u64,

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -521,11 +521,18 @@ fn parse_default_colors(default_colors_arguments: Vec<Value>) -> Result<RedrawEv
     let [foreground, background, special, _term_foreground, _term_background] =
         extract_values(default_colors_arguments)?;
 
+    let fg = parse_u64(foreground)?;
+    let bg = parse_u64(background)?;
+    let sp = parse_u64(special)?;
+
     Ok(RedrawEvent::DefaultColorsSet {
         colors: Colors {
-            foreground: Some(unpack_color(parse_u64(foreground)?)),
-            background: Some(unpack_color(parse_u64(background)?)),
-            special: Some(unpack_color(parse_u64(special)?)),
+            foreground: Some(unpack_color(fg)),
+            background: Some(unpack_color(bg)),
+            special: Some(unpack_color(sp)),
+            fg: Some(fg),
+            bg: Some(bg),
+            sp: Some(sp),
         },
     })
 }
@@ -533,19 +540,25 @@ fn parse_default_colors(default_colors_arguments: Vec<Value>) -> Result<RedrawEv
 fn parse_style(style_map: Value, _info_array: Value) -> Result<Style> {
     let attributes = parse_map(style_map)?;
 
-    let mut style = Style::new(Colors::new(None, None, None));
+    let mut style = Style::new(Colors::new(None, None, None, None, None, None));
 
     for attribute in attributes {
         if let (Value::String(name), value) = attribute {
             match (name.as_str().unwrap(), value) {
-                ("foreground", Value::Integer(packed_color)) => {
-                    style.colors.foreground = Some(unpack_color(packed_color.as_u64().unwrap()))
+                ("foreground", Value::Integer(color)) => {
+                    let color = color.as_u64().unwrap();
+                    style.colors.fg = Some(color);
+                    style.colors.foreground = Some(unpack_color(color));
                 }
-                ("background", Value::Integer(packed_color)) => {
-                    style.colors.background = Some(unpack_color(packed_color.as_u64().unwrap()))
+                ("background", Value::Integer(color)) => {
+                    let color = color.as_u64().unwrap();
+                    style.colors.bg = Some(color);
+                    style.colors.background = Some(unpack_color(color))
                 }
-                ("special", Value::Integer(packed_color)) => {
-                    style.colors.special = Some(unpack_color(packed_color.as_u64().unwrap()))
+                ("special", Value::Integer(color)) => {
+                    let color = color.as_u64().unwrap();
+                    style.colors.sp = Some(color);
+                    style.colors.special = Some(unpack_color(color))
                 }
                 ("reverse", Value::Boolean(reverse)) => style.reverse = reverse,
                 ("italic", Value::Boolean(italic)) => style.italic = italic,

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -96,8 +96,11 @@ impl Handler for NeovimHandler {
                 }
             }
             "setting_changed" => {
-                SETTINGS
-                    .handle_setting_changed_notification(arguments, &self.proxy.lock().unwrap());
+                SETTINGS.handle_setting_changed_notification(
+                    arguments,
+                    &self.proxy.lock().unwrap(),
+                    &self.sender,
+                );
             }
             "option_changed" => {
                 SETTINGS.handle_option_changed_notification(arguments, &self.proxy.lock().unwrap());

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2,9 +2,11 @@ mod cursor;
 mod draw_command_batcher;
 mod grid;
 mod style;
+mod style_registry;
 mod window;
 
-use std::{collections::HashMap, rc::Rc, sync::Arc, thread};
+use std::{collections::HashMap, rc::Rc, thread};
+use style_registry::StyleRegistry;
 use tokio::sync::mpsc::unbounded_channel;
 
 use log::{error, trace, warn};
@@ -21,7 +23,8 @@ use crate::{
     bridge::{GuiOption, NeovimHandler, RedrawEvent, WindowAnchor},
     profiling::{tracy_named_frame, tracy_zone},
     renderer::{DrawCommand, WindowDrawCommand},
-    window::{UserEvent, WindowCommand},
+    settings::SETTINGS,
+    window::{UserEvent, WindowCommand, WindowSettings},
 };
 
 #[cfg(target_os = "macos")]
@@ -29,7 +32,7 @@ use crate::{cmd_line::CmdLineSettings, frame::Frame, settings::SETTINGS};
 
 pub use cursor::{Cursor, CursorMode, CursorShape};
 pub use draw_command_batcher::DrawCommandBatcher;
-pub use style::{Colors, Style, UnderlineStyle};
+pub use style::{ColorOpacity, Colors, Style, UnderlineStyle};
 pub use window::*;
 
 const MODE_CMDLINE: u64 = 4;
@@ -87,7 +90,7 @@ impl WindowAnchor {
 pub struct Editor {
     pub windows: HashMap<u64, Window>,
     pub cursor: Cursor,
-    pub defined_styles: HashMap<u64, Arc<Style>>,
+    pub style_registry: StyleRegistry,
     pub mode_list: Vec<CursorMode>,
     pub draw_command_batcher: Rc<DrawCommandBatcher>,
     pub current_mode_index: Option<u64>,
@@ -101,7 +104,7 @@ impl Editor {
         Editor {
             windows: HashMap::new(),
             cursor: Cursor::new(),
-            defined_styles: HashMap::new(),
+            style_registry: StyleRegistry::new(),
             mode_list: Vec::new(),
             draw_command_batcher: Rc::new(DrawCommandBatcher::new()),
             current_mode_index: None,
@@ -127,7 +130,8 @@ impl Editor {
                 self.mode_list = cursor_modes;
                 if let Some(current_mode_i) = self.current_mode_index {
                     if let Some(current_mode) = self.mode_list.get(current_mode_i as usize) {
-                        self.cursor.change_mode(current_mode, &self.defined_styles)
+                        self.cursor
+                            .change_mode(current_mode, self.style_registry.defined_styles())
                     }
                 }
             }
@@ -138,7 +142,8 @@ impl Editor {
             RedrawEvent::ModeChange { mode, mode_index } => {
                 tracy_zone!("ModeChange");
                 if let Some(cursor_mode) = self.mode_list.get(mode_index as usize) {
-                    self.cursor.change_mode(cursor_mode, &self.defined_styles);
+                    self.cursor
+                        .change_mode(cursor_mode, self.style_registry.defined_styles());
                     self.current_mode_index = Some(mode_index)
                 } else {
                     self.current_mode_index = None
@@ -190,14 +195,46 @@ impl Editor {
                     );
                 }
 
+                // Use id 0 for the default style
+                self.style_registry.set_style(
+                    Style::new(colors),
+                    0,
+                    SETTINGS.get::<WindowSettings>().transparency,
+                );
+                let style = self.style_registry.default_style().unwrap();
                 self.draw_command_batcher
-                    .queue(DrawCommand::DefaultStyleChanged(Style::new(colors)));
+                    .queue(DrawCommand::DefaultStyleChanged(style));
                 self.redraw_screen();
                 self.draw_command_batcher.send_batch(&self.event_loop_proxy);
             }
             RedrawEvent::HighlightAttributesDefine { id, style } => {
                 tracy_zone!("EditorHighlightAttributesDefine");
-                self.defined_styles.insert(id, Arc::new(style));
+                self.style_registry.set_style(
+                    style,
+                    id,
+                    SETTINGS.get::<WindowSettings>().transparency,
+                );
+            }
+            RedrawEvent::ColorOpacitySet {
+                color,
+                color_opacity,
+            } => {
+                let default_style = self.style_registry.default_style();
+                self.style_registry.set_opacity(
+                    color,
+                    color_opacity,
+                    SETTINGS.get::<WindowSettings>().transparency,
+                );
+                let updated_default_style = self.style_registry.default_style();
+
+                if default_style != updated_default_style {
+                    if let Some(new_style) = updated_default_style {
+                        self.draw_command_batcher
+                            .queue(DrawCommand::DefaultStyleChanged(new_style));
+                        self.redraw_screen();
+                        self.draw_command_batcher.send_batch(&self.event_loop_proxy);
+                    }
+                }
             }
             RedrawEvent::CursorGoto {
                 grid,
@@ -223,7 +260,7 @@ impl Editor {
             } => {
                 tracy_zone!("EditorGridLine");
                 self.set_ui_ready();
-                let defined_styles = &self.defined_styles;
+                let defined_styles = &self.style_registry.defined_styles();
                 let window = self.windows.get_mut(&grid);
                 if let Some(window) = window {
                     window.draw_grid_line(row, column_start, cells, defined_styles);

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -236,6 +236,15 @@ impl Editor {
                     }
                 }
             }
+            RedrawEvent::OpacityChanged { opacity } => {
+                self.style_registry.update_all_styles_opacity(opacity);
+                if let Some(default_style) = self.style_registry.default_style() {
+                    self.draw_command_batcher
+                        .queue(DrawCommand::DefaultStyleChanged(default_style));
+                    self.redraw_screen();
+                    self.draw_command_batcher.send_batch(&self.event_loop_proxy);
+                }
+            }
             RedrawEvent::CursorGoto {
                 grid,
                 column: left,

--- a/src/editor/style.rs
+++ b/src/editor/style.rs
@@ -5,6 +5,9 @@ pub struct Colors {
     pub foreground: Option<Color4f>,
     pub background: Option<Color4f>,
     pub special: Option<Color4f>,
+    pub fg: Option<u64>,
+    pub bg: Option<u64>,
+    pub sp: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -85,24 +88,24 @@ impl Style {
             .unwrap_or_else(|| self.foreground(default_colors))
     }
 
-    pub fn packed_foreground(&self) -> Option<u64> {
+    pub fn fg(&self) -> Option<u64> {
         if self.reverse {
-            self.colors.packed_background
+            self.colors.bg
         } else {
-            self.colors.packed_foreground
+            self.colors.fg
         }
     }
 
-    pub fn packed_background(&self) -> Option<u64> {
+    pub fn bg(&self) -> Option<u64> {
         if self.reverse {
-            self.colors.packed_foreground
+            self.colors.fg
         } else {
-            self.colors.packed_background
+            self.colors.bg
         }
     }
 
-    pub fn packed_special(&self) -> Option<u64> {
-        self.colors.packed_special
+    pub fn sp(&self) -> Option<u64> {
+        self.colors.sp
     }
 
     pub fn set_background_opacity(&mut self, color_opacity: &ColorOpacity, default_opacity: f32) {
@@ -126,12 +129,18 @@ mod tests {
         foreground: Some(Color4f::new(0.1, 0.1, 0.1, 0.1)),
         background: Some(Color4f::new(0.2, 0.1, 0.1, 0.1)),
         special: Some(Color4f::new(0.3, 0.1, 0.1, 0.1)),
+        fg: None,
+        bg: None,
+        sp: None,
     };
 
     const DEFAULT_COLORS: Colors = Colors {
         foreground: Some(Color4f::new(0.1, 0.2, 0.1, 0.1)),
         background: Some(Color4f::new(0.2, 0.2, 0.1, 0.1)),
         special: Some(Color4f::new(0.3, 0.2, 0.1, 0.1)),
+        fg: None,
+        bg: None,
+        sp: None,
     };
 
     #[test]

--- a/src/editor/style_registry.rs
+++ b/src/editor/style_registry.rs
@@ -1,0 +1,155 @@
+use std::{collections::HashMap, sync::Arc};
+
+use super::{style::Style, ColorOpacity};
+
+type StyleId = u64;
+type ColorId = u64;
+
+/// The `StyleRegistry` struct is responsible for keeping styles updated with corresponding opacity settings.
+/// Styles and opacities are associated with background and foreground colors.
+#[derive(Default)]
+pub struct StyleRegistry {
+    /// Maps style IDs (neovim highlight table id) to their corresponding styles
+    defined_styles: HashMap<StyleId, Arc<Style>>,
+
+    /// Associates each color with opacity settings.
+    /// This is used to update the opacity of all styles when the global opacity changes.
+    defined_opacities: HashMap<ColorId, ColorOpacity>,
+
+    /// Maps background colors to their corresponding style IDs
+    background_color_style_map: HashMap<ColorId, Vec<StyleId>>,
+
+    /// Maps foreground colors to their corresponding style IDs
+    foreground_color_style_map: HashMap<ColorId, Vec<StyleId>>,
+}
+
+impl StyleRegistry {
+    pub fn new() -> Self {
+        Self {
+            defined_opacities: HashMap::new(),
+            defined_styles: HashMap::new(),
+            background_color_style_map: HashMap::new(),
+            foreground_color_style_map: HashMap::new(),
+        }
+    }
+
+    pub fn default_style(&self) -> Option<Style> {
+        self.defined_styles.get(&0).map(|style| (**style).clone())
+    }
+
+    pub fn defined_styles(&self) -> &HashMap<u64, Arc<Style>> {
+        &self.defined_styles
+    }
+
+    pub fn set_style(&mut self, mut style: Style, id: u64, default_opacity: f32) {
+        self.update_style_opacities_from_existing_mapping(&mut style, default_opacity);
+        self.update_color_to_style_mapping(&style, id);
+        self.defined_styles.insert(id, Arc::new(style));
+    }
+
+    /// Set the foreground and background opacity of a color and update all styles that use this color
+    pub fn set_opacity(
+        &mut self,
+        color: ColorId,
+        color_opacity: ColorOpacity,
+        default_opacity: f32,
+    ) {
+        // Update the opacity of all styles that use this color
+        let mut update_opacity =
+            |styles_map: &HashMap<ColorId, Vec<StyleId>>,
+             set_opacity_fn: fn(&mut Style, &ColorOpacity, f32)| {
+                if let Some(styles_id) = styles_map.get(&color) {
+                    styles_id.iter().for_each(|id| {
+                        if let Some(arc) = self.defined_styles.get(id) {
+                            let mut style = (**arc).to_owned();
+                            set_opacity_fn(&mut style, &color_opacity, default_opacity);
+                            self.defined_styles.insert(*id, Arc::new(style));
+                        }
+                    });
+                }
+            };
+
+        update_opacity(
+            &self.background_color_style_map,
+            Style::set_background_opacity,
+        );
+        update_opacity(
+            &self.foreground_color_style_map,
+            Style::set_foreground_opacity,
+        );
+
+        self.defined_opacities.insert(color, color_opacity);
+    }
+
+    /// Update all styles with existing color opacity settings with updated global opacity
+    pub fn update_all_styles_opacity(&mut self, default_opacity: f32) {
+        let get_updated_styles =
+            |color_style_map: &HashMap<ColorId, Vec<StyleId>>,
+             set_opacity_fn: fn(&mut Style, &ColorOpacity, f32)| {
+                color_style_map
+                    .iter()
+                    .filter_map(|(color, style_ids)| {
+                        self.defined_opacities.get(color).map(|color_opacity| {
+                            style_ids
+                                .iter()
+                                .filter_map(|id| self.defined_styles.get_key_value(id))
+                                .map(|(id, arc)| {
+                                    let mut style = (**arc).to_owned();
+                                    set_opacity_fn(&mut style, color_opacity, default_opacity);
+                                    (*id, style)
+                                })
+                        })
+                    })
+                    .flatten()
+                    .collect::<Vec<_>>()
+            };
+
+        let new_background_styles = get_updated_styles(
+            &self.background_color_style_map,
+            Style::set_background_opacity,
+        );
+
+        let new_foreground_styles = get_updated_styles(
+            &self.foreground_color_style_map,
+            Style::set_foreground_opacity,
+        );
+
+        new_background_styles.iter().for_each(|(id, style)| {
+            self.defined_styles.insert(*id, Arc::new(style.clone()));
+        });
+
+        new_foreground_styles.iter().for_each(|(id, style)| {
+            self.defined_styles.insert(*id, Arc::new(style.clone()));
+        });
+    }
+
+    /// Updates the opacity of the background and foreground style based on an existing opacity mapping.
+    /// This function should be called when a style is defined or opacity changes.
+    fn update_style_opacities_from_existing_mapping(&mut self, style: &mut Style, opacity: f32) {
+        if let Some(o) = style.bg().and_then(|bg| self.defined_opacities.get(&bg)) {
+            style.set_background_opacity(o, opacity);
+        }
+
+        if let Some(o) = style.fg().and_then(|fg| self.defined_opacities.get(&fg)) {
+            style.set_foreground_opacity(o, opacity);
+        }
+    }
+
+    /// Add style id in the background and foreground mapping with corresponding color.
+    /// Should be called when a new style is defined
+    fn update_color_to_style_mapping(&mut self, style: &Style, id: StyleId) {
+        if let Some(color) = style.bg() {
+            self.background_color_style_map
+                .entry(color)
+                .or_default()
+                .push(id);
+        }
+
+        if let Some(color) = style.fg() {
+            self.foreground_color_style_map
+                .entry(color)
+                .or_default()
+                .push(id);
+        }
+    }
+}

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -38,6 +38,9 @@ impl GridRenderer {
             Some(colors::WHITE),
             Some(colors::BLACK),
             Some(colors::GREY),
+            Some(16777215),
+            Some(0),
+            Some(8947848),
         )));
         let em_size = shaper.current_size();
         let font_dimensions = shaper.font_base_dimensions();

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -204,14 +204,13 @@ impl Renderer {
 
     pub fn draw_frame(&mut self, root_canvas: &Canvas, dt: f32) {
         tracy_zone!("renderer_draw_frame");
-        let default_background = self.grid_renderer.get_default_background();
+        let default_background = self.grid_renderer.get_default_background().to_color();
         let grid_scale = self.grid_renderer.grid_scale;
 
-        let transparency = SETTINGS.get::<WindowSettings>().transparency;
         let layer_grouping = SETTINGS
             .get::<RendererSettings>()
             .experimental_layer_grouping;
-        root_canvas.clear(default_background.with_a((255.0 * transparency) as u8));
+        root_canvas.clear(default_background);
         root_canvas.save();
         root_canvas.reset_matrix();
 
@@ -285,24 +284,13 @@ impl Renderer {
         let settings = SETTINGS.get::<RendererSettings>();
         let root_window_regions = root_windows
             .into_iter()
-            .map(|window| {
-                window.draw(
-                    root_canvas,
-                    default_background.with_a((255.0 * transparency) as u8),
-                    grid_scale,
-                )
-            })
+            .map(|window| window.draw(root_canvas, default_background, grid_scale))
             .collect_vec();
 
         let floating_window_regions = floating_layers
             .into_iter()
             .flat_map(|mut layer| {
-                layer.draw(
-                    root_canvas,
-                    &settings,
-                    default_background.with_a((255.0 * transparency) as u8),
-                    grid_scale,
-                )
+                layer.draw(root_canvas, &settings, default_background, grid_scale)
             })
             .collect_vec();
 

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -75,7 +75,7 @@ impl<'w> FloatingLayer<'w> {
         let save_layer_rec = SaveLayerRec::default().bounds(&bound_rect).paint(&paint);
 
         root_canvas.save_layer(&save_layer_rec);
-        root_canvas.clear(default_background.with_a(255));
+        root_canvas.clear(default_background);
 
         let regions = self
             .windows

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -69,7 +69,6 @@ impl<'w> FloatingLayer<'w> {
 
         let paint = Paint::default()
             .set_anti_alias(false)
-            .set_color(Color::from_argb(255, 255, 255, default_background.a()))
             .set_blend_mode(BlendMode::SrcOver)
             .to_owned();
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -296,7 +296,6 @@ impl RenderedWindow {
 
         let paint = Paint::default()
             .set_anti_alias(false)
-            .set_color(Color::from_argb(255, 255, 255, default_background.a()))
             .set_blend_mode(if self.anchor_info.is_some() {
                 BlendMode::SrcOver
             } else {

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -308,13 +308,12 @@ impl RenderedWindow {
 
         let mut background_paint = Paint::default();
         background_paint.set_blend_mode(BlendMode::Src);
-        background_paint.set_alpha(default_background.a());
         let background_layer_rec = SaveLayerRec::default()
             .bounds(&pixel_region)
             .paint(&background_paint);
 
         root_canvas.save_layer(&background_layer_rec);
-        root_canvas.clear(default_background.with_a(255));
+        root_canvas.clear(default_background);
         self.draw_background_surface(root_canvas, pixel_region_box, grid_scale);
         root_canvas.restore();
         self.draw_foreground_surface(root_canvas, pixel_region_box, grid_scale);

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Spaces"
+indent_width = 4
+column_width = 120


### PR DESCRIPTION
Add `neovide_set_transparent_color(colors, opts)` lua function to set color transparency/opacity.  
Update all styles opacity background and foreground (alpha values) sharing the same color with the provided settings.

## Changes

- [x] Reformat Lua files and add `stylua.toml`
- [x] All colors are opaque by default
- [x] Add packed colors to styles
- [x] Add `neovide_set_transparent_color` function with `ColorOpacity` struct/table.
  - Updated `RedrawEvent` to include `ColorOpacitySet`
  - Added `StyleRegistry` to keep a mapping between styles, colors and opacity settings.
  - Modified `Editor` to use `StyleRegistry` for managing styles and opacities.
- [x] Updated settings mod to trigger `RedrawEvent` on transparency changes.
  - This feels a little hacky, but it's the only way I found to properly update the styles when the transparency changes.  
    Alternatively, all styles alpha values could be computed on each redraw.
- [ ] Set default opacity for some styles such as `Normal` and default_background
- [ ] Add test

> [!WARNING]
> blend is not used anymore and can be reintroduce with `blend_multiplier` in #2704

> [!IMPORTANT]
> The current changes only deals with the style background/foreground  
> Other settings will be handled in issues from the transparency milestone (floating, reset function, alpha composition, ...)

> [!NOTE]
> It might be better to allow user to set different opacity for background and foreground color (for readability)  
> and change `applies_to_foreground` to `applies_to` accepting `background`, `foreground` or even `special`


Please feel free to ask for any changes or perform them directly.

## Usage

```lua
vim.g.neovide_transparency = 0.75
if type(neovide_set_transparent_color) == 'function' then
  local opacity_opts = {
    disable = false,
    base_opacity = 0.0,
    multiplier = 1.0,
    applies_to_foreground = false,
  }
  vim.api.nvim_create_autocmd('ColorScheme', {
    pattern = '*',
    callback = function()
      -- Set the default background opacity
      -- Required if Normal background or foreground is set to None
      neovide_set_transparent_color(0, opacity_opts)
      local highlights = {
        'Normal',
        'NormalNC',
        'StatusLine',
        'StatusLineNC',
      }
      vim
        .iter(highlights)
        :map(function(name) return vim.api.nvim_get_hl(0, { name = name }).bg end)
        :filter(function(bg) return type(bg) == 'number' end)
        :each(function(bg) neovide_set_transparent_color(bg, opacity_opts) end)
    end,
  })
end
```

## Related Issue

- #2780 Can be integrated by setting default style opacity for all styles without configured opacity setting  
  This might be useful for users to set all backgrounds opacity at once instead of relying on `neovide_set_transparent_color`.

## What kind of change does this PR introduce?

- Feature

## Did this PR introduce a breaking change?

_A breaking change includes anything that breaks backward compatibility either at compile or run time._
- Yes
  - All colors are opaque by default

Close #2702