### PR TITLE
on macOS, activate when launched

### DIFF
--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -288,10 +288,15 @@ impl MacosWindowFeature {
         }
     }
 
-    pub fn ensure_menu_added(&mut self) {
+    /// Create the application menu and grab initial focus.
+    pub fn ensure_app_initialized(&mut self) {
         let mtm = MainThreadMarker::new().expect("Menu must be created on the main thread");
         if self.menu.is_none() {
             self.menu = Some(Menu::new(mtm));
+            let app = NSApplication::sharedApplication(mtm);
+
+            #[allow(deprecated)]
+            app.activateIgnoringOtherApps(true)
         }
     }
 }

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -337,7 +337,7 @@ impl ApplicationHandler<UserEvent> for UpdateLoop {
                     .macos_feature
                     .as_mut()
                     .expect("MacosWindowFeature should already be created here.")
-                    .ensure_menu_added();
+                    .ensure_app_initialized();
             }
             _ => {}
         }


### PR DESCRIPTION
Generally, it is considered bad form for an application to un-cooperatively take the focus. However, for applications that are frequently launched from the terminal, they must strongly request focus because the terminal, in its ignorance, will not automatically yield.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix: Fixes #2330 

## Did this PR introduce a breaking change? 
- No
