### PR TITLE
Initialize the window when 'win_viewport_margins' is received

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -433,6 +433,9 @@ impl Renderer {
                         }
                         WindowDrawCommand::ViewportMargins { .. } => {
                             warn!("ViewportMargins recieved before window was initialized");
+                            let new_window =
+                                RenderedWindow::new(grid_id, GridPos::ZERO, GridSize::ZERO);
+                            vacant_entry.insert(new_window);
                         }
                         _ => {
                             let settings = SETTINGS.get::<CmdLineSettings>();


### PR DESCRIPTION


<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
`win_viewport_margins` can be received before `win_viewport`, so initialize a zero sized window when that happens, so that further events can be processed in the correct order.

This replaces the broken custom window sorting that was implemented before in https://github.com/neovide/neovide/pull/2487

* Fixes https://github.com/neovide/neovide/issues/2838
* A better fix for https://github.com/neovide/neovide/issues/2464

## Did this PR introduce a breaking change? 
- No
