### PR TITLE
feat: background blur for Windows

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -578,7 +578,7 @@ impl WinitWindowWrapper {
         window.set_blur(window_blurred && transparency < 1.0);
 
         #[cfg(target_os = "windows")]
-        if window_blurred && transparency < 1.0 {
+        if window_blurred {
             window.set_system_backdrop(BackdropType::TransientWindow); // Acrylic blur
         }
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -36,7 +36,7 @@ use crate::{
 #[cfg(windows)]
 use {
     crate::windows_utils::{register_right_click, unregister_right_click},
-    winit::platform::windows::{Color, WindowExtWindows, BackdropType},
+    winit::platform::windows::{BackdropType, Color, WindowExtWindows},
 };
 
 #[cfg(target_os = "macos")]

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -54,6 +54,7 @@ fn round_or_op<Op: FnOnce(f32) -> f32>(v: f32, op: Op) -> f32 {
 }
 
 use approx::AbsDiffEq;
+use winit::platform::windows::BackdropType;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct WindowPadding {
@@ -575,6 +576,12 @@ impl WinitWindowWrapper {
         );
 
         window.set_blur(window_blurred && transparency < 1.0);
+
+        #[cfg(target_os = "windows")]
+        if window_blurred && transparency < 1.0 {
+            window.set_system_backdrop(BackdropType::TransientWindow); // Acrylic blur
+        }
+
         if fullscreen {
             let handle = window.current_monitor();
             window.set_fullscreen(Some(Fullscreen::Borderless(handle)));

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -36,7 +36,7 @@ use crate::{
 #[cfg(windows)]
 use {
     crate::windows_utils::{register_right_click, unregister_right_click},
-    winit::platform::windows::{Color, WindowExtWindows},
+    winit::platform::windows::{Color, WindowExtWindows, BackdropType},
 };
 
 #[cfg(target_os = "macos")]
@@ -54,7 +54,6 @@ fn round_or_op<Op: FnOnce(f32) -> f32>(v: f32, op: Op) -> f32 {
 }
 
 use approx::AbsDiffEq;
-use winit::platform::windows::BackdropType;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct WindowPadding {


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

Added acrylic blur for the background for Windows.
The implementation was made in winit library, just added the function call.
![image](https://github.com/user-attachments/assets/df4e5cec-e34b-4fe0-a7ed-0481ff59fb1c)
