### PR TITLE
fix!: The unit of neovide_cursor_vfx_particle_density is now particles per line

### DIFF
--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -273,8 +273,7 @@ impl CursorVfx for ParticleTrail {
 
                 // Increase amount of particles when cursor travels further
                 let f_particle_count = ((travel_distance / cursor_dimensions.height)
-                    * settings.vfx_particle_density
-                    * 0.1)
+                    * settings.vfx_particle_density)
                     + self.count_reminder;
 
                 let particle_count = f_particle_count as usize;

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -58,7 +58,7 @@ impl Default for CursorSettings {
             vfx_mode: cursor_vfx::VfxMode::Disabled,
             vfx_opacity: 200.0,
             vfx_particle_lifetime: 1.2,
-            vfx_particle_density: 7.0,
+            vfx_particle_density: 0.7,
             vfx_particle_speed: 10.0,
             vfx_particle_phase: 1.5,
             vfx_particle_curl: 1.0,

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -1113,16 +1113,16 @@ Sets the amount of time the generated particles should survive.
 VimScript:
 
 ```vim
-let g:neovide_cursor_vfx_particle_density = 7.0
+let g:neovide_cursor_vfx_particle_density = 0.7
 ```
 
 Lua:
 
 ```lua
-vim.g.neovide_cursor_vfx_particle_density = 7.0
+vim.g.neovide_cursor_vfx_particle_density = 0.7
 ```
 
-Sets the number of generated particles. The unit is roughly the amount of particles per 10 lines of
+Sets the number of generated particles. The unit is the amount of particles per lines of
 travel.
 
 #### Particle Speed
@@ -1139,7 +1139,7 @@ Lua:
 vim.g.neovide_cursor_vfx_particle_speed = 10.0
 ```
 
-Sets the speed of particle movement.
+Sets the speed of particle movement in pixels / second.
 
 #### Particle Phase
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The unit was changed to particles per 10 lines in https://github.com/neovide/neovide/pull/3052 to match old configuration settings. But that does not make much sense, so make a breaking change and change it to particles per line instead. 

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Yes, the same configuration values will generate 10 times as many particles
