### PR TITLE
chore: pass DrawCommandBatcher around instead of relying on interior mutability

### DIFF
--- a/src/editor/draw_command_batcher.rs
+++ b/src/editor/draw_command_batcher.rs
@@ -1,27 +1,21 @@
-use std::cell::RefCell;
-
 use crate::{editor::DrawCommand, window::UserEvent};
 
 use winit::event_loop::EventLoopProxy;
 
 pub struct DrawCommandBatcher {
-    batch: RefCell<Vec<DrawCommand>>,
+    batch: Vec<DrawCommand>,
 }
 
 impl DrawCommandBatcher {
     pub fn new() -> DrawCommandBatcher {
-        Self {
-            batch: RefCell::default(),
-        }
+        Self { batch: Vec::new() }
     }
 
-    pub fn queue(&self, draw_command: DrawCommand) {
-        self.batch.borrow_mut().push(draw_command);
+    pub fn queue(&mut self, draw_command: DrawCommand) {
+        self.batch.push(draw_command);
     }
 
-    pub fn send_batch(&self, proxy: &EventLoopProxy<UserEvent>) {
-        proxy
-            .send_event(self.batch.borrow_mut().split_off(0).into())
-            .ok();
+    pub fn send_batch(&mut self, proxy: &EventLoopProxy<UserEvent>) {
+        proxy.send_event(self.batch.split_off(0).into()).ok();
     }
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     renderer::{DrawCommand, WindowDrawCommand},
     running_tracker::RunningTracker,
     settings::Settings,
+    units::{GridRect, GridSize},
     window::{UserEvent, WindowCommand, WindowSettings},
 };
 
@@ -266,12 +267,8 @@ impl Editor {
                 if let Some(window) = window {
                     window.scroll_region(
                         &mut self.draw_command_batcher,
-                        top,
-                        bottom,
-                        left,
-                        right,
-                        rows,
-                        columns,
+                        GridRect::from_min_max((left, top), (right, bottom)),
+                        GridSize::new(columns, rows),
                     );
                 }
             }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -4,7 +4,7 @@ mod grid;
 mod style;
 mod window;
 
-use std::{collections::HashMap, rc::Rc, sync::Arc, thread};
+use std::{collections::HashMap, sync::Arc, thread};
 
 use log::{error, trace, warn};
 use tokio::sync::mpsc::unbounded_channel;
@@ -92,7 +92,7 @@ pub struct Editor {
     pub cursor: Cursor,
     pub defined_styles: HashMap<u64, Arc<Style>>,
     pub mode_list: Vec<CursorMode>,
-    pub draw_command_batcher: Rc<DrawCommandBatcher>,
+    pub draw_command_batcher: DrawCommandBatcher,
     pub current_mode_index: Option<u64>,
     pub ui_ready: bool,
     event_loop_proxy: EventLoopProxy<UserEvent>,
@@ -108,7 +108,7 @@ impl Editor {
             cursor: Cursor::new(),
             defined_styles: HashMap::new(),
             mode_list: Vec::new(),
-            draw_command_batcher: Rc::new(DrawCommandBatcher::new()),
+            draw_command_batcher: DrawCommandBatcher::new(),
             current_mode_index: None,
             ui_ready: false,
             settings,
@@ -232,14 +232,20 @@ impl Editor {
                 let defined_styles = &self.defined_styles;
                 let window = self.windows.get_mut(&grid);
                 if let Some(window) = window {
-                    window.draw_grid_line(row, column_start, cells, defined_styles);
+                    window.draw_grid_line(
+                        &mut self.draw_command_batcher,
+                        row,
+                        column_start,
+                        cells,
+                        defined_styles,
+                    );
                 }
             }
             RedrawEvent::Clear { grid } => {
                 tracy_zone!("EditorClear");
                 let window = self.windows.get_mut(&grid);
                 if let Some(window) = window {
-                    window.clear();
+                    window.clear(&mut self.draw_command_batcher);
                 }
             }
             RedrawEvent::Destroy { grid } => {
@@ -258,7 +264,15 @@ impl Editor {
                 tracy_zone!("EditorScroll");
                 let window = self.windows.get_mut(&grid);
                 if let Some(window) = window {
-                    window.scroll_region(top, bottom, left, right, rows, columns);
+                    window.scroll_region(
+                        &mut self.draw_command_batcher,
+                        top,
+                        bottom,
+                        left,
+                        right,
+                        rows,
+                        columns,
+                    );
                 }
             }
             RedrawEvent::WindowPosition {
@@ -299,7 +313,7 @@ impl Editor {
                 let window = self.windows.get_mut(&grid);
                 if let Some(window) = window {
                     window.anchor_info = None;
-                    window.hide();
+                    window.hide(&mut self.draw_command_batcher);
                 }
             }
             RedrawEvent::WindowClose { grid } => {
@@ -358,7 +372,7 @@ impl Editor {
 
     fn close_window(&mut self, grid: u64) {
         if let Some(window) = self.windows.remove(&grid) {
-            window.close();
+            window.close(&mut self.draw_command_batcher);
             self.draw_command_batcher
                 .queue(DrawCommand::CloseWindow(grid));
         }
@@ -366,7 +380,7 @@ impl Editor {
 
     fn resize_window(&mut self, grid: u64, width: u64, height: u64) {
         if let Some(window) = self.windows.get_mut(&grid) {
-            window.resize((width, height));
+            window.resize(&mut self.draw_command_batcher, (width, height));
             if let Some(anchor_info) = &window.anchor_info {
                 let anchor_grid_id = anchor_info.anchor_grid_id;
                 let anchor_type = anchor_info.anchor_type.clone();
@@ -389,7 +403,7 @@ impl Editor {
                 None,
                 (0.0, 0.0),
                 (width, height),
-                Rc::clone(&self.draw_command_batcher),
+                &mut self.draw_command_batcher,
             );
             self.windows.insert(grid, window);
         }
@@ -404,8 +418,13 @@ impl Editor {
         height: u64,
     ) {
         if let Some(window) = self.windows.get_mut(&grid) {
-            window.position(None, (width, height), (start_left as f64, start_top as f64));
-            window.show();
+            window.position(
+                &mut self.draw_command_batcher,
+                None,
+                (width, height),
+                (start_left as f64, start_top as f64),
+            );
+            window.show(&mut self.draw_command_batcher);
         } else {
             let new_window = Window::new(
                 grid,
@@ -413,7 +432,7 @@ impl Editor {
                 None,
                 (start_left as f64, start_top as f64),
                 (width, height),
-                Rc::clone(&self.draw_command_batcher),
+                &mut self.draw_command_batcher,
             );
             self.windows.insert(grid, new_window);
         }
@@ -458,6 +477,7 @@ impl Editor {
             };
 
             window.position(
+                &mut self.draw_command_batcher,
                 Some(AnchorInfo {
                     anchor_grid_id: anchor_grid,
                     anchor_type,
@@ -468,7 +488,7 @@ impl Editor {
                 (width, height),
                 (modified_left, modified_top),
             );
-            window.show();
+            window.show(&mut self.draw_command_batcher);
         } else {
             error!("Attempted to float window that does not exist.");
         }
@@ -496,11 +516,12 @@ impl Editor {
         if let Some(window) = self.windows.get_mut(&grid) {
             window.window_type = WindowType::Message { scrolled };
             window.position(
+                &mut self.draw_command_batcher,
                 Some(anchor_info),
                 (parent_width, window.get_height()),
                 (0.0, grid_top as f64),
             );
-            window.show();
+            window.show(&mut self.draw_command_batcher);
         } else {
             let new_window = Window::new(
                 grid,
@@ -508,7 +529,7 @@ impl Editor {
                 Some(anchor_info),
                 (0.0, grid_top as f64),
                 (parent_width, 1),
-                Rc::clone(&self.draw_command_batcher),
+                &mut self.draw_command_batcher,
             );
             self.windows.insert(grid, new_window);
         }
@@ -632,7 +653,7 @@ impl Editor {
 
     fn redraw_screen(&mut self) {
         for window in self.windows.values() {
-            window.redraw();
+            window.redraw(&mut self.draw_command_batcher);
         }
     }
 

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -7,6 +7,7 @@ use crate::{
     bridge::GridLineCell,
     editor::{grid::CharacterGrid, style::Style, AnchorInfo, DrawCommand, DrawCommandBatcher},
     renderer::{box_drawing, LineFragment, WindowDrawCommand},
+    units::{GridRect, GridSize},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -274,13 +275,15 @@ impl Window {
     pub fn scroll_region(
         &mut self,
         batcher: &mut DrawCommandBatcher,
-        top: u64,
-        bottom: u64,
-        left: u64,
-        right: u64,
-        rows: i64,
-        cols: i64,
+        region: GridRect<u64>,
+        size: GridSize<i64>,
     ) {
+        let top = region.min.y;
+        let bottom = region.max.y;
+        let left = region.min.x;
+        let right = region.max.x;
+        let rows = size.height;
+        let cols = size.width;
         // Scrolls must move the data and send a WindowDrawCommand to move the rendered texture so
         // that future renders draw correctly
         let is_pure_updown = self.grid.scroll_region(


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Refactor the code to pass the `DrawCommandBatcher` around instead of relying on interior mutability. This makes it easier to extend it with new functionality and also gets rid of the overhead of reference counting.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
