### PR TITLE
fix: Ensure that the target directory exists before writing backtrace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ extern crate derive_new;
 
 use std::{
     env::{self, args},
-    fs::{File, OpenOptions},
+    fs::{create_dir_all, File, OpenOptions},
     io::Write,
     panic::set_hook,
     process::ExitCode,
@@ -342,6 +342,10 @@ fn log_panic_to_file(panic_info: &PanicHookInfo, backtrace: &Backtrace, path: &O
             Err(_) => settings::neovide_std_datapath().join(DEFAULT_BACKTRACES_FILE),
         },
     };
+
+    if let Some(parent) = file_path.parent() {
+        create_dir_all(parent).ok();
+    }
 
     let mut file = match OpenOptions::new()
         .append(true)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The backtrace file was not written if the target directory doesn't exist, so create it first.

* Fixes https://github.com/neovide/neovide/issues/2976

## Did this PR introduce a breaking change? 
- No
