### PR TITLE
Release 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "neovide"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "neovide-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "convert_case",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neovide"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 build = "build.rs"
 resolver = "2"
@@ -65,7 +65,7 @@ indoc = "2.0.5"
 itertools = "0.14.0"
 log = "0.4.22"
 lru = "0.13.0"
-neovide-derive = { path = "neovide-derive", version = "0.1.1" }
+neovide-derive = { path = "neovide-derive", version = "0.1.2" }
 num = "0.4.3"
 nvim-rs = { version = "0.7.0", features = ["use_tokio"] }
 parking_lot = "0.12.3"
@@ -163,7 +163,7 @@ debug = true
 name = "Neovide"
 identifier = "com.neovide.neovide"
 icon = ["assets/neovide.ico"]
-version = "0.14.0"
+version = "0.14.1"
 resources = []
 copyright = "Copyright (c) Neovide Contributors 2024. All rights reserved."
 category = "Productivity"

--- a/extra/osx/Neovide.app/Contents/Info.plist
+++ b/extra/osx/Neovide.app/Contents/Info.plist
@@ -19,7 +19,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.14.0</string>
+  <string>0.14.1</string>
   <key>CFBundleVersion</key>
   <string>20230908.235224</string>
   <key>LSMinimumSystemVersion</key>

--- a/neovide-derive/Cargo.toml
+++ b/neovide-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neovide-derive"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "Derive macros for the Neovide gui"


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Bumps the version number to 0.14.1 and Neovide-derive to 0.1.2, since one of the dependencies has been updated since the last release.

## Did this PR introduce a breaking change? 
- No
