### PR TITLE
fix: setting of lines/columns on Wayland

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -727,6 +727,7 @@ impl WinitWindowWrapper {
             height: new_size.height,
         };
         let _ = window.request_inner_size(new_size);
+        self.skia_renderer.as_mut().unwrap().resize();
     }
 
     fn get_grid_size_from_window(&self, min: GridSize<u32>) -> GridSize<u32> {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Winit 0.30.x does no longer send `WindowEvent::Resized` when the window is programmatically resized on Wayland, so we need to ensure that the render buffers are updated when that is done.

See: 
* https://github.com/rust-windowing/winit/issues/3919

## Did this PR introduce a breaking change? 
- No
