### PR TITLE
fix(renderer): use saturating_sub for safer arithmetic in

### DIFF
--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -496,7 +496,7 @@ impl RenderedWindow {
         if scroll_delta != 0 {
             let mut scroll_offset = self.scroll_animation.position;
 
-            let max_delta = self.scrollback_lines.len() - self.grid_size.height as usize;
+            let max_delta = self.scrollback_lines.len().saturating_sub(self.grid_size.height as usize);
             log::trace!(
                 "Scroll offset {scroll_offset}, delta {scroll_delta}, max_delta {max_delta}"
             );


### PR DESCRIPTION
rendered_window.rs
Neovide panics on Windows when the scrollback buffer has fewer lines than the window height. The subtraction


let max_delta = self.scrollback_lines.len() - self.grid_size.height as usize;
underflows when self.scrollback_lines.len() < self.grid_size.height as usize, causing:

Neovide panicked with the message 'attempt to subtract with overflow'. (File: src\renderer\rendered_window.rs; Line: 499, Column: 29)
This is a bug and we would love for it to be reported to https://github.com/neovide/neovide/issues
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace

Steps to Reproduce
Launch Neovide on Windows with a fresh session.

Ensure the terminal buffer has fewer lines than the window height (e.g. start Neovide and do nothing).

Scroll up (e.g. with the mouse wheel or <C-y>).

Observe the panic.



## What kind of change does this PR introduce?
- Fix


## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._

No
