### PR TITLE
fix: Neovide transparency works for floating windows again

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -145,7 +145,7 @@ impl GridRenderer {
 
         BackgroundInfo {
             custom_color,
-            transparent: alpha > 0.0,
+            transparent: alpha < 1.0,
         }
     }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -99,6 +99,7 @@ impl GridRenderer {
         grid_position: GridPos<i32>,
         cell_width: i32,
         style: &Option<Arc<Style>>,
+        opacity: f32,
     ) -> BackgroundInfo {
         tracy_zone!("draw_background");
         let debug = SETTINGS.get::<RendererSettings>().debug_renderer;
@@ -123,11 +124,12 @@ impl GridRenderer {
         } else {
             paint.set_color(style.background(&self.default_style.colors).to_color());
         }
-        if style.blend > 0 {
-            paint.set_alpha_f((100 - style.blend) as f32 / 100.0);
+        let alpha = if style.blend > 0 {
+            (100 - style.blend) as f32 / 100.0
         } else {
-            paint.set_alpha_f(1.0);
-        }
+            1.0
+        } * opacity;
+        paint.set_alpha_f(alpha);
 
         let custom_color = paint.color4f() != self.default_style.colors.background.unwrap();
         if custom_color {
@@ -136,7 +138,7 @@ impl GridRenderer {
 
         BackgroundInfo {
             custom_color,
-            transparent: style.blend > 0,
+            transparent: alpha > 0.0,
         }
     }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -88,8 +88,15 @@ impl GridRenderer {
         PixelRect::from_origin_and_size(pos, size)
     }
 
-    pub fn get_default_background(&self) -> Color {
-        self.default_style.colors.background.unwrap().to_color()
+    pub fn get_default_background(&self, opacity: f32) -> Color {
+        log::info!("blend {}", self.default_style.blend);
+        let alpha = opacity * (100 - self.default_style.blend) as f32 / 100.0;
+        self.default_style
+            .colors
+            .background
+            .unwrap()
+            .to_color()
+            .with_a((alpha * 255.0) as u8)
     }
 
     /// Draws a single background cell with the same style
@@ -106,7 +113,7 @@ impl GridRenderer {
         if style.is_none() && !debug {
             return BackgroundInfo {
                 custom_color: false,
-                transparent: opacity < 1.0,
+                transparent: self.default_style.blend > 0 || opacity < 1.0,
             };
         }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -106,7 +106,7 @@ impl GridRenderer {
         if style.is_none() && !debug {
             return BackgroundInfo {
                 custom_color: false,
-                transparent: false,
+                transparent: opacity < 1.0,
             };
         }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -209,14 +209,14 @@ impl Renderer {
 
     pub fn draw_frame(&mut self, root_canvas: &Canvas, dt: f32) {
         tracy_zone!("renderer_draw_frame");
-        let default_background = self.grid_renderer.get_default_background();
+        let opacity = SETTINGS.get::<WindowSettings>().transparency;
+        let default_background = self.grid_renderer.get_default_background(opacity);
         let grid_scale = self.grid_renderer.grid_scale;
 
-        let opacity = SETTINGS.get::<WindowSettings>().transparency;
         let layer_grouping = SETTINGS
             .get::<RendererSettings>()
             .experimental_layer_grouping;
-        root_canvas.clear(default_background.with_a((255.0 * opacity) as u8));
+        root_canvas.clear(default_background);
         root_canvas.save();
         root_canvas.reset_matrix();
 
@@ -290,19 +290,13 @@ impl Renderer {
         let settings = SETTINGS.get::<RendererSettings>();
         let root_window_regions = root_windows
             .into_iter()
-            .map(|window| window.draw(root_canvas, default_background, opacity, grid_scale))
+            .map(|window| window.draw(root_canvas, default_background, grid_scale))
             .collect_vec();
 
         let floating_window_regions = floating_layers
             .into_iter()
             .flat_map(|mut layer| {
-                layer.draw(
-                    root_canvas,
-                    &settings,
-                    default_background,
-                    opacity,
-                    grid_scale,
-                )
+                layer.draw(root_canvas, &settings, default_background, grid_scale)
             })
             .collect_vec();
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -212,11 +212,11 @@ impl Renderer {
         let default_background = self.grid_renderer.get_default_background();
         let grid_scale = self.grid_renderer.grid_scale;
 
-        let transparency = SETTINGS.get::<WindowSettings>().transparency;
+        let opacity = SETTINGS.get::<WindowSettings>().transparency;
         let layer_grouping = SETTINGS
             .get::<RendererSettings>()
             .experimental_layer_grouping;
-        root_canvas.clear(default_background.with_a((255.0 * transparency) as u8));
+        root_canvas.clear(default_background.with_a((255.0 * opacity) as u8));
         root_canvas.save();
         root_canvas.reset_matrix();
 
@@ -290,13 +290,7 @@ impl Renderer {
         let settings = SETTINGS.get::<RendererSettings>();
         let root_window_regions = root_windows
             .into_iter()
-            .map(|window| {
-                window.draw(
-                    root_canvas,
-                    default_background.with_a((255.0 * transparency) as u8),
-                    grid_scale,
-                )
-            })
+            .map(|window| window.draw(root_canvas, default_background, opacity, grid_scale))
             .collect_vec();
 
         let floating_window_regions = floating_layers
@@ -305,7 +299,8 @@ impl Renderer {
                 layer.draw(
                     root_canvas,
                     &settings,
-                    default_background.with_a((255.0 * transparency) as u8),
+                    default_background,
+                    opacity,
                     grid_scale,
                 )
             })
@@ -401,9 +396,10 @@ impl Renderer {
     }
 
     pub fn prepare_lines(&mut self, force: bool) {
+        let transparency = SETTINGS.get::<WindowSettings>().transparency;
         self.rendered_windows
             .iter_mut()
-            .for_each(|(_, w)| w.prepare_lines(&mut self.grid_renderer, force));
+            .for_each(|(_, w)| w.prepare_lines(&mut self.grid_renderer, transparency, force));
     }
 
     fn handle_draw_command(&mut self, draw_command: DrawCommand, result: &mut DrawCommandResult) {

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -27,7 +27,6 @@ impl FloatingLayer<'_> {
         root_canvas: &Canvas,
         settings: &RendererSettings,
         default_background: Color,
-        opacity: f32,
         grid_scale: GridScale,
     ) -> Vec<WindowDrawDetails> {
         let pixel_regions = self
@@ -75,7 +74,8 @@ impl FloatingLayer<'_> {
         let save_layer_rec = SaveLayerRec::default().bounds(&bound_rect).paint(&paint);
 
         root_canvas.save_layer(&save_layer_rec);
-        root_canvas.clear(default_background.with_a((opacity * 255.0) as u8));
+        let background_paint = Paint::default().set_color(default_background).to_owned();
+        root_canvas.draw_path(&silhouette, &background_paint);
 
         let regions = self
             .windows

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -1,8 +1,6 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-use skia_safe::{
-    canvas::SaveLayerRec, BlendMode, Canvas, Color, Matrix, Paint, Picture, PictureRecorder, Rect,
-};
+use skia_safe::{Canvas, Color, Matrix, Picture, PictureRecorder, Rect};
 
 use crate::{
     cmd_line::CmdLineSettings,
@@ -230,6 +228,8 @@ impl RenderedWindow {
                 canvas.draw_picture(background_picture, Some(&matrix), None);
             }
         }
+        canvas.restore();
+
         canvas.save();
         canvas.clip_rect(inner_region, None, false);
         let mut pics = 0;
@@ -246,7 +246,6 @@ impl RenderedWindow {
             inner_region,
             pics
         );
-        canvas.restore();
         canvas.restore();
     }
 
@@ -290,6 +289,7 @@ impl RenderedWindow {
         &mut self,
         root_canvas: &Canvas,
         default_background: Color,
+        opacity: f32,
         grid_scale: GridScale,
     ) -> WindowDrawDetails {
         let pixel_region_box = self.pixel_region(grid_scale);
@@ -304,33 +304,10 @@ impl RenderedWindow {
 
         root_canvas.save();
         root_canvas.clip_rect(pixel_region, None, Some(false));
+        root_canvas.clear(default_background.with_a((255.0 * opacity) as u8));
 
-        let paint = Paint::default()
-            .set_anti_alias(false)
-            .set_color(Color::from_argb(255, 255, 255, default_background.a()))
-            .set_blend_mode(if self.anchor_info.is_some() {
-                BlendMode::SrcOver
-            } else {
-                BlendMode::Src
-            })
-            .to_owned();
-
-        let save_layer_rec = SaveLayerRec::default().bounds(&pixel_region).paint(&paint);
-        root_canvas.save_layer(&save_layer_rec);
-
-        let mut background_paint = Paint::default();
-        background_paint.set_blend_mode(BlendMode::Src);
-        background_paint.set_alpha(default_background.a());
-        let background_layer_rec = SaveLayerRec::default()
-            .bounds(&pixel_region)
-            .paint(&background_paint);
-
-        root_canvas.save_layer(&background_layer_rec);
-        root_canvas.clear(default_background.with_a(255));
         self.draw_background_surface(root_canvas, pixel_region_box, grid_scale);
-        root_canvas.restore();
         self.draw_foreground_surface(root_canvas, pixel_region_box, grid_scale);
-        root_canvas.restore();
 
         root_canvas.restore();
 
@@ -606,7 +583,7 @@ impl RenderedWindow {
         to_skia_rect(&adjusted_region)
     }
 
-    pub fn prepare_lines(&mut self, grid_renderer: &mut GridRenderer, force: bool) {
+    pub fn prepare_lines(&mut self, grid_renderer: &mut GridRenderer, opacity: f32, force: bool) {
         let scroll_offset_lines = self.scroll_animation.position.floor() as isize;
         let height = self.grid_size.height as isize;
         if height == 0 {
@@ -642,6 +619,7 @@ impl RenderedWindow {
                     grid_position,
                     i32::try_from(*width).unwrap(),
                     style,
+                    opacity,
                 );
                 custom_background |= background_info.custom_color;
                 has_transparency |= background_info.transparent;

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -289,7 +289,6 @@ impl RenderedWindow {
         &mut self,
         root_canvas: &Canvas,
         default_background: Color,
-        opacity: f32,
         grid_scale: GridScale,
     ) -> WindowDrawDetails {
         let pixel_region_box = self.pixel_region(grid_scale);
@@ -304,7 +303,7 @@ impl RenderedWindow {
 
         root_canvas.save();
         root_canvas.clip_rect(pixel_region, None, Some(false));
-        root_canvas.clear(default_background.with_a((255.0 * opacity) as u8));
+        root_canvas.clear(default_background);
 
         self.draw_background_surface(root_canvas, pixel_region_box, grid_scale);
         self.draw_foreground_surface(root_canvas, pixel_region_box, grid_scale);

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -239,6 +239,9 @@ impl WinitWindowWrapper {
                     skia_renderer.window().set_blur(blur && transparent);
                 }
             }
+            WindowSettingsChanged::Transparency(..) => {
+                self.renderer.prepare_lines(true);
+            }
             #[cfg(target_os = "windows")]
             WindowSettingsChanged::TitleBackgroundColor(color) => {
                 self.handle_title_background_color(&color);


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* Alternative implementation of https://github.com/neovide/neovide/pull/2883
* The `neovide_transparency` option now works for floating windows again, this was regressed in Neovide 0.13.2
* Simplified the transparency rendering so the transparency info is completely stored in the lines and the background clear. So there's no longer any skia layer based blending.

* Fixes https://github.com/neovide/neovide/issues/2884


NOTE:
This does not respect the documentation https://github.com/neovim/neovim/issues/24472#issuecomment-2563970117
> blend={integer}					[highlight-blend](https://neovim.io/doc/user/syntax.html#highlight-blend) [opacity](https://neovim.io/doc/user/syntax.html#opacity)
	Override the blend level for a highlight group within the popupmenu
	or floating windows. Only takes effect if ['pumblend'](https://neovim.io/doc/user/options.html#'pumblend') or ['winblend'](https://neovim.io/doc/user/options.html#'winblend')
	is set for the menu or window. See the help at the respective option.

Blend is applied also at the toplevel non-floating windows, so you can set parts of the UI transparent, for example by making the lualine transparent but keep the rest. 

It's also applied without the need of setting `winblend` or `pumblend`.

NOTE: you can't set highlight blend for the `Normal` highlight group, due to restriction in the UI protocol. If that was possible, then the `neovide_transparency` setting would no longer be needed, and you would have more control. But there are also some other bugs in the way currently.
See:
* https://github.com/neovim/neovim/discussions/31737
* https://github.com/neovim/neovim/issues/24472

@lucobellic, you probably want to take a look at this

## Did this PR introduce a breaking change? 
- No
