### PR TITLE
fix: Fix mouse manager rounding

### DIFF
--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -92,6 +92,7 @@ impl FloatingLayer<'_> {
             ret.push(WindowDrawDetails {
                 id: window.id,
                 region: regions[i],
+                grid_size: window.grid_size,
             });
         });
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -97,6 +97,7 @@ pub struct RenderedWindow {
 pub struct WindowDrawDetails {
     pub id: u64,
     pub region: PixelRect<f32>,
+    pub grid_size: GridSize<u32>,
 }
 
 impl WindowDrawDetails {
@@ -298,6 +299,7 @@ impl RenderedWindow {
             return WindowDrawDetails {
                 id: self.id,
                 region: pixel_region_box,
+                grid_size: self.grid_size,
             };
         }
 
@@ -313,6 +315,7 @@ impl RenderedWindow {
         WindowDrawDetails {
             id: self.id,
             region: pixel_region_box,
+            grid_size: self.grid_size,
         }
     }
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The rounding done by the mouse manager was a bit inaccurate, which for example made it impossible to click the last column with some window sizes. This is now fixed

## Did this PR introduce a breaking change? 
- No
