### PR TITLE
feat: add metadata for `binstall` package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,16 @@ exclude = [
     "stylua.toml",
 ]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/Neovide-{ target }.{ archive-format }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/{ version }/neovide.exe.{ archive-format }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "zip"
+
 [workspace]
 members = ["neovide-derive"]
 


### PR DESCRIPTION
This actual changes must also be done on our pipeline packages to fill all requirements.

The final end pkg-fmt for each platform must be discussed still.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
