### PR TITLE
refactor: remove pointless nvim_cmd_impl

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -40,11 +40,11 @@ pub struct NeovimRuntime {
     pub runtime: Runtime,
 }
 
-fn neovim_instance(settings: &Settings) -> Result<NeovimInstance> {
+async fn neovim_instance(settings: &Settings) -> Result<NeovimInstance> {
     if let Some(address) = settings.get::<CmdLineSettings>().server {
         Ok(NeovimInstance::Server { address })
     } else {
-        let cmd = create_nvim_command(settings)?;
+        let cmd = create_nvim_command(settings).await?;
         Ok(NeovimInstance::Embedded(cmd))
     }
 }
@@ -78,7 +78,7 @@ async fn launch(
     grid_size: Option<GridSize<u32>>,
     settings: Arc<Settings>,
 ) -> Result<NeovimSession> {
-    let neovim_instance = neovim_instance(settings.as_ref())?;
+    let neovim_instance = neovim_instance(settings.as_ref()).await?;
 
     let session = NeovimSession::new(neovim_instance, handler)
         .await

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -328,6 +328,7 @@ mod tests {
         settings.set::<CmdLineSettings>(&CmdLineSettings::default());
 
         let command = create_nvim_command(&settings)
+            .await
             .unwrap_or_explained_panic("Could not create nvim command");
         let instance = NeovimInstance::Embedded(command);
         let NeovimSession { neovim: nvim, .. } = NeovimSession::new(instance, NeovimHandler())


### PR DESCRIPTION

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Refactor to remove duplicate code


The code was almost duplicate of `create_platform_shell_command`, but used `std::process::Command` instead of `tokio::process::Command`

Some code had to be converted to async due to this.

## Did this PR introduce a breaking change? 
- No
