### PR TITLE
Use composition information from Neovim

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -210,6 +210,9 @@ pub enum RedrawEvent {
         #[allow(unused)]
         focusable: bool,
         z_index: u64,
+        comp_index: Option<u64>,
+        screen_row: Option<u64>,
+        screen_col: Option<u64>,
     },
     #[allow(unused)]
     WindowExternalPosition {
@@ -227,6 +230,8 @@ pub enum RedrawEvent {
         scrolled: bool,
         #[allow(unused)]
         separator_character: String,
+        z_index: Option<u64>,
+        comp_index: Option<u64>,
     },
     WindowViewport {
         grid: u64,
@@ -678,8 +683,10 @@ fn parse_window_anchor(value: Value) -> Result<WindowAnchor> {
 }
 
 fn parse_win_float_pos(win_float_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let [grid, _window, anchor, anchor_grid, anchor_row, anchor_column, focusable, z_index] =
-        extract_values(win_float_pos_arguments)?;
+    let (
+        [grid, _window, anchor, anchor_grid, anchor_row, anchor_column, focusable, z_index],
+        [comp_index, screen_row, screen_col],
+    ) = extract_values_with_optional(win_float_pos_arguments)?;
 
     Ok(RedrawEvent::WindowFloatPosition {
         grid: parse_u64(grid)?,
@@ -689,6 +696,9 @@ fn parse_win_float_pos(win_float_pos_arguments: Vec<Value>) -> Result<RedrawEven
         anchor_column: parse_f64(anchor_column)?,
         focusable: parse_bool(focusable)?,
         z_index: parse_u64(z_index)?,
+        comp_index: comp_index.map(parse_u64).transpose()?,
+        screen_row: screen_row.map(parse_u64).transpose()?,
+        screen_col: screen_col.map(parse_u64).transpose()?,
     })
 }
 
@@ -717,13 +727,16 @@ fn parse_win_close(win_close_arguments: Vec<Value>) -> Result<RedrawEvent> {
 }
 
 fn parse_msg_set_pos(msg_set_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let [grid, row, scrolled, separator_character] = extract_values(msg_set_pos_arguments)?;
+    let ([grid, row, scrolled, separator_character], [z_index, comp_index]) =
+        extract_values_with_optional(msg_set_pos_arguments)?;
 
     Ok(RedrawEvent::MessageSetPosition {
         grid: parse_u64(grid)?,
         row: parse_u64(row)?,
         scrolled: parse_bool(scrolled)?,
         separator_character: parse_string(separator_character)?,
+        z_index: z_index.map(parse_u64).transpose()?,
+        comp_index: comp_index.map(parse_u64).transpose()?,
     })
 }
 

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -119,6 +119,7 @@ pub enum WindowAnchor {
     NorthEast,
     SouthWest,
     SouthEast,
+    Absolute,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -289,6 +289,7 @@ impl Editor {
                 anchor_column: anchor_left,
                 anchor_row: anchor_top,
                 z_index,
+                comp_index,
                 ..
             } => {
                 tracy_zone!("EditorWindowFloatPosition");
@@ -301,7 +302,7 @@ impl Editor {
                     anchor_top,
                     SortOrder {
                         z_index,
-                        composition_order: self.composition_order,
+                        composition_order: comp_index.unwrap_or(self.composition_order),
                     },
                 )
             }
@@ -321,10 +322,12 @@ impl Editor {
                 grid,
                 row,
                 scrolled,
+                z_index,
+                comp_index,
                 ..
             } => {
                 tracy_zone!("EditorMessageSetPosition");
-                self.set_message_position(grid, row, scrolled)
+                self.set_message_position(grid, row, scrolled, z_index, comp_index)
             }
             RedrawEvent::WindowViewport {
                 grid,
@@ -494,8 +497,15 @@ impl Editor {
         }
     }
 
-    fn set_message_position(&mut self, grid: u64, grid_top: u64, scrolled: bool) {
-        let z_index = MSG_ZINDEX;
+    fn set_message_position(
+        &mut self,
+        grid: u64,
+        grid_top: u64,
+        scrolled: bool,
+        z_index: Option<u64>,
+        comp_index: Option<u64>,
+    ) {
+        let z_index = z_index.unwrap_or(MSG_ZINDEX); // From the Neovim source code
         let parent_width = self
             .windows
             .get(&1)
@@ -509,7 +519,7 @@ impl Editor {
             anchor_top: grid_top as f64,
             sort_order: SortOrder {
                 z_index,
-                composition_order: self.composition_order,
+                composition_order: comp_index.unwrap_or(self.composition_order),
             },
         };
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This requires this corresponding PR to Neovim https://github.com/neovim/neovim/pull/31837 to enable the support, but works without.

This fixes a lot of multigrid issues like:
* Windows positioned slightly wrong
* Windows rendered in the wrong z-order
* We don't seem to have any issues open for this, but this also fixes most of the issues re-connecting to a remote nvim instance,
  *  https://github.com/neovim/neovim/issues/30581
  * ~https://github.com/neovim/neovim/issues/30582~ (not fixed)
  * ~https://github.com/neovim/neovim/issues/30583~ (not fixed)

NOTE: Part of this PR was split out into 
* https://github.com/neovide/neovide/pull/3111

## Did this PR introduce a breaking change? 
- No
