### PR TITLE
linux: Support xdg activation

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -21,7 +21,11 @@ use winit::{
 use winit::platform::macos::WindowAttributesExtMacOS;
 
 #[cfg(target_os = "linux")]
-use winit::platform::{wayland::WindowAttributesExtWayland, x11::WindowAttributesExtX11};
+use winit::platform::{
+    startup_notify::{self, EventLoopExtStartupNotify, WindowAttributesExtStartupNotify},
+    wayland::WindowAttributesExtWayland,
+    x11::WindowAttributesExtX11,
+};
 
 #[cfg(target_os = "windows")]
 use winit::platform::windows::WindowAttributesExtWindows;
@@ -199,6 +203,14 @@ pub fn create_window(
 
     #[cfg(target_os = "linux")]
     let window_attributes = {
+        let window_attributes =
+            if let Some(token) = EventLoopExtStartupNotify::read_token_from_env(event_loop) {
+                startup_notify::reset_activation_token_env();
+                WindowAttributesExtStartupNotify::with_activation_token(window_attributes, token)
+            } else {
+                window_attributes
+            };
+
         if env::var("WAYLAND_DISPLAY").is_ok() {
             let app_id = &cmd_line_settings.wayland_app_id;
             WindowAttributesExtWayland::with_name(window_attributes, app_id.clone(), "neovide")


### PR DESCRIPTION
This allows the window to gain focus when it's created even with strict focus stealing prevention on wayland. On x11 it's also used for things like loading indicator between launching and the window appearing (I think we need to add `StartupNotify=true` to the desktop for this to work, I'm not very familiar with it so I didn't touch it here)
Tested on [niri](https://github.com/YaLTeR/niri) with:
```kdl
debug {
    strict-new-window-focus-policy
}
```
For more details see [this mutter blog post](https://blogs.gnome.org/shell-dev/2024/09/20/understanding-gnome-shells-focus-stealing-prevention/)

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Other

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
