### PR TITLE
fix: point highlight cursor effects are properly emitted and animated

### DIFF
--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -20,6 +20,7 @@ pub trait CursorVfx {
         dt: f32,
     ) -> bool;
     fn restart(&mut self, position: PixelPos<f32>);
+    fn cursor_jumped(&mut self, position: PixelPos<f32>);
     fn render(
         &self,
         settings: &CursorSettings,
@@ -126,6 +127,10 @@ impl CursorVfx for PointHighlight {
     fn restart(&mut self, position: PixelPos<f32>) {
         self.t = 0.0;
         self.center_position = position;
+    }
+
+    fn cursor_jumped(&mut self, position: PixelPos<f32>) {
+        self.restart(position);
     }
 
     fn render(
@@ -334,6 +339,8 @@ impl CursorVfx for ParticleTrail {
     fn restart(&mut self, _position: PixelPos<f32>) {
         self.count_reminder = 0.0;
     }
+
+    fn cursor_jumped(&mut self, _position: PixelPos<f32>) {}
 
     fn render(
         &self,

--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -114,14 +114,18 @@ impl PointHighlight {
 impl CursorVfx for PointHighlight {
     fn update(
         &mut self,
-        _settings: &CursorSettings,
+        settings: &CursorSettings,
         current_cursor_destination: PixelPos<f32>,
         _cursor_dimensions: PixelSize<f32>,
         _immediate_movement: bool,
         dt: f32,
     ) -> bool {
         self.center_position = current_cursor_destination;
-        self.t = (self.t + dt * 5.0).min(1.0); // TODO - speed config
+        if settings.vfx_particle_lifetime > 0.0 {
+            self.t = (self.t + dt * (1.0 / settings.vfx_particle_lifetime)).min(1.0);
+        } else {
+            self.t = 1.0
+        }
         self.t < 1.0
     }
 

--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -115,11 +115,12 @@ impl CursorVfx for PointHighlight {
     fn update(
         &mut self,
         _settings: &CursorSettings,
-        _current_cursor_destination: PixelPos<f32>,
+        current_cursor_destination: PixelPos<f32>,
         _cursor_dimensions: PixelSize<f32>,
         _immediate_movement: bool,
         dt: f32,
     ) -> bool {
+        self.center_position = current_cursor_destination;
         self.t = (self.t + dt * 5.0).min(1.0); // TODO - speed config
         self.t < 1.0
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The point highlight cursor effects are now emitted when the cursor moves (jumps) instead of just when the mode changes. The effect is also now properly animated when the window is scrolled.

Finally, the lifetime is controlled by the `vfx_particle_lifetime` setting

## Did this PR introduce a breaking change? 
- No

Technically it probably is, but since the effect has worked so poorly before I don't think it matters. The default lifetime is now much higher, it was 0.2 seconds before (hardcoded), and now 1.2 seconds (but configurable). And the same as for other particles, which I think makes sense, especially in combination with https://github.com/neovide/neovide/pull/3009
