### PR TITLE
feat: low latency cursor animation

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -141,7 +141,7 @@ impl Corner {
         if (self.t - 1.0).abs() < f32::EPSILON {
             // We are at destination, move t out of 0-1 range to stop the animation
             self.t = 2.0;
-        } else {
+        } else if direction_alignment <= 0.0 {
             let corner_dt = dt
                 * lerp(
                     1.0,
@@ -150,6 +150,9 @@ impl Corner {
                 );
             self.t =
                 (self.t + corner_dt / (settings.animation_length * self.length_multiplier)).min(1.0)
+        } else {
+            // The front of the cursor jumps to the destination immediately
+            self.t = 1.0;
         }
 
         self.current_position = ease_point(


### PR DESCRIPTION
The front of the cursor immediately moves to the destination, for a much snappier feel.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
One thing that always bothered me is the additional latency the cursor animation causes, sometimes it's enough to make you go one step too far when travelling by word or `f`. But I have been too lazy to bother investigating and fixing it.

The issue was that all parts of the cursor were animating, so there was always some time until you got a visual indication of what the destination is. This is fixed by always snapping the leading edge of the cursor to the destination, only animating the trail

I considered making this an option, but I don't see any reason why anyone would prefer the old behaviour. If it feels too fast, then the animating length can be increased. But the default is plenty enough, at least for me, to give a good visual hint where the cursor is moving.


## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
