### PR TITLE
fix: box drawing gaps due to inconsistent rendering

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -532,10 +532,10 @@ impl CursorRenderer {
         // corners.
         let mut path = Path::new();
 
-        path.move_to(to_skia_point(self.corners[0].current_position));
-        path.line_to(to_skia_point(self.corners[1].current_position));
-        path.line_to(to_skia_point(self.corners[2].current_position));
-        path.line_to(to_skia_point(self.corners[3].current_position));
+        path.move_to(to_skia_point(self.corners[0].current_position.round()));
+        path.line_to(to_skia_point(self.corners[1].current_position.round()));
+        path.line_to(to_skia_point(self.corners[2].current_position.round()));
+        path.line_to(to_skia_point(self.corners[3].current_position.round()));
         path.close();
 
         canvas.draw_path(&path, paint);
@@ -544,10 +544,10 @@ impl CursorRenderer {
 
     fn draw_rectangular_outline(&self, canvas: &Canvas, paint: &Paint, outline_width: f32) -> Path {
         let mut rectangle = Path::new();
-        rectangle.move_to(to_skia_point(self.corners[0].current_position));
-        rectangle.line_to(to_skia_point(self.corners[1].current_position));
-        rectangle.line_to(to_skia_point(self.corners[2].current_position));
-        rectangle.line_to(to_skia_point(self.corners[3].current_position));
+        rectangle.move_to(to_skia_point(self.corners[0].current_position.round()));
+        rectangle.line_to(to_skia_point(self.corners[1].current_position.round()));
+        rectangle.line_to(to_skia_point(self.corners[2].current_position.round()));
+        rectangle.line_to(to_skia_point(self.corners[3].current_position.round()));
         rectangle.close();
 
         let offsets: [PixelVec<f32>; 4] = [


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
When a pixel position with a fraction very close to 0.5 was rendering, there's some inconsistency between how Skia (or the graphics drivers) rounds them and how Neovide does it. Therefore, always round non-antialiased coordinates as well.

* Fixes https://github.com/neovide/neovide/issues/3080

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
