### PR TITLE
fix: handle font changes during frame prepare

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -410,10 +410,6 @@ impl WinitWindowWrapper {
         let skia_renderer = self.skia_renderer.as_mut().unwrap();
         let vsync = self.vsync.as_mut().unwrap();
 
-        if self.font_changed_last_frame {
-            self.font_changed_last_frame = false;
-            self.renderer.prepare_lines(true);
-        }
         self.renderer.draw_frame(skia_renderer.canvas(), dt);
         skia_renderer.flush();
         {
@@ -677,6 +673,11 @@ impl WinitWindowWrapper {
         self.update_ime_position(false);
 
         should_render.update(self.renderer.prepare_frame());
+
+        if self.font_changed_last_frame {
+            self.renderer.prepare_lines(true);
+            self.font_changed_last_frame = false;
+        }
 
         should_render
     }


### PR DESCRIPTION


<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
If the scale factor for example, changes between prepare and render, then font change status was reset too early, and the following prepare step did not get a chance to process it. 

* fixes https://github.com/neovide/neovide/issues/2901
* fixes https://github.com/neovide/neovide/issues/2479

## Did this PR introduce a breaking change? 
- No
