### PR TITLE
fix: file drop with open in tabs set to false

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -42,13 +42,9 @@ end
 
 -- Quit when Command+Q is pressed on macOS
 if vim.fn.has("macunix") then
-    vim.keymap.set(
-        {"n", "i", "c", "v", "o", "t", "l"},
-        "<D-q>",
-        function()
-            rpcnotify("neovide.exec_detach_handler")
-        end
-    )
+    vim.keymap.set({ "n", "i", "c", "v", "o", "t", "l" }, "<D-q>", function()
+        rpcnotify("neovide.exec_detach_handler")
+    end)
 end
 
 if args.register_clipboard and not vim.g.neovide_no_custom_clipboard then
@@ -136,7 +132,8 @@ M.private.dropfile = function(filename, tabs)
     vim.api.nvim_cmd({
         cmd = "drop",
         args = { vim.fn.fnameescape(filename) },
-        mods = { tab = tabs and 1 or 0 },
+        -- Always open as the last tabpage
+        mods = tabs and { tab = #vim.api.nvim_list_tabpages() } or {},
     }, {})
 end
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The tabs option takes a count not a boolean, so `--no-tabs` did not work. Furthermore, when tabs were used, the tabs were always opened after the first tab, now they are opened after the last.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
