### PR TITLE
fix: the z-index of message windows

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -35,6 +35,7 @@ pub use style::{Colors, Style, UnderlineStyle};
 pub use window::*;
 
 const MODE_CMDLINE: u64 = 4;
+pub const MSG_ZINDEX: u64 = 200; // See the documenation for nvim_open_win
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SortOrder {
@@ -474,7 +475,7 @@ impl Editor {
     }
 
     fn set_message_position(&mut self, grid: u64, grid_top: u64, scrolled: bool) {
-        let z_index = 250; // From the Neovim source code
+        let z_index = MSG_ZINDEX;
         let parent_width = self
             .windows
             .get(&1)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The z-index of the message window was wrong. Either because reading the source code wrong or a typo.

## Did this PR introduce a breaking change? 
- No
