### PR TITLE
fix: mousemanager regression

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -109,15 +109,13 @@ impl MouseManager {
         let relative_position = (self.window_position - window_details.region.min).to_point();
         (relative_position / *editor_state.grid_scale)
             .floor()
+            .max((0.0, 0.0).into())
             .try_cast()
             .unwrap()
-            .clamp(
-                (0, 0).into(),
-                Point2::new(
-                    window_details.grid_size.width.max(1) - 1,
-                    window_details.grid_size.height.max(1) - 1,
-                ),
-            )
+            .min(Point2::new(
+                window_details.grid_size.width.max(1) - 1,
+                window_details.grid_size.height.max(1) - 1,
+            ))
     }
 
     fn handle_pointer_motion(&mut self, position: PixelPos<f32>, editor_state: &EditorState) {


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This fixes a regression in https://github.com/neovide/neovide/pull/3015. It crashes when dragging to the left or top outside of a split window.

* fixes https://github.com/neovide/neovide/issues/3017

## Did this PR introduce a breaking change? 
- No
