### PR TITLE
fix: build failure on case sensitive file system

### DIFF
--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -29,7 +29,7 @@ use crate::{cmd_line::CmdLineSettings, error_msg, frame::Frame};
 use super::{WindowSettings, WindowSettingsChanged};
 
 static NEOVIDE_ICON_PATH: &[u8] =
-    include_bytes!("../../extra/osx/Neovide.app/Contents/resources/Neovide.icns");
+    include_bytes!("../../extra/osx/Neovide.app/Contents/Resources/Neovide.icns");
 
 #[derive(Clone)]
 struct TitlebarClickHandlerIvars {}


### PR DESCRIPTION
Normally on macOS the case here wouldn't matter, but if you happen to be running a case sensitive file system (as I am) then the build fails because it can't find the icon file.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
