### PR TITLE
fix: separate text underline from baseline by at least 1 pixel

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -212,7 +212,8 @@ impl CachingShaper {
 
     pub fn underline_position(&mut self) -> f32 {
         let metrics = self.metrics();
-        self.baseline_offset() - metrics.underline_offset
+        // At least 1 pixel between baseline and underline
+        self.baseline_offset() - metrics.underline_offset.min(-1.)
     }
 
     pub fn stroke_size(&mut self) -> f32 {

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -271,9 +271,12 @@ impl GridRenderer {
         let stroke_width = (stroke_size * underline_stroke_scale).max(1.).round();
 
         // offset y by width / 2 to align the *top* of the underline with p1 and p2
-        // also round to avoid aliasing issues
-        let p1 = (p1.x.round(), (p1.y + stroke_width / 2.).round());
-        let p2 = (p2.x.round(), (p2.y + stroke_width / 2.).round());
+        // offset is rounded up because the stroke asymmetry for odd values of stroke_width ends up
+        // on top
+        // round p1 and p2 to avoid aliasing issues
+        let offset = (stroke_width / 2.).ceil();
+        let p1 = (p1.x.round(), p1.y.round() + offset);
+        let p2 = (p2.x.round(), p2.y.round() + offset);
 
         underline_paint
             .set_color(style.special(&self.default_style.colors).to_color())


### PR DESCRIPTION
In my experience, it's common for text underline to be separated from the baseline by a minimum of 1 pixel. I'd like to see the same behavior in neovide.

Problem:
- The underline_offset metric might be less than 1 pixel below the baseline (> -1)
- draw_underline rounds after adding stroke_width / 2 to the top position, which can lead to a position that is 1 pixel higher than intended

Solution:
- underline_offset.min(-1.)
- the top position and stroke_width / 2 should be rounded separately before being added together

Here's a comparison of underlined text in neovide before and after this change. The font is Iosevka.
![underline-touching-baseline](https://github.com/user-attachments/assets/ce11534f-38d3-403d-a0cd-f5356dce760d)

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No