### PR TITLE
fix: the calculation of the window size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ d3d_debug = [] # Enable the D3D debug layer
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
+approx = "0.5.1"
 async-trait = "0.1.83"
 backtrace = "0.3.74"
 clap = { version = "4.5.23", features = ["cargo", "derive", "env", "color"] }
@@ -79,7 +80,6 @@ notify-debouncer-full = "0.4.0"
 regex = "1.11.1"
 
 [dev-dependencies]
-approx = "0.5.1"
 scoped-env = "2.1.0"
 serial_test = "3.2.0"
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -31,6 +31,9 @@ use {
 #[cfg(target_os = "macos")]
 use super::macos::MacosWindowFeature;
 
+const GRID_TOLERANCE: f32 = 0e-6;
+
+use approx::AbsDiffEq;
 use log::trace;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::{
@@ -693,10 +696,14 @@ impl WinitWindowWrapper {
             window_padding.top + window_padding.bottom,
         );
 
-        let window_size = (*grid_size * self.renderer.grid_renderer.grid_scale)
-            .floor()
-            .try_cast()
-            .unwrap()
+        let window_size = *grid_size * self.renderer.grid_renderer.grid_scale;
+        let window_size = if window_size.abs_diff_eq(&window_size.round(), GRID_TOLERANCE) {
+            window_size.round()
+        } else {
+            window_size.floor()
+        }
+        .try_cast()
+        .unwrap()
             + window_padding_size;
 
         log::info!(
@@ -740,10 +747,14 @@ impl WinitWindowWrapper {
             PixelSize::new(self.saved_inner_size.width, self.saved_inner_size.height)
                 - window_padding_size;
 
-        let grid_size = (content_size / self.renderer.grid_renderer.grid_scale)
-            .floor()
-            .try_cast()
-            .unwrap();
+        let grid_size = content_size / self.renderer.grid_renderer.grid_scale;
+        let grid_size = if grid_size.abs_diff_eq(&grid_size.round(), GRID_TOLERANCE) {
+            grid_size.round()
+        } else {
+            grid_size.ceil()
+        }
+        .try_cast()
+        .unwrap();
 
         grid_size.max(min)
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The rounding when calculating the window size was wrong and caused an extra margin. This is now fixed

* Fixes https://github.com/neovide/neovide/issues/2367
* Fixes https://github.com/neovide/neovide/issues/2879

## Did this PR introduce a breaking change? 
- No
