### PR TITLE
fix: Glyph offsets within a single cluster

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -405,7 +405,7 @@ impl CachingShaper {
                 let mut x_offset = glyph_width * glyph_cluster.data as f32;
 
                 for glyph in glyph_cluster.glyphs {
-                    let position = (x_offset + glyph.x, glyph.y);
+                    let position = (x_offset + glyph.x, -glyph.y);
                     glyph_data.push((glyph.id, position));
                     x_offset += glyph.advance;
                 }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -401,9 +401,13 @@ impl CachingShaper {
             let mut glyph_data = Vec::new();
 
             shaper.shape_with(|glyph_cluster| {
+                //Align to the grid at the start of each cluster
+                let mut x_offset = glyph_width * glyph_cluster.data as f32;
+
                 for glyph in glyph_cluster.glyphs {
-                    let position = (glyph.data as f32 * glyph_width, glyph.y);
+                    let position = (x_offset + glyph.x, glyph.y);
                     glyph_data.push((glyph.id, position));
+                    x_offset += glyph.advance;
                 }
             });
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Use the shape information from Swash for positioning the individual glyphs of a cluster, so that characters consisting of multiple glyphs are rendered correctly. Note that each cluster is still aligned to the grid.

The y-offset was also reversed and is now fixed. This could be seen as accents being too low, especially on capital letters. I haven't seen a bug report for it though.

* Fixes https://github.com/neovide/neovide/issues/2969
* Fixes https://github.com/neovide/neovide/issues/2539

## Did this PR introduce a breaking change? 
- No
