### PR TITLE
fix: add `text_background_opacity` in the opaque validation

### DIFF
--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -257,9 +257,8 @@ impl MacosWindowFeature {
         }
     }
 
-    fn update_ns_background(&self, transparency: f32, show_border: bool) {
+    fn update_ns_background(&self, opaque: bool, show_border: bool) {
         unsafe {
-            let opaque = transparency >= 1.0;
             // Setting the background color to `NSColor::windowBackgroundColor()`
             // makes the background opaque and draws a grey border around the window
             let ns_background = match opaque && show_border {
@@ -280,13 +279,15 @@ impl MacosWindowFeature {
             background_color,
             show_border,
             transparency,
+            normal_opacity,
             ..
         } = SETTINGS.get::<WindowSettings>();
+        let opaque = transparency.min(normal_opacity) >= 1.0;
         match background_color.parse::<Color>() {
             Ok(color) => {
                 self.update_ns_background_legacy(color, show_border, ignore_deprecation_warning)
             }
-            _ => self.update_ns_background(transparency, show_border),
+            _ => self.update_ns_background(opaque, show_border),
         }
     }
 


### PR DESCRIPTION
During our changes to [fix](https://github.com/neovide/neovide/pull/2780) the opacity we also re-introduced a bug showing the [shadow](https://github.com/neovide/neovide/pull/2272) artifacts we already had in the past.

AT this moment we should update it adding the new `text_background_opacity` in the validation.