### PR TITLE
feat: add cursor color settings

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -34,6 +34,8 @@ pub struct CursorSettings {
     trail_size: f32,
     unfocused_outline_width: f32,
     smooth_blink: bool,
+    bg: String,
+    fg: String,
 
     vfx_mode: cursor_vfx::VfxMode,
     vfx_opacity: f32,
@@ -53,6 +55,8 @@ impl Default for CursorSettings {
             animate_in_insert_mode: true,
             animate_command_line: true,
             trail_size: 0.7,
+            bg: String::from(""),
+            fg: String::from(""),
             unfocused_outline_width: 1.0 / 8.0,
             smooth_blink: false,
             vfx_mode: cursor_vfx::VfxMode::Disabled,
@@ -285,12 +289,21 @@ impl CursorRenderer {
             return;
         }
         // Draw Background
-        let background_color = self
-            .cursor
-            .background(&grid_renderer.default_style.colors)
-            .to_color()
-            .with_a((opacity * alpha) as u8);
-        paint.set_color(background_color);
+        let bg = &settings.bg.trim_start_matches("#");
+        let bg_color = if bg.is_empty() {
+            self.cursor.background(&grid_renderer.default_style.colors)
+        } else {
+            match (0..bg.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&bg[i..i + 2], 16).unwrap_or(0) as u32)
+                .reduce(|l, r| (l << 8) + r)
+                {
+                    Some(v) => skia_safe::Color4f::from(v),
+                    None => self.cursor.foreground(&grid_renderer.default_style.colors),
+                }
+        };
+
+        paint.set_color(bg_color.to_color().with_a((opacity * alpha) as u8));
 
         let path = if self.window_has_focus || self.cursor.shape != CursorShape::Block {
             self.draw_rectangle(canvas, &paint)
@@ -300,12 +313,21 @@ impl CursorRenderer {
         };
 
         // Draw foreground
-        let foreground_color = self
-            .cursor
-            .foreground(&grid_renderer.default_style.colors)
-            .to_color()
-            .with_a((opacity * alpha) as u8);
-        paint.set_color(foreground_color);
+        let fg = &settings.fg.trim_start_matches("#");
+        let fg_color = if fg.is_empty() {
+            self.cursor.foreground(&grid_renderer.default_style.colors)
+        } else {
+            match (0..bg.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&fg[i..i + 2], 16).unwrap_or(0) as u32)
+                .reduce(|l, r| (l << 8) + r)
+                {
+                    Some(v) => skia_safe::Color4f::from(v),
+                    None => self.cursor.foreground(&grid_renderer.default_style.colors),
+                }
+        };
+
+        paint.set_color(fg_color.to_color().with_a((opacity * alpha) as u8));
 
         canvas.save();
         canvas.clip_path(&path, None, Some(false));

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -289,13 +289,15 @@ impl CursorRenderer {
             return;
         }
         // Draw Background
-        let bg_color = if settings.bg == 0 {
-            self.cursor.background(&grid_renderer.default_style.colors).to_color()
+        let background_color = if settings.bg == 0 {
+            self.cursor
+                .background(&grid_renderer.default_style.colors)
+                .to_color()
         } else {
-            skia_safe::Color::from(settings.bg)
-        };
-
-        paint.set_color(bg_color.with_a((opacity * alpha) as u8));
+            settings.bg.into()
+        }
+        .with_a((opacity * alpha) as u8);
+        paint.set_color(background_color);
 
         let path = if self.window_has_focus || self.cursor.shape != CursorShape::Block {
             self.draw_rectangle(canvas, &paint)
@@ -305,13 +307,15 @@ impl CursorRenderer {
         };
 
         // Draw foreground
-        let fg_color = if settings.fg == 0 {
-            self.cursor.foreground(&grid_renderer.default_style.colors).to_color()
+        let foreground_color = if settings.fg == 0 {
+            self.cursor
+                .foreground(&grid_renderer.default_style.colors)
+                .to_color()
         } else {
-            skia_safe::Color::from(settings.fg)
-        };
-
-        paint.set_color(fg_color.with_a((opacity * alpha) as u8));
+            settings.fg.into()
+        }
+        .with_a((opacity * alpha) as u8);
+        paint.set_color(foreground_color);
 
         canvas.save();
         canvas.clip_path(&path, None, Some(false));


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

adds the ability to set colors using g:neovide_cursor_fg and g:neovide_cursor_bg, which can be used to make the cursor work with 'Cursor' highlight group, if left empty it defaults to default style
