### PR TITLE
fix: Statically link the msvc runtime when deploying

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,10 @@ jobs:
         run: |
           if ! which cargo-wix; then cargo binstall -y cargo-wix; fi
 
+      - name: Setup Ninja
+        if: matrix.os == 'windows-latest'
+        uses: seanmiddleditch/gha-setup-ninja@v6
+
       - name: Install dependencies (macOS)
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         env:
           RUSTFLAGS: "-Ctarget-feature=+crt-static" 
-        run: cargo wix --output target/release/neovide.msi --package neovide
+        run: cargo wix --nocapture --output target/release/neovide.msi --package neovide
 
       - name: Build (macOS)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,11 @@ jobs:
         if: matrix.os == 'windows-latest'
         env:
           RUSTFLAGS: "-Ctarget-feature=+crt-static" 
-        run: cargo wix --nocapture --output target/release/neovide.msi --package neovide
+        # The file paths are to long, so we need to vendor the dependencies
+        run: |
+          mkdir .cargo
+          cargo vendor ../c > .cargo/config.toml
+          cargo wix --nocapture --output target/release/neovide.msi --package neovide
 
       - name: Build (macOS)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,8 @@ jobs:
 
       - name: Build (Windows)
         if: matrix.os == 'windows-latest'
+        env:
+          RUSTFLAGS: "-Ctarget-feature=+crt-static" 
         run: cargo wix --output target/release/neovide.msi --package neovide
 
       - name: Build (macOS)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Statically link the MSVC runtime when deploying. This is only done for the deploy step in the CI, since statically linking is not necessary when building manually. And Skia does not provide a statically linked library, so the build times are much longer.

* Fixes https://github.com/neovide/neovide/issues/2948

**NOTE:** This is quite slow to run in the CI. It could maybe be changed to run only on main in the future. Or maybe we could build our own Skia binaries?

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
