### PR TITLE
feat: make it possible to disable the cursor hack

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     renderer::{DrawCommand, WindowDrawCommand},
     running_tracker::RunningTracker,
     settings::Settings,
-    window::{UserEvent, WindowCommand},
+    window::{UserEvent, WindowCommand, WindowSettings},
 };
 
 #[cfg(target_os = "macos")]
@@ -553,32 +553,34 @@ impl Editor {
             }
         }
 
-        if let Some(Window {
-            window_type: WindowType::Message { .. },
-            ..
-        }) = window
-        {
-            // When the user presses ":" to type a command, the cursor is sent to the gutter
-            // in position 1 (right after the ":"). In all other cases, we want to skip
-            // positioning to avoid confusing movements.
-            let intentional = grid_left == 1;
-            // If the cursor was already in this message, we can still move within it.
-            let already_there = self.cursor.parent_window_id == grid;
-            // This ^ check alone is a bit buggy though, since it fails when the cursor is
-            // technically still in the edit window but "temporarily" at the cmdline. (#1207)
-            let using_cmdline = self
-                .current_mode_index
-                .map(|current| current == MODE_CMDLINE)
-                .unwrap_or(false);
+        if self.settings.get::<WindowSettings>().cursor_hack {
+            if let Some(Window {
+                window_type: WindowType::Message { .. },
+                ..
+            }) = window
+            {
+                // When the user presses ":" to type a command, the cursor is sent to the gutter
+                // in position 1 (right after the ":"). In all other cases, we want to skip
+                // positioning to avoid confusing movements.
+                let intentional = grid_left == 1;
+                // If the cursor was already in this message, we can still move within it.
+                let already_there = self.cursor.parent_window_id == grid;
+                // This ^ check alone is a bit buggy though, since it fails when the cursor is
+                // technically still in the edit window but "temporarily" at the cmdline. (#1207)
+                let using_cmdline = self
+                    .current_mode_index
+                    .map(|current| current == MODE_CMDLINE)
+                    .unwrap_or(false);
 
-            if !intentional && !already_there && !using_cmdline {
-                trace!(
-                    "Cursor unexpectedly sent to message buffer {} ({}, {})",
-                    grid,
-                    grid_left,
-                    grid_top
-                );
-                return;
+                if !intentional && !already_there && !using_cmdline {
+                    trace!(
+                        "Cursor unexpectedly sent to message buffer {} ({}, {})",
+                        grid,
+                        grid_left,
+                        grid_top
+                    );
+                    return;
+                }
             }
         }
 

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -345,6 +345,9 @@ impl CursorRenderer {
         dt: f32,
     ) -> bool {
         tracy_zone!("cursor_animate");
+        if !self.cursor.enabled {
+            return false;
+        }
         let settings = self.settings.get::<CursorSettings>();
 
         if settings.vfx_mode != self.previous_vfx_mode {

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -33,6 +33,7 @@ pub struct WindowSettings {
     pub input_macos_option_key_is_meta: OptionAsMeta,
     pub input_ime: bool,
     pub show_border: bool,
+    pub cursor_hack: bool,
 
     #[cfg(target_os = "windows")]
     pub title_background_color: String,
@@ -79,6 +80,7 @@ impl Default for WindowSettings {
             observed_lines: None,
             observed_columns: None,
             show_border: false,
+            cursor_hack: true,
 
             #[cfg(target_os = "windows")]
             title_background_color: "".to_string(),

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -676,6 +676,28 @@ vim.g.neovide_profiler = false
 Setting this to `v:true` enables the profiler, which shows a frametime graph in the upper left
 corner.
 
+#### Cursor hack
+
+VimScript:
+
+```vim
+let g:neovide_cursor_hack = v:true
+```
+
+Lua:
+
+```lua
+vim.g.neovide_cursor_hack = true
+```
+
+**Unreleased yet.**
+
+Prevents the cursor from flickering to the command line when it shouldn't. This will be disabled by
+default when Neovim properly sends the UI busy events and the hack is no longer needed. NOTE: In
+some cases the hack itself is buggy and prevents the cursor from moving to the command line when it
+should. In that case you can try to disable it, especially if you are not using cursor animations
+and the flickering does not bother as much.
+
 ### Input Settings
 
 #### macOS Option Key is Meta


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This makes it possible to disable the cursor hack from https://github.com/neovide/neovide/pull/753. 

The option is still enabled by default, but will be changed once Neovim deals with the busy state correctly. See
* https://github.com/neovim/neovim/issues/25980
* https://github.com/neovim/neovim/pull/29446
* https://github.com/neovim/neovim/pull/29447

However, if the flickering does not bother, especially if not using cursor animations, it can be disabled befor that.

These issues are fixed when the hack is disabled:
* https://github.com/neovide/neovide/issues/3000
* https://github.com/neovide/neovide/issues/2376
* https://github.com/neovide/neovide/issues/2516
* https://github.com/neovide/neovide/issues/2206
* https://github.com/neovide/neovide/issues/1665

## Did this PR introduce a breaking change? 
- No
