### PR TITLE
fix: correct command-line animation logic

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -455,7 +455,7 @@ impl CursorRenderer {
 
         if center_destination != PixelPos::ZERO {
             let immediate_movement = !settings.animate_in_insert_mode && in_insert_mode
-                || !settings.animate_command_line && !changed_to_from_cmdline;
+                || !settings.animate_command_line && changed_to_from_cmdline;
             if self.jumped {
                 // Caclculate the direction alignment for each corner and generate a sorted list
                 // This way we know which corner is the front and which is the back


### PR DESCRIPTION
🤖: The original logic with `!changed_to_from_cmdline` caused command-line animations to persist even when `animate_command_line` was disabled, because it only applied the setting when *not* transitioning to/from command-line mode.

> [!NOTE]
>
> It seems that even after this change, the animation to/from cmdline is still
> inconsistent, sometimes it exists sometimes not.


https://github.com/user-attachments/assets/91af4624-9a9a-4707-900e-c101d565dd76

