### PR TITLE
fix: particle vfx not being emitted for short travels

### DIFF
--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -1100,7 +1100,8 @@ Lua:
 vim.g.neovide_cursor_vfx_particle_density = 7.0
 ```
 
-Sets the number of generated particles.
+Sets the number of generated particles. The unit is roughly the amount of particles per 10 lines of
+travel.
 
 #### Particle Speed
 


### PR DESCRIPTION


<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
No particles were emitted when the buffer was scrolled so that the cursor moves a very small distance at a time. There were two bugs

1. Each cursor movement was processed in isolation. So, if the move was short enough, then the density setting might not be big enough to emit any particles. This is fixed by using an accumulator, so that a particle is emitted when the total distance traveled since the last particle is long enough.
2. The first particle emitted always got a lifetime of zero due to an off by one error



## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

Note: Because the exponential formula would be almost impossible to calculate with the accumulator,  the particle count formula has been changed from
```rust
let particle_count = ((travel_distance / cursor_dimensions.height).powf(1.5)
    * settings.vfx_particle_density
    * 0.01) as usize;
```
to
```rust
let f_particle_count = (travel_distance / cursor_dimensions.height)
    * settings.vfx_particle_density
    * 0.1)
```
In practice they give almost the same result for the common movement distances. Only after distances more than 100 rows, do the formulas start to diverge. So, I think we can consider this a non-breaking change.

![image](https://github.com/user-attachments/assets/e08f195e-f3c4-4aff-bf9d-749f17aa3b79)