### PR TITLE
fix: --wsl error if using non-POSIX shell as login shell

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -180,14 +180,14 @@ fn neovim_ok(bin: &str, args: &[String]) -> Result<bool> {
 
     let unexpected_output = !output.status.success()
         || !stdout.starts_with("NVIM v")
-        || non_matching_stderr_lines.len() != stderr.lines().count();
+        || !non_matching_stderr_lines.is_empty();
 
     if unexpected_output {
         let error_message = create_error_message(bin, &stdout, non_matching_stderr_lines, is_wsl);
         let command = if is_wsl {
-            "wsl --shell-type login -- {bin} -v"
+            format!("wsl --shell-type login -- {bin} -v")
         } else {
-            "$SHELL -lc '{bin} -v'"
+            format!("$SHELL -lc '{bin} -v'")
         };
 
         bail!("{error_message}{command}")


### PR DESCRIPTION
Reopening #2949 , realized you need to specify `--shell-type login` to wsl.exe to not be a breaking change and accidentally closed the previous PR.

## What kind of change does this PR introduce?
- Fixes #2941 

## Did this PR introduce a breaking change? 
- No
- `nvim_cmd_impl` changed to use the syntax `wsl --shell-type login -- <bin> <args>` rather than `wsl $SHELL -lc <bin> <args>` which will still spawn the default shell.  The previous implementation actually spawns two shells.
- `create_platform_shell_command` changed to use `/bin/sh`, since non-POSIX shells might not have the `which` command

@fredizzimo 

> Thanks, but we can't change the shell to `sh`, becuase the user might have only configured their default shell and not `sh`. So, custom paths for example won't be set, which means that things like LSP won't work.
> 
> So, we need to find another way to do this, maybe bootstrap through another shell, like was done on macOS #2928.

It is only using `/bin/sh` for doing `which nvim` and `nvim -v`, the `wsl -- <bin>` syntax does spawn the user's default shell, for example, if I run `wsl -- sudo ps -ef` I can see:

```
236     233  0 00:08 pts/0    00:00:00 /usr/local/bin/elvish -c sudo ps -ef
```

When my default shell is `elvish`