### PR TITLE
fix: Mouse scrolling when multigrid is disabled

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -243,7 +243,9 @@ impl MouseManager {
         }
 
         let draw_details = self.get_window_details_under_mouse(editor_state);
-        let grid_id = draw_details.map(|details| details.id).unwrap_or(0);
+        let grid_id = draw_details
+            .map(|details| details.event_grid_id())
+            .unwrap_or(0);
 
         let previous: GridPos<i32> = self.scroll_position.floor().try_cast().unwrap();
         self.scroll_position += amount;


### PR DESCRIPTION


<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Fix the mouse scrolling when multigrid is disabled. The window id should always be 0, so use the `event_grid_id` function.

* fixes https://github.com/neovide/neovide/issues/2801

## Did this PR introduce a breaking change? 
- No
