### PR TITLE
fix: Call format_key_text when delivering IME input

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -59,7 +59,7 @@ impl KeyboardManager {
             }
             WindowEvent::Ime(Ime::Commit(text)) => {
                 log::trace!("Ime commit {text}");
-                send_ui(SerialCommand::Keyboard(text.to_string()));
+                send_ui(SerialCommand::Keyboard(self.format_key_text(text, false)));
             }
             WindowEvent::Ime(Ime::Preedit(text, cursor_offset)) => {
                 self.ime_preedit = (text.to_string(), *cursor_offset)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The IME input was sent unescaped, so special characters like `<` did not work. Modifiers were also not sent when using IME. This has been fixed by calling `format_key_text`

* Fixes https://github.com/neovide/neovide/issues/2975
* Most likely fixes https://github.com/neovide/neovide/issues/1866

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
