### PR TITLE
feat: add an API for disabling redraw

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -137,4 +137,14 @@ M.private.dropfile = function(filename, tabs)
     }, {})
 end
 
+M.disable_redraw = function()
+    -- Wrap inside pcall to avoid errors if Neovide disconnects
+    pcall(rpcnotify, "neovide.set_redraw", false)
+end
+
+M.enable_redraw = function()
+    -- Wrap inside pcall to avoid errors if Neovide disconnects
+    pcall(rpcnotify, "neovide.set_redraw", true)
+end
+
 _G["neovide"] = M

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -305,6 +305,7 @@ pub enum RedrawEvent {
         entries: Vec<(MessageKind, StyledContent)>,
     },
     Suspend,
+    NeovideSetRedraw(bool),
 }
 
 fn unpack_color(packed_color: u64) -> Color4f {

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -128,6 +128,12 @@ impl Handler for NeovimHandler {
             "neovide.exec_detach_handler" => {
                 send_ui(ParallelCommand::Quit);
             }
+            "neovide.set_redraw" => {
+                if let Some(value) = arguments.first() {
+                    let value = value.as_bool().unwrap_or(true);
+                    let _ = self.sender.send(RedrawEvent::NeovideSetRedraw(value));
+                }
+            }
             _ => {}
         }
     }

--- a/src/editor/draw_command_batcher.rs
+++ b/src/editor/draw_command_batcher.rs
@@ -4,18 +4,39 @@ use winit::event_loop::EventLoopProxy;
 
 pub struct DrawCommandBatcher {
     batch: Vec<DrawCommand>,
+    enabled: bool,
+    queued: Vec<Vec<DrawCommand>>,
 }
 
 impl DrawCommandBatcher {
     pub fn new() -> DrawCommandBatcher {
-        Self { batch: Vec::new() }
+        Self {
+            batch: Vec::new(),
+            enabled: true,
+            queued: Vec::new(),
+        }
     }
 
     pub fn queue(&mut self, draw_command: DrawCommand) {
         self.batch.push(draw_command);
     }
 
+    pub fn set_enabled(&mut self, enabled: bool, proxy: &EventLoopProxy<UserEvent>) {
+        log::info!("Set redraw {enabled}");
+        if enabled && !self.enabled {
+            for queued in self.queued.drain(..) {
+                proxy.send_event(queued.into()).ok();
+            }
+        }
+        self.enabled = enabled;
+    }
+
     pub fn send_batch(&mut self, proxy: &EventLoopProxy<UserEvent>) {
-        proxy.send_event(self.batch.split_off(0).into()).ok();
+        let batch = self.batch.split_off(0);
+        if self.enabled {
+            proxy.send_event(batch.into()).ok();
+        } else {
+            self.queued.push(batch);
+        }
     }
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -363,6 +363,9 @@ impl Editor {
                     .event_loop_proxy
                     .send_event(WindowCommand::Minimize.into());
             }
+            RedrawEvent::NeovideSetRedraw(enable) => self
+                .draw_command_batcher
+                .set_enabled(enable, &self.event_loop_proxy),
             _ => {}
         };
     }

--- a/website/docs/SUMMARY.md
+++ b/website/docs/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Commands](commands.md)
 - [Command Line Reference](command-line-reference.md)
 - [Config File](config-file.md)
+- [API](api.md)
 - [Integration w/ External Tools](integration-with-external-tools.md)
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -1,0 +1,41 @@
+# API
+
+The API fuctions are always available without any imports as long as Neovide is connected.
+
+## Redraw Control
+
+`neovide.disable_redraw()`
+`neovide.enable_redraw()`
+
+These can be used to by plugins to temporarily disable redrawing while performing some update. They
+can for exapmple, be used to prevent the cursor from temporarily moving to the wrong location, or to
+atomically spawn a group of windows together. The animations are still updated even when the
+re-drawing is disabled, but no new updates from Neovim will be visible.
+
+This is a temporary API, until support for this has been added natively to Neovim.
+
+It's recommended to use the following pattern with `pcall` to ensure that `enable_redraw()` is
+always called even when there are errors. And also checking for the existence of the functions.
+
+```lua
+if neovide and neovide.disable_redraw then neovide.disable_redraw() end
+local success, ret = pcall(actual_function_that_does_something, param1, param2)
+if neovide and neovide.enable_redraw then neovide.enable_redraw() end
+if success then
+    -- do something with the result
+else
+    -- propagate the error (or ignore it)
+    error(ret)
+end
+```
+
+Or if you don't care about the result
+
+```lua
+if neovide and neovide.disable_redraw then neovide.disable_redraw() end
+pcall(actual_function_that_does_something, param1, param2)
+if neovide and neovide.enable_redraw then neovide.enable_redraw() end
+```
+
+**Don't call these functions as a regular user, since you won't see any updates on the screen until
+the redrawing is enabled again, so it might be hard to type in the command.**


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Some plugins like blink.cmp (see https://github.com/Saghen/blink.cmp/issues/1247), is causing the cursor to flicker due lack of APIs on the Neovim side to support it completely. A temporary solution on the Neovide side is therefore implemented, which makes it possible to disable the redrawing and then re-enable it again.

The disabling is done by buffering on the editor side until it's re-enabled and sent to the renderer. All animations keep working even when the redraw is disabled.

Corresponding PR on the blink.cmp side https://github.com/Saghen/blink.cmp/pull/1582

## Did this PR introduce a breaking change? 
- No
