### PR TITLE
fix: calculate grid_size everytime to avoid random blank lines appearing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ pub use channel_utils::*;
 #[cfg(target_os = "windows")]
 pub use windows_utils::*;
 
-use crate::settings::{load_last_window_settings, Config, PersistentWindowSettings, Settings};
+use crate::settings::{load_last_window_settings, Config, Settings};
 
 pub use profiling::startup_profiler;
 
@@ -244,16 +244,20 @@ fn setup(
 
     let window_settings = load_last_window_settings().ok();
     let window_size = determine_window_size(window_settings.as_ref(), &settings);
-    let grid_size = match window_size {
-        WindowSize::Grid(grid_size) => Some(grid_size),
-        // Clippy wrongly suggests to use unwrap or default here
-        #[allow(clippy::manual_unwrap_or_default)]
-        _ => match window_settings {
-            Some(PersistentWindowSettings::Maximized { grid_size, .. }) => grid_size,
-            Some(PersistentWindowSettings::Windowed { grid_size, .. }) => grid_size,
-            _ => None,
-        },
-    };
+    // let grid_size = match window_size {
+    //     WindowSize::Grid(grid_size) => Some(grid_size),
+    //     // Clippy wrongly suggests to use unwrap or default here
+    //     #[allow(clippy::manual_unwrap_or_default)]
+    //     _ => match window_settings {
+    //         Some(PersistentWindowSettings::Maximized { grid_size, .. }) => grid_size,
+    //         Some(PersistentWindowSettings::Windowed { grid_size, .. }) => grid_size,
+    //         _ => None,
+    //     },
+    // };
+
+    // let neovide calc grid_size manually every time to avoid blank lines
+    // issues#3150
+    let grid_size = None;
 
     let mut runtime = NeovimRuntime::new()?;
     runtime.launch(proxy, grid_size, running_tracker, settings)?;

--- a/src/settings/window_size.rs
+++ b/src/settings/window_size.rs
@@ -25,16 +25,16 @@ pub const MAX_GRID_SIZE: GridSize<u32> = GridSize {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PersistentWindowSettings {
     Maximized {
-        #[serde(default)]
-        grid_size: Option<GridSize<u32>>,
+        // #[serde(default)]
+        // grid_size: Option<GridSize<u32>>,
     },
     Windowed {
         #[serde(default)]
         position: PhysicalPosition<i32>,
         #[serde(default)]
         pixel_size: Option<PhysicalSize<u32>>,
-        #[serde(default)]
-        grid_size: Option<GridSize<u32>>,
+        // #[serde(default)]
+        // grid_size: Option<GridSize<u32>>,
     },
 }
 
@@ -86,12 +86,12 @@ pub fn save_window_size(window_wrapper: &WinitWindowWrapper, settings: &Settings
     let settings = PersistentSettings {
         window: if maximized && window_settings.remember_window_size {
             PersistentWindowSettings::Maximized {
-                grid_size: { window_settings.remember_window_size.then_some(grid_size) },
+                // grid_size: { window_settings.remember_window_size.then_some(grid_size) },
             }
         } else {
             PersistentWindowSettings::Windowed {
                 pixel_size: { window_settings.remember_window_size.then_some(pixel_size) },
-                grid_size: { window_settings.remember_window_size.then_some(grid_size) },
+                // grid_size: { window_settings.remember_window_size.then_some(grid_size) },
                 position: {
                     window_settings
                         .remember_window_position


### PR DESCRIPTION
## What kind of change does this PR introduce?

This pr makes Neovide calculate grid_size everytime when user run the program.

fix the problem described in
https://github.com/neovide/neovide/issues/3150

## Did this PR introduce a breaking change? 

It removes the `grid_size` option in `neovide-settings.json` file
