### PR TITLE
feat!: more configurable cursor animation

### DIFF
--- a/src/profiling/profiling_enabled.rs
+++ b/src/profiling/profiling_enabled.rs
@@ -317,8 +317,11 @@ macro_rules! tracy_named_frame {
 
 #[macro_export]
 macro_rules! tracy_plot {
-    ($name: expr, $dt: expr) => {
+    ($name: literal, $dt: expr) => {
         $crate::profiling::_tracy_plot($crate::profiling::cstr!($name), $dt)
+    };
+    ($name: expr, $dt: expr) => {
+        $crate::profiling::_tracy_plot($name, $dt)
     };
 }
 

--- a/src/renderer/animation_utils.rs
+++ b/src/renderer/animation_utils.rs
@@ -87,53 +87,45 @@ pub fn ease_point<T: Unit<Scalar = f32>>(
 
 pub struct CriticallyDampedSpringAnimation {
     pub position: f32,
-    start_position: f32,
     velocity: f32,
-    scroll_t: f32,
 }
 
 impl CriticallyDampedSpringAnimation {
     pub fn new() -> Self {
         Self {
             position: 0.0,
-            start_position: 0.0,
             velocity: 0.0,
-            scroll_t: 2.0,
         }
     }
 
     pub fn update(&mut self, dt: f32, animation_length: f32) -> bool {
-        if self.scroll_t == 2.0 && self.position != 0.0 {
-            self.start_position = self.position;
-            self.scroll_t = 0.0;
+        if animation_length <= dt {
+            self.reset();
+            return false;
+        }
+        if self.position == 0.0 {
+            return false;
         }
 
-        if self.scroll_t > 1.0 - f32::EPSILON {
-            // We are at destination, move t out of 0-1 range to stop the animation.
-            self.scroll_t = 2.0;
-        } else {
-            self.scroll_t = (self.scroll_t + dt / animation_length).min(1.0);
-        }
+        // Simulate a critically damped spring, also known as a PD controller.
+        // For more details of why this was chosen, see this:
+        // https://gdcvault.com/play/1027059/Math-In-Game-Development-Summit
+        // < 1 underdamped,  1 critically damped, > 1 overdamped
+        let zeta = 1.0;
+        // The omega is calculated so that the destination is reached with a 2% tolerance in
+        // animation_length time.
+        let omega = 4.0 / (zeta * animation_length);
 
-        // For short animations use a standard ease function
-        // This prevents precision errors, and division by zero
-        if animation_length < 0.05 {
-            self.position = ease(ease_out_expo, self.start_position, 0.0, self.scroll_t);
-        } else {
-            // Simulate critically damped spring, also known as a PD controller.
-            // For more details of why this was chosen, see this:
-            // https://gdcvault.com/play/1027059/Math-In-Game-Development-Summit
-            // < 1 underdamped,  1 critically damped, > 1 overdamped
-            let zeta = 1.0;
-            // The omega is calculated so that the destination is reached with a 2% tolerance in
-            // animation_length time.
-            let omega = 4.0 / (zeta * animation_length);
-            let k_p = omega * omega;
-            let k_d = -2.0 * zeta * omega;
-            let acc = -k_p * self.position + k_d * self.velocity;
-            self.velocity += acc * dt;
-            self.position += self.velocity * dt;
-        }
+        // Use the analytica formula for critically damped harmonic oscillation
+        // a and b are the intial conditions by setting dt to zero and solving the position and
+        // velocity respectively
+        let a = self.position;
+        let b = self.position * omega + self.velocity;
+
+        let c = (-omega * dt).exp();
+
+        self.position = (a + b * dt) * c;
+        self.velocity = c * (-a * omega - b * dt * omega + b);
 
         if self.position.abs() < 0.01 {
             self.reset();
@@ -146,7 +138,6 @@ impl CriticallyDampedSpringAnimation {
     pub fn reset(&mut self) {
         self.position = 0.0;
         self.velocity = 0.0;
-        self.scroll_t = 2.0
     }
 }
 

--- a/src/renderer/animation_utils.rs
+++ b/src/renderer/animation_utils.rs
@@ -85,6 +85,7 @@ pub fn ease_point<T: Unit<Scalar = f32>>(
     )
 }
 
+#[derive(Clone)]
 pub struct CriticallyDampedSpringAnimation {
     pub position: f32,
     velocity: f32,

--- a/src/units.rs
+++ b/src/units.rs
@@ -68,6 +68,12 @@ impl GridScale {
     }
 }
 
+impl From<PixelSize<f32>> for GridScale {
+    fn from(value: PixelSize<f32>) -> Self {
+        Self::new(value)
+    }
+}
+
 impl<T: Scalar> Mul<GridScale> for GridVec<T> {
     type Output = PixelVec<f32>;
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -834,17 +834,17 @@ this happens too often accidentally to you, set this to a higher value like `0.3
 VimScript:
 
 ```vim
-let g:neovide_cursor_animation_length = 0.13
+let g:neovide_cursor_animation_length = 0.150
 ```
 
 Lua:
 
 ```lua
-vim.g.neovide_cursor_animation_length = 0.13
+vim.g.neovide_cursor_animation_length = 0.150
 ```
 
 Setting `g:neovide_cursor_animation_length` determines the time it takes for the cursor to complete
-it's animation in seconds. Set to `0` to disable.
+its animation in seconds. Set to `0` to disable.
 
 #### Animation Trail Size
 
@@ -857,17 +857,20 @@ it's animation in seconds. Set to `0` to disable.
 VimScript:
 
 ```vim
-let g:neovide_cursor_trail_size = 0.8
+let g:neovide_cursor_trail_size = 1.0
 ```
 
 Lua:
 
 ```lua
-vim.g.neovide_cursor_trail_size = 0.8
+vim.g.neovide_cursor_trail_size = 1.0
 ```
 
-Setting `g:neovide_cursor_trail_size` determines how much the trail of the cursor lags behind the
-front edge.
+Range 0.0 to 1.0
+
+Setting `g:neovide_cursor_trail_size` changes how much the back of the cursor trails the front. Set
+to 1.0 to make the front jump to the destination immediately with a maximum trail size. A lower
+value makes a smoother animation, with a shorter trail, but also adds lag.
 
 #### Antialiasing
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
https://github.com/neovide/neovide/pull/3054 added low latency cursor movement, but unfortunately the new behaviour doesn't suite everyone. This therefore adds more configuration possibilities. 

The `neovide_cursor_animation_length`, now controls the animation length exactly in milliseconds. And the trail size controls how much faster front of the cursor moves in relation to the back. With the default value of 1.0 the front jumps to the destination immediately, with minimum lag. For a smoother experience you can lower the value at the cost of more lag.

* fixes https://github.com/neovide/neovide/issues/3059

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, the meaning of the values changes, and the `neovide_cursor_animation_length` quite drastically, the previous default was 0.06, which did not match the previous description of being specified in seconds.

We discussed this on discord, and I think it makes sense to do a big breaking change and change the defaults of all the cursor animations in the 0.15.0 release.

