### PR TITLE
disable AppKit's command line processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ skia-safe = { version = "0.75.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.2"
-objc2-foundation = { version = "0.2.2" }
+objc2-foundation = { version = "0.2.2", features = [ "NSUserDefaults" ] }
 objc2-app-kit = { version = "0.2.2", features = [ "NSLayoutConstraint" ] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -10,7 +10,7 @@ use objc2_app_kit::{
 };
 use objc2_foundation::{
     ns_string, MainThreadMarker, NSArray, NSObject, NSPoint, NSProcessInfo, NSRect, NSSize,
-    NSString,
+    NSString, NSUserDefaults, NSDictionary,
 };
 
 use csscolorparser::Color;
@@ -481,5 +481,12 @@ pub fn register_file_handler() {
         //  * overriden methods are compatible with old (we implement protocol method)
         let delegate_obj = Retained::cast::<AnyObject>(delegate);
         AnyObject::set_class(&delegate_obj, class);
+
+        // Prevent AppKit from interpreting our command line.
+        let key = NSString::from_str("NSTreatUnknownArgumentsAsOpen");
+        let keys = vec![key.as_ref()];
+        let objects = vec![Retained::cast::<AnyObject>(NSString::from_str("NO"))];
+        let dict = NSDictionary::from_vec(&keys, objects);
+        NSUserDefaults::standardUserDefaults().registerDefaults(dict.as_ref());
     }
 }


### PR DESCRIPTION
By default, AppKit will helpfully collect any command line arguments that do not start with a dash and pass them to `application:openFiles:`. We do our own non-trivial command line parsing for our arguments and for Neovim, so we must disable this default behavior. (Otherwise, command lines like `neovide -- -c 'color blue'` will result in a modified buffer named "color blue".)

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix: Fixes #2609 https://github.com/neovide/neovide/issues/2629

## Did this PR introduce a breaking change? 
- No
