### PR TITLE
Check for window focus when showing or hiding cursor

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -391,7 +391,7 @@ impl MouseManager {
                     (position.x as f32, position.y as f32).into(),
                     &editor_state,
                 );
-                if self.mouse_hidden {
+                if self.mouse_hidden && window.has_focus() {
                     window.set_cursor_visible(true);
                     self.mouse_hidden = false;
                 }
@@ -427,7 +427,7 @@ impl MouseManager {
             } => {
                 if key_event.state == ElementState::Pressed {
                     let window_settings = self.settings.get::<WindowSettings>();
-                    if window_settings.hide_mouse_when_typing && !self.mouse_hidden {
+                    if window_settings.hide_mouse_when_typing && !self.mouse_hidden && window.has_focus() {
                         window.set_cursor_visible(false);
                         self.mouse_hidden = true;
                     }


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR checks for window focus when showing/hiding the cursor to address the bug described in #2414.

## Testing
- successful local build and install on macOS 14.6.1
- verified cursor went hidden when typing in neovide window
- verified cursor stayed visible when opening iterm window via hotkey and tabbing back
- verified cursor stayed visible when tabbing to different window and tabbing back

## Did this PR introduce a breaking change? 
- No
