### PR TITLE
fix: Use drop for filedrop

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -10,6 +10,9 @@
 ---@type Args
 local args = ...
 
+local M = {}
+M.private = {}
+
 vim.g.neovide_channel_id = args.neovide_channel_id
 vim.g.neovide_version = args.neovide_version
 
@@ -117,3 +120,13 @@ vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
         rpcrequest("neovide.quit", vim.v.exiting)
     end,
 })
+
+M.private.dropfile = function(filename, tabs)
+    vim.api.nvim_cmd({
+        cmd = "drop",
+        args = { vim.fn.fnameescape(filename) },
+        mods = { tab = tabs and 1 or 0 },
+    }, {})
+end
+
+_G["neovide"] = M

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -12,6 +12,7 @@ use crate::{
     bridge::NeovimWriter,
     cmd_line::CmdLineSettings,
     profiling::{tracy_dynamic_zone, tracy_fiber_enter, tracy_fiber_leave},
+    utils::handle_wslpaths,
     LoggingSender,
 };
 
@@ -206,7 +207,9 @@ impl ParallelCommand {
                 .exec_lua(
                     &format!(
                         "neovide.private.dropfile([[{}]], {})",
-                        path,
+                        handle_wslpaths(vec![path], settings.get::<CmdLineSettings>().wsl, false)
+                            .first()
+                            .unwrap(),
                         settings.get::<CmdLineSettings>().tabs
                     ),
                     Vec::new(),

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -203,19 +203,13 @@ impl ParallelCommand {
                 nvim.ui_set_focus(true).await.context("FocusGained failed")
             }
             ParallelCommand::FileDrop(path) => nvim
-                .cmd(
-                    vec![
-                        (
-                            "cmd".into(),
-                            (settings.get::<CmdLineSettings>().tabs)
-                                .then(|| "tabnew".to_string())
-                                .unwrap_or("edit".into())
-                                .into(),
-                        ),
-                        ("magic".into(), vec![("file".into(), false.into())].into()),
-                        ("args".into(), vec![Value::from(path)].into()),
-                    ],
-                    vec![],
+                .exec_lua(
+                    &format!(
+                        "neovide.private.dropfile([[{}]], {})",
+                        path,
+                        settings.get::<CmdLineSettings>().tabs
+                    ),
+                    Vec::new(),
                 )
                 .await
                 .map(|_| ()) // We don't care about the result

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,10 +2,44 @@ mod ring_buffer;
 #[cfg(test)]
 mod test;
 
+#[cfg(target_os = "windows")]
+use wslpath_rs::windows_to_wsl;
+
 pub use ring_buffer::*;
 
 #[cfg(not(target_os = "windows"))]
 pub fn is_tty() -> bool {
     use std::io::IsTerminal;
     std::io::stdout().is_terminal()
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn handle_wslpaths(paths: Vec<String>, _wsl: bool, quote: bool) -> Vec<String> {
+    paths
+        .into_iter()
+        .map(|path| if quote { format!("'{}'", path) } else { path })
+        .collect()
+}
+
+/// Convert a Vector of Windows path strings to a Vector of WSL paths if `wsl` is true.
+///
+/// If conversion of a path fails, the path is passed to neovim unchanged.
+#[cfg(target_os = "windows")]
+pub fn handle_wslpaths(paths: Vec<String>, wsl: bool, quote: bool) -> Vec<String> {
+    if !wsl {
+        return paths;
+    }
+
+    paths
+        .into_iter()
+        .map(|path| {
+            let path = std::fs::canonicalize(&path).map_or(path, |p| p.to_string_lossy().into());
+            let wslpath = windows_to_wsl(&path).unwrap_or(path);
+            if quote {
+                format!("'{}'", wslpath)
+            } else {
+                wslpath
+            }
+        })
+        .collect()
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,11 +14,8 @@ pub fn is_tty() -> bool {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn handle_wslpaths(paths: Vec<String>, _wsl: bool, quote: bool) -> Vec<String> {
+pub fn handle_wslpaths(paths: Vec<String>, _wsl: bool, _quote: bool) -> Vec<String> {
     paths
-        .into_iter()
-        .map(|path| if quote { format!("'{}'", path) } else { path })
-        .collect()
 }
 
 /// Convert a Vector of Windows path strings to a Vector of WSL paths if `wsl` is true.


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Use `drop` for file drop instead of `edit`. The actual handling is also moved to lua, and the path escaped with `fnameescape`, due to drop not supporting `magic file=false`, https://github.com/neovim/neovim/issues/32351

This sets the arglist
* fixes https://github.com/neovide/neovide/issues/2629

It also fixes file drops when using WSL, the path is now properly converted.

It indirectly fixes customizing the drop behaviour, it's not documented, and a hack, but should do until we have a proper solution. The user can override `neovide.private.dropfile`
* https://github.com/neovide/neovide/issues/2991

@falcucci, can you test this on macOS that file drag still works, and that the arglist is now set and fixes #2629 

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
