### PR TITLE
chore: Use nvim_exec2 instead of deprecated nvim_exec

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -77,13 +77,13 @@ vim.api.nvim_create_user_command("NeovideFocus", function()
     rpcnotify("neovide.focus_window")
 end, {})
 
-vim.api.nvim_exec(
+vim.api.nvim_exec2(
     [[
 function! WatchGlobal(variable, callback)
     call dictwatcheradd(g:, a:variable, a:callback)
 endfunction
 ]],
-    false
+    { output = false }
 )
 
 for _, global_variable_setting in ipairs(args.global_variable_settings) do


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
`nvim_exec` is deprecated, so use `nvim_exec2` instead.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
