### PR TITLE
fix: cmdline escaping when using WSL

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -58,9 +58,9 @@ fn create_platform_command(command: &str, args: &Vec<String>, settings: &Setting
     let mut result = if cfg!(target_os = "windows") && settings.get::<CmdLineSettings>().wsl {
         let mut result = TokioCommand::new("wsl");
         result.args(["$SHELL", "-l", "-c"]);
-        // There's no need to use shlex on Windows, the WSL path conversion already takes care of
-        // quoting
-        result.arg(format!("{} {}", command, args.join(" ")));
+        let args =
+            shlex::try_join(args.iter().map(|s| s.as_ref())).expect("Failed to join arguments");
+        result.arg(format!("{} {}", command, args));
         result
     } else {
         // There's no need to go through the shell on Windows when not using WSL

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -207,7 +207,7 @@ impl ParallelCommand {
                 .exec_lua(
                     &format!(
                         "neovide.private.dropfile([[{}]], {})",
-                        handle_wslpaths(vec![path], settings.get::<CmdLineSettings>().wsl, false)
+                        handle_wslpaths(vec![path], settings.get::<CmdLineSettings>().wsl)
                             .first()
                             .unwrap(),
                         settings.get::<CmdLineSettings>().tabs

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -215,7 +215,6 @@ pub fn handle_command_line_arguments(args: Vec<String>, settings: &Settings) -> 
         .chain(handle_wslpaths(
             mem::take(&mut cmdline.files_to_open),
             cmdline.wsl,
-            true,
         ))
         .chain(cmdline.neovim_args)
         .collect();
@@ -282,9 +281,9 @@ mod tests {
         assert_eq!(
             settings.get::<CmdLineSettings>().neovim_args,
             vec![
-                "'/mnt/c/Users/MyUser/foo.txt'",
-                "'/mnt/c/bar.md'",
-                "'/mnt/c/Program Files (x86)/Some Application/Settings.ini'"
+                "/mnt/c/Users/MyUser/foo.txt",
+                "/mnt/c/bar.md",
+                "/mnt/c/Program Files (x86)/Some Application/Settings.ini"
             ]
         );
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,7 +14,7 @@ pub fn is_tty() -> bool {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn handle_wslpaths(paths: Vec<String>, _wsl: bool, _quote: bool) -> Vec<String> {
+pub fn handle_wslpaths(paths: Vec<String>, _wsl: bool) -> Vec<String> {
     paths
 }
 
@@ -22,7 +22,7 @@ pub fn handle_wslpaths(paths: Vec<String>, _wsl: bool, _quote: bool) -> Vec<Stri
 ///
 /// If conversion of a path fails, the path is passed to neovim unchanged.
 #[cfg(target_os = "windows")]
-pub fn handle_wslpaths(paths: Vec<String>, wsl: bool, quote: bool) -> Vec<String> {
+pub fn handle_wslpaths(paths: Vec<String>, wsl: bool) -> Vec<String> {
     if !wsl {
         return paths;
     }
@@ -31,12 +31,7 @@ pub fn handle_wslpaths(paths: Vec<String>, wsl: bool, quote: bool) -> Vec<String
         .into_iter()
         .map(|path| {
             let path = std::fs::canonicalize(&path).map_or(path, |p| p.to_string_lossy().into());
-            let wslpath = windows_to_wsl(&path).unwrap_or(path);
-            if quote {
-                format!("'{}'", wslpath)
-            } else {
-                wslpath
-            }
+            windows_to_wsl(&path).unwrap_or(path)
         })
         .collect()
 }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
When using WSL only the filename was escaped, and not other Neovim options like `--cmd "cd ~"`. This was a regression from https://github.com/neovide/neovide/pull/3045. But is fixed here, by using `shlex::try_join'

## Did this PR introduce a breaking change? 
- No
