### PR TITLE
fix!: simplify and fix the launching of neovim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,17 +905,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
@@ -1638,19 +1627,16 @@ dependencies = [
 
 [[package]]
 name = "nvim-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fcd98ddbb0c866684dacec0d99a7c623c1784b0facfd44cfee17cc79aa81b2"
+version = "0.9.0"
+source = "git+https://github.com/fredizzimo/nvim-rs?branch=handshake#030722ee22387e9a7e7f61d273f59e08341bc377"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
  "log",
- "parity-tokio-ipc",
  "rmp",
  "rmpv",
  "tokio",
  "tokio-util",
- "winapi",
 ]
 
 [[package]]
@@ -1925,20 +1911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-tokio-ipc"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
-dependencies = [
- "futures 0.3.31",
- "libc",
- "log",
- "rand 0.7.3",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,19 +2116,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -2170,19 +2129,9 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
  "zerocopy 0.8.23",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2193,15 +2142,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2217,15 +2157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2970,12 +2901,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "toml 0.8.20",
  "tracy-client-sys",
  "unicode-segmentation",
+ "uzers",
  "which",
  "windows",
  "windows-registry",
@@ -2885,6 +2886,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uzers"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,9 @@ objc2-metal = { version = "0.2.2", default-features = false, features = [
     "MTLCommandBuffer",
 ] }
 skia-safe = { version = "0.81.0", features = ["metal", "gl", "textlayout"] }
+uzers = "0.12.1"
+
+
 [target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
 skia-safe = { version = "0.81.0", features = ["gl", "textlayout"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ log = "0.4.22"
 lru = "0.13.0"
 neovide-derive = { path = "neovide-derive", version = "0.1.2" }
 num = "0.4.3"
-nvim-rs = { version = "0.7.0", features = ["use_tokio"] }
+nvim-rs = { version = "0.9.0", features = ["use_tokio"], git= "https://github.com/fredizzimo/nvim-rs", branch="handshake" }
 parking_lot = "0.12.3"
 rand = "0.9.0"
 raw-window-handle = "0.6.2"

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -1,12 +1,8 @@
-use std::process::Stdio;
-
-use anyhow::Result;
-use log::debug;
 use tokio::process::Command as TokioCommand;
 
 use crate::{cmd_line::CmdLineSettings, settings::*};
 
-pub fn create_nvim_command(settings: &Settings) -> Result<TokioCommand> {
+pub fn create_nvim_command(settings: &Settings) -> TokioCommand {
     let bin = settings
         .get::<CmdLineSettings>()
         .neovim_bin
@@ -14,17 +10,7 @@ pub fn create_nvim_command(settings: &Settings) -> Result<TokioCommand> {
     let mut args = Vec::new();
     args.push("--embed".to_string());
     args.extend(settings.get::<CmdLineSettings>().neovim_args);
-    let mut cmd = create_platform_command(&bin, &args, settings);
-
-    debug!("Starting neovim with: {:?}", cmd);
-
-    #[cfg(not(debug_assertions))]
-    cmd.stderr(Stdio::piped());
-
-    #[cfg(debug_assertions)]
-    cmd.stderr(Stdio::inherit());
-
-    Ok(cmd)
+    create_platform_command(&bin, &args, settings)
 }
 
 // Creates a shell command if needed on this platform

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -1,14 +1,20 @@
-use std::{ffi::OsStr, process::Stdio};
+use std::process::Stdio;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use log::debug;
-use regex::Regex;
 use tokio::process::Command as TokioCommand;
 
 use crate::{cmd_line::CmdLineSettings, settings::*};
 
-pub async fn create_nvim_command(settings: &Settings) -> Result<TokioCommand> {
-    let mut cmd = build_nvim_cmd(settings).await?;
+pub fn create_nvim_command(settings: &Settings) -> Result<TokioCommand> {
+    let bin = settings
+        .get::<CmdLineSettings>()
+        .neovim_bin
+        .unwrap_or("nvim".to_owned());
+    let mut args = Vec::new();
+    args.push("--embed".to_string());
+    args.extend(settings.get::<CmdLineSettings>().neovim_args);
+    let mut cmd = create_platform_command(&bin, &args, settings);
 
     debug!("Starting neovim with: {:?}", cmd);
 
@@ -18,252 +24,72 @@ pub async fn create_nvim_command(settings: &Settings) -> Result<TokioCommand> {
     #[cfg(debug_assertions)]
     cmd.stderr(Stdio::inherit());
 
-    #[cfg(windows)]
-    cmd.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
-
     Ok(cmd)
-}
-
-async fn build_nvim_cmd(settings: &Settings) -> Result<TokioCommand> {
-    if let Some(cmdline) = settings.get::<CmdLineSettings>().neovim_bin {
-        if let Some((bin, args)) = lex_nvim_cmdline(&cmdline, settings).await? {
-            return Ok(build_nvim_cmd_with_args(bin, args, settings));
-        }
-
-        bail!("ERROR: NEOVIM_BIN='{}' was not found.", cmdline);
-    } else if let Some(path) = platform_which("nvim", settings).await {
-        if neovim_ok(&path, &[], settings).await? {
-            return Ok(build_nvim_cmd_with_args(path, vec![], settings));
-        }
-    }
-
-    bail!("ERROR: nvim not found!")
-}
-
-#[cfg(target_os = "macos")]
-fn build_login_cmd_args<T: AsRef<OsStr> + AsRef<str> + ToString>(
-    command: &str,
-    args: &[T],
-) -> (String, Vec<String>) {
-    use std::env;
-
-    use crate::error_handling::ResultPanicExplanation;
-
-    // If $TERM is set, we assume user is running from a terminal, and we shouldn't
-    // re-initialize the environment.
-    // See https://github.com/neovide/neovide/issues/2584
-    if env::var_os("TERM").is_some() {
-        return (
-            command.to_string(),
-            args.iter().map(|s| s.to_string()).collect(),
-        );
-    }
-
-    let user = env::var("USER").unwrap_or_explained_panic("USER environment variable not found");
-    let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-    let shell_name = shell.split('/').next_back().unwrap_or("zsh");
-
-    let args = match shlex::try_join(args.iter().map(|s| s.as_ref())) {
-        Ok(args) => args,
-        Err(_) => panic!("Failed to join arguments"),
-    };
-
-    // Executes neovim as a login shell, so it will source the user's startup files.
-    let exec = format!(
-        "exec -a -{} {} -c '{} {}'",
-        shell_name, shell, command, args
-    );
-
-    // See "man login". It sets up some important env vars like $PATH and $HOME.
-    // On macOS, use the `login` command so it will appear as a tty session.
-    let cmd_path = "/usr/bin/login";
-
-    // We use a special flag to tell login not to prompt us for a password, because we're
-    // going to spawn it as the current user anyway. The addition of "p",
-    // preserves the environment.
-    // -f: Bypasses authentication for the already-logged-in user.
-    // -l: Skips changing directory to $HOME and prepending '-' to argv[0].
-    // -p: Preserves the environment.
-    // -q: Forces quiet logins, as if a .hushlogin is present.
-    let cmd_args = vec!["-flpq", &user, "/bin/zsh", "-fc", &exec];
-
-    (
-        cmd_path.to_string(),
-        cmd_args.into_iter().map(|s| s.to_string()).collect(),
-    )
 }
 
 // Creates a shell command if needed on this platform
 #[cfg(target_os = "macos")]
-fn create_platform_command<T: AsRef<OsStr> + AsRef<str> + ToString>(
+fn create_platform_command(
     command: &str,
-    args: &[T],
+    args: &Vec<String>,
     _settings: &Settings,
 ) -> TokioCommand {
-    let (cmd, cmd_args) = build_login_cmd_args(command, args);
+    use uzers::os::unix::UserExt;
+    if env::var_os("TERM").is_some() {
+        // If $TERM is set, we assume user is running from a terminal, and we shouldn't
+        // re-initialize the environment.
+        // See https://github.com/neovide/neovide/issues/2584
+        let mut result = TokioCommand::new(command);
+        result.args(args);
+        result
+    } else {
+        // Otherwise run inside a login shell
+        let mut result = TokioCommand::new("/usr/bin/login");
+        let user = uzers::get_user_by_uid(uzers::get_current_uid()).unwrap();
+        let shell = user::shell();
+        // -f: Bypasses authentication for the already-logged-in user.
+        // -p: Preserves the environment.
+        // -q: Forces quiet logins, as if a .hushlogin is present.
 
-    let mut result = TokioCommand::new(cmd);
-    result.args(cmd_args);
+        // Convert to a single string and add quotes
+        let args =
+            shlex::try_join(args.iter().map(|s| s.as_ref())).expect("Failed to join arguments");
+        result.args(["-flq", shell, "-c"]);
+        result.arg(format!("{} {}", command, args));
+        result
+    }
+}
 
+// Creates a shell command if needed on this platform
+#[cfg(target_os = "windows")]
+fn create_platform_command(command: &str, args: &Vec<String>, settings: &Settings) -> TokioCommand {
+    let mut result = if cfg!(target_os = "windows") && settings.get::<CmdLineSettings>().wsl {
+        let mut result = TokioCommand::new("wsl");
+        result.args(["$SHELL", "-l", "-c"]);
+        // There's no need to use shlex on Windows, the WSL path conversion already takes care of
+        // quoting
+        result.arg(format!("{} {}", command, args.join(" ")));
+        result
+    } else {
+        // There's no need to go through the shell on Windows when not using WSL
+        let mut result = TokioCommand::new(command);
+        result.args(args);
+        result
+    };
+
+    result.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
     result
 }
 
 // Creates a shell command if needed on this platform
-#[cfg(not(target_os = "macos"))]
-fn create_platform_command<T: AsRef<OsStr>>(
+#[cfg(target_os = "linux")]
+fn create_platform_command(
     command: &str,
-    args: &[T],
-    settings: &Settings,
+    args: &Vec<String>,
+    _settings: &Settings,
 ) -> TokioCommand {
-    if cfg!(target_os = "windows") && settings.get::<CmdLineSettings>().wsl {
-        let mut result = TokioCommand::new("wsl");
-        result.args(["--shell-type", "login"]);
-        result.arg("--");
-        result.arg(command);
-        result.args(args);
-
-        #[cfg(target_os = "windows")]
-        result.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
-
-        result
-    } else {
-        let mut result = TokioCommand::new(command);
-        result.args(args);
-
-        #[cfg(target_os = "windows")]
-        result.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
-
-        result
-    }
-}
-
-fn create_error_message(bin: &str, stdout: &str, stderr: Vec<&str>, is_wsl: bool) -> String {
-    let mut error_message = format!(
-        concat!(
-            "ERROR: Unexpected output from neovim binary:\n",
-            "\t{bin} -v\n",
-            "stdout: {stdout}\n",
-            "stderr: {stderr}\n",
-            "\t"
-        ),
-        bin = bin,
-        stdout = stdout,
-        stderr = stderr.join("\n")
-    );
-
-    if is_wsl {
-        error_message.push_str("\n\nPlease check your WSL configuration.\n");
-    } else {
-        error_message.push_str("\n\nPlease check your shell configuration.\n");
-    }
-
-    error_message
-}
-
-async fn neovim_ok(bin: &str, args: &[String], settings: &Settings) -> Result<bool> {
-    let is_wsl = settings.get::<CmdLineSettings>().wsl;
-    let mut args = args.iter().map(String::as_str).collect::<Vec<_>>();
-    args.push("-v");
-
-    let mut cmd = create_platform_command(bin, &args, settings);
-    let Ok(output) = cmd.output().await else {
-        return Ok(false);
-    };
-
-    // The output is not utf8 on Windows and can contain special characters.
-    // But a lossy conversion is OK for our purposes
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    let error_regex = Regex::new(r"your \d+x\d+ screen size is bogus. expect trouble").unwrap();
-    let (_, non_matching_stderr_lines): (Vec<_>, Vec<_>) =
-        stderr.lines().partition(|line| error_regex.is_match(line));
-
-    let unexpected_output = !output.status.success()
-        || !stdout.starts_with("NVIM v")
-        || !non_matching_stderr_lines.is_empty();
-
-    if unexpected_output {
-        let error_message = create_error_message(bin, &stdout, non_matching_stderr_lines, is_wsl);
-        let command = if is_wsl {
-            format!("wsl --shell-type login -- {bin} -v")
-        } else {
-            format!("$SHELL -lc '{bin} -v'")
-        };
-
-        bail!("{error_message}{command}")
-    }
-
-    Ok(true)
-}
-
-async fn lex_nvim_cmdline(
-    cmdline: &str,
-    settings: &Settings,
-) -> Result<Option<(String, Vec<String>)>> {
-    let is_windows = cfg!(target_os = "windows") && !settings.get::<CmdLineSettings>().wsl;
-    // shlex::split does not work with windows path separators, so pass the cmdline as it is
-    // Note that on WSL we can still try to split it to support specifying neovim-bin as
-    // /usr/bin/env nvim for example
-    let splitted = if is_windows {
-        Some((cmdline.to_owned(), Vec::new()))
-    } else {
-        shlex::split(cmdline)
-            .filter(|t| !t.is_empty())
-            .map(|mut tokens| (tokens.remove(0), tokens))
-    };
-    let splitted = if let Some((bin, args)) = splitted {
-        // if neovim_bin contains a path separator, then try to launch it directly
-        // otherwise use which to find the full path
-        if !bin.contains('/') && !bin.contains('\\') {
-            platform_which(&bin, settings).await.map(|bin| (bin, args))
-        } else {
-            Some((bin, args))
-        }
-    } else {
-        None
-    };
-    if let Some((bin, args)) = splitted {
-        neovim_ok(&bin, &args, settings)
-            .await
-            .map(|res| res.then_some((bin, args)))
-    } else {
-        Ok(None)
-    }
-}
-
-async fn platform_which(bin: &str, settings: &Settings) -> Option<String> {
-    let is_wsl = settings.get::<CmdLineSettings>().wsl;
-
-    // The which crate won't work in WSL, a shell always needs to be started
-    // In all other cases always try which::which first to avoid shell specific problems
-    if !is_wsl {
-        if let Ok(path) = which::which(bin) {
-            return path.into_os_string().into_string().ok();
-        }
-    }
-
-    // But if that does not work, try the shell anyway
-    let mut which_command = create_platform_command("which", &[bin], settings);
-    debug!("Running which command: {:?}", which_command);
-    if let Ok(output) = which_command.output().await {
-        if output.status.success() {
-            // The output is not utf8 on Windows and can contain special characters.
-            // This might fail with special characters in the path, but that probably does
-            // not matter, since which::which should handle almost all cases.
-            let nvim_path = String::from_utf8_lossy(&output.stdout);
-            return Some(nvim_path.trim().to_owned());
-        }
-    }
-    None
-}
-
-fn build_nvim_cmd_with_args(
-    bin: String,
-    mut args: Vec<String>,
-    settings: &Settings,
-) -> TokioCommand {
-    args.push("--embed".to_string());
-    args.extend(settings.get::<CmdLineSettings>().neovim_args);
-    create_platform_command(&bin, &args, settings)
+    // On Linux we can just launch directly
+    let mut result = TokioCommand::new(command);
+    result.args(args);
+    result
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -40,11 +40,11 @@ pub struct NeovimRuntime {
     pub runtime: Runtime,
 }
 
-fn neovim_instance(settings: &Settings) -> Result<NeovimInstance> {
+async fn neovim_instance(settings: &Settings) -> Result<NeovimInstance> {
     if let Some(address) = settings.get::<CmdLineSettings>().server {
         Ok(NeovimInstance::Server { address })
     } else {
-        let cmd = create_nvim_command(settings)?;
+        let cmd = create_nvim_command(settings).await?;
         Ok(NeovimInstance::Embedded(cmd))
     }
 }
@@ -78,7 +78,7 @@ async fn launch(
     grid_size: Option<GridSize<u32>>,
     settings: Arc<Settings>,
 ) -> Result<NeovimSession> {
-    let neovim_instance = neovim_instance(settings.as_ref())?;
+    let neovim_instance = neovim_instance(settings.as_ref()).await?;
 
     let session = NeovimSession::new(neovim_instance, handler)
         .await

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -44,7 +44,7 @@ async fn neovim_instance(settings: &Settings) -> Result<NeovimInstance> {
     if let Some(address) = settings.get::<CmdLineSettings>().server {
         Ok(NeovimInstance::Server { address })
     } else {
-        let cmd = create_nvim_command(settings).await?;
+        let cmd = create_nvim_command(settings)?;
         Ok(NeovimInstance::Embedded(cmd))
     }
 }

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -42,10 +42,14 @@ impl NeovimSession {
     pub async fn new(
         instance: NeovimInstance,
         handler: impl Handler<Writer = NeovimWriter>,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         let (reader, writer, neovim_process) = instance.connect().await?;
-        let (neovim, io) =
-            Neovim::<NeovimWriter>::new(reader.compat(), Box::new(writer.compat_write()), handler);
+        let (neovim, io) = Neovim::<NeovimWriter>::handshake(
+            reader.compat(),
+            Box::new(writer.compat_write()),
+            handler,
+        )
+        .await?;
         let io_handle = spawn(io);
 
         Ok(Self {

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -63,7 +63,6 @@ This is the error that caused the crash. In case you don't know what to do with 
 
 {err:?}"
     );
-    log::error!("{}", msg);
     msg
 }
 
@@ -79,7 +78,8 @@ pub fn handle_startup_errors(
         let _ = clap_error.print();
         ExitCode::from(clap_error.exit_code() as u8)
     } else if stdout().is_terminal() {
-        eprintln!("{}", &format_and_log_error_message(err));
+        // The logger already writes to stderr
+        log::error!("{}", &format_and_log_error_message(err));
         ExitCode::from(1)
     } else {
         show_error_window(&format_and_log_error_message(err), event_loop, settings);

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -327,8 +327,7 @@ mod tests {
         //create_nvim_command tries to read from CmdLineSettings.neovim_args
         settings.set::<CmdLineSettings>(&CmdLineSettings::default());
 
-        let command = create_nvim_command(&settings)
-            .unwrap_or_explained_panic("Could not create nvim command");
+        let command = create_nvim_command(&settings);
         let instance = NeovimInstance::Embedded(command);
         let NeovimSession { neovim: nvim, .. } = NeovimSession::new(instance, NeovimHandler())
             .await

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -328,6 +328,7 @@ mod tests {
         settings.set::<CmdLineSettings>(&CmdLineSettings::default());
 
         let command = create_nvim_command(&settings)
+            .await
             .unwrap_or_explained_panic("Could not create nvim command");
         let instance = NeovimInstance::Embedded(command);
         let NeovimSession { neovim: nvim, .. } = NeovimSession::new(instance, NeovimHandler())

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -328,7 +328,6 @@ mod tests {
         settings.set::<CmdLineSettings>(&CmdLineSettings::default());
 
         let command = create_nvim_command(&settings)
-            .await
             .unwrap_or_explained_panic("Could not create nvim command");
         let instance = NeovimInstance::Embedded(command);
         let NeovimSession { neovim: nvim, .. } = NeovimSession::new(instance, NeovimHandler())


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
With https://github.com/KillTheMule/nvim-rs/pull/53, the complexity of command.rs can be almost completely eliminated. Both stdout and stderr are now reported normally, so there's no need to try to test running `nvim -v` . There's also no need to run `which`. That's now handled by `tokio::process::Command` or by the shell depending on if a shell is launched or not. 

A login shell is started for WSL and on macOS when running through the GUI like before. Otherwise `nvim` is started directly.

With https://github.com/KillTheMule/nvim-rs/pull/53, we are now tolerant to both stdout and stderr output. 
* fixes https://github.com/neovide/neovide/issues/2741
* fixes https://github.com/neovide/neovide/issues/3026

The macOS startup is now simplified (but untested yet).
* fixes https://github.com/neovide/neovide/issues/3030
* https://github.com/neovide/neovide/issues/3029
* https://github.com/neovide/neovide/issues/2960

WSL is now only started once, and therefore it's faster
* fixes https://github.com/neovide/neovide/issues/2024

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, it re-opens this bug on platforms where the shell is not started. But I don't really see why we should support it, the user can trivially make a shell script that hides all complexity inside a single command.
* https://github.com/neovide/neovide/issues/2060

