### PR TITLE
fix: don't draw shadows for the cmdline window unless it's scrolled and displaying a message

### DIFF
--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -8,7 +8,10 @@ use skia_safe::{
 
 use glamour::Intersection;
 
-use crate::units::{to_skia_rect, GridScale, PixelRect};
+use crate::{
+    editor::WindowType,
+    units::{to_skia_rect, GridScale, PixelRect},
+};
 
 use super::{RenderedWindow, RendererSettings, WindowDrawDetails};
 
@@ -105,6 +108,14 @@ impl FloatingLayer<'_> {
 
     fn _draw_shadow(&self, root_canvas: &Canvas, path: &Path, settings: &RendererSettings) {
         if !settings.floating_shadow {
+            return;
+        }
+        // Assume that the message window is the only one in the layer
+        if self
+            .windows
+            .first()
+            .is_some_and(|w| matches!(w.window_type, WindowType::Message { scrolled: false }))
+        {
             return;
         }
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -76,7 +76,7 @@ pub struct RenderedWindow {
     valid: bool,
     pub hidden: bool,
     pub anchor_info: Option<AnchorInfo>,
-    window_type: WindowType,
+    pub window_type: WindowType,
 
     pub grid_size: GridSize<u32>,
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* fixes https://github.com/neovide/neovide/issues/2931

NOTE: That we currently don't draw a message separator, see https://github.com/neovide/neovide/issues/2237. And because we don't we need to draw the shadow when it's scrolled. It's a little bit more complex to draw the separator, we need to manually get the highlight group, and it also affect the message window scrolling, so it's left out from here and the 0.15.0 release.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
