### PR TITLE
chore!: upgrade the Ubuntu runners to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         # NOTE: Should use the oldest available Ubuntu release, for maximum compatibility
-        os: [windows-latest, macos-latest, ubuntu-20.04]
+        os: [windows-latest, macos-latest, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -170,7 +170,7 @@ jobs:
           rustup target add aarch64-apple-darwin
 
       - name: Install dependencies (Linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get -qq install -y \
@@ -205,7 +205,7 @@ jobs:
           cargo build --locked --release --target=aarch64-apple-darwin
 
       - name: Build (Linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: cargo build --locked --release
 
       - name: create Neovide.app (macOS only)
@@ -307,7 +307,7 @@ jobs:
           echo "ARTIFACT5=Neovide-aarch64-apple-darwin.dmg" >> $GITHUB_ENV
 
       - name: Prepare Artifacts (Linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           cd target/release
           # archive artifact


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The Ubuntu 20.04 Github runners are deprecated and will soon stop working. Currently they might randomly fail. So, this upgrades them to 22.04

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, the Linux AppImage and binaries will stop working on some older Linux installations
