### PR TITLE
fix: crash when flushed before win_pos

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use log::{error, warn};
+use log::error;
 use skia_safe::Canvas;
 
 use winit::{
@@ -37,7 +37,7 @@ use crate::{
     profiling::{tracy_create_gpu_context, tracy_named_frame, tracy_zone},
     renderer::rendered_layer::{group_windows, FloatingLayer},
     settings::*,
-    units::{to_skia_rect, GridPos, GridRect, GridSize, PixelPos},
+    units::{to_skia_rect, GridRect, GridSize, PixelPos},
     window::{ShouldRender, UserEvent},
     WindowSettings,
 };
@@ -421,20 +421,10 @@ impl Renderer {
                         rendered_window.handle_window_draw_command(command);
                     }
                     Entry::Vacant(vacant_entry) => match command {
-                        WindowDrawCommand::Position {
-                            grid_position,
-                            grid_size,
-                            ..
-                        } => {
-                            let grid_position = GridPos::from(grid_position).try_cast().unwrap();
-                            let grid_size = GridSize::from(grid_size).try_cast().unwrap();
-                            let new_window = RenderedWindow::new(grid_id, grid_position, grid_size);
-                            vacant_entry.insert(new_window);
-                        }
-                        WindowDrawCommand::ViewportMargins { .. } => {
-                            warn!("ViewportMargins recieved before window was initialized");
-                            let new_window =
-                                RenderedWindow::new(grid_id, GridPos::ZERO, GridSize::ZERO);
+                        WindowDrawCommand::Position { .. }
+                        | WindowDrawCommand::ViewportMargins { .. } => {
+                            let mut new_window = RenderedWindow::new(grid_id);
+                            new_window.handle_window_draw_command(command);
                             vacant_entry.insert(new_window);
                         }
                         _ => {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
https://github.com/neovide/neovide/pull/2904 caused a regression, which manifests in a very similar crash that the PR was supposed to fix, but it happens for different reasons.

It turns out that `win_viewport_margins` can be sent in a different batch than the first `win_pos`. Which causes the flush to happen when the window is in an invalid state. Fix this by keeping track of this invalid state, and don't perform the actual flush for the window until `win_pos` has been received.

* Fixes https://github.com/neovide/neovide/issues/2910

## Did this PR introduce a breaking change? 
- No
