### PR TITLE
fix: Remove duplicate nvim bin argument for WSL

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -260,9 +260,8 @@ fn nvim_cmd_impl(bin: String, args: Vec<String>, _settings: &Settings) -> TokioC
 }
 
 #[cfg(not(target_os = "macos"))]
-fn nvim_cmd_impl(bin: String, mut args: Vec<String>, settings: &Settings) -> TokioCommand {
+fn nvim_cmd_impl(bin: String, args: Vec<String>, settings: &Settings) -> TokioCommand {
     if cfg!(target_os = "windows") && settings.get::<CmdLineSettings>().wsl {
-        args.insert(0, bin.clone());
         let mut cmd = TokioCommand::new("wsl");
         cmd.args(["--shell-type", "login"]);
         cmd.arg("--");


### PR DESCRIPTION
This causes the executable itself to be opened as a buffer...

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The nvim binary was passed twice on the command line, which caused it to be opened as a buffer on WSL. The extra argument is now removed.

* Fixes https://github.com/neovide/neovide/issues/2609

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
