### PR TITLE
change backtrace file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ use crate::settings::{load_last_window_settings, Config, FontSettings, Persisten
 
 pub use profiling::startup_profiler;
 
-const BACKTRACES_FILE: &str = "neovide_backtraces.log";
+const BACKTRACES_FILE: &str = ".neovide_backtraces.log";
 const REQUEST_MESSAGE: &str = "This is a bug and we would love for it to be reported to https://github.com/neovide/neovide/issues";
 
 fn main() -> NeovideExitCode {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

I don't want `neovide_backtrace.log` to be displayed when I open the file manager or when I `ls`. So I added `.` to make it hidden. Also most of the tools I have used put `.` before filenames when they put them in the home directory. Also if you don't want this, you may change it to be like `$XDG_STATE_HOME/neovide/neovida_backtrace.log` or something else for other platforms.