### PR TITLE
feat: configurable short cursor animation

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -50,7 +50,7 @@ static PLOT_NAMES_Y: [&CStr; 4] = [
 pub struct CursorSettings {
     antialiasing: bool,
     animation_length: f32,
-    distance_length_adjust: bool,
+    short_animation_length: f32,
     animate_in_insert_mode: bool,
     animate_command_line: bool,
     trail_size: f32,
@@ -72,7 +72,7 @@ impl Default for CursorSettings {
         CursorSettings {
             antialiasing: true,
             animation_length: 0.150,
-            distance_length_adjust: true,
+            short_animation_length: 0.04,
             animate_in_insert_mode: true,
             animate_command_line: true,
             trail_size: 1.0,
@@ -165,7 +165,9 @@ impl Corner {
         {
             // Use a fast animation time for short jumps less than two characters, typically when
             // typing or holding a key in insert mode
-            settings.animation_length.min(0.04)
+            settings
+                .animation_length
+                .min(settings.short_animation_length)
         } else {
             let leading = settings.animation_length * (1.0 - settings.trail_size).clamp(0.0, 1.0);
             let trailing = settings.animation_length;

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -844,6 +844,23 @@ vim.g.neovide_cursor_animation_length = 0.150
 Setting `g:neovide_cursor_animation_length` determines the time it takes for the cursor to complete
 its animation in seconds. Set to `0` to disable.
 
+#### Short Animation Length
+
+VimScript:
+
+```vim
+let g:neovide_cursor_short_animation_length = 0.04
+```
+
+Lua:
+
+```lua
+vim.g.neovide_cursor_short_animation_length = 0.04
+```
+
+Setting `g:neovide_cursor_short_animation_length` determines the time it takes for the cursor to complete
+its animation in seconds for short horizontal travels of one or two characters, like when typing.
+
 #### Animation Trail Size
 
 <p align="center">


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The animation length for short movements was hardcoded to 0.04, and is now a configurable setting instead.

The unused `cursor_distance_length_adjust` setting was also removed
* fixes https://github.com/neovide/neovide/issues/3090

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
