### PR TITLE
fix: publishing to crates-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "neovide-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "convert_case",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ indoc = "2.0.5"
 itertools = "0.14.0"
 log = "0.4.22"
 lru = "0.13.0"
-neovide-derive = { path = "neovide-derive", version = "0.1.2" }
+neovide-derive = { path = "neovide-derive", version = "0.1.3" }
 num = "0.4.3"
 nvim-rs = { version = "0.9.2", features = ["use_tokio"] }
 parking_lot = "0.12.3"

--- a/neovide-derive/Cargo.toml
+++ b/neovide-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neovide-derive"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "Derive macros for the Neovide gui"

--- a/website/docs/maintainer-cookbook.md
+++ b/website/docs/maintainer-cookbook.md
@@ -106,9 +106,12 @@ Now here's where the order becomes important:
   Cargo.lock` to make sure releases stay reproducible
   ([#1628](https://github.com/neovide/neovide/issues/1628),
   [#1482](https://github.com/neovide/neovide/issues/1482))**
-6. Create a commit called `Bump version to $tag`
-7. Push and wait for CI to complete (will take around 25 minutes)
-8. Run `cargo build --frozen`
+6. Check that `cargo publish --workspace --dry-run` works
+   If necessary, you might have to bump the version number for the
+   `neovide-derive` crate as well.
+7. Create a commit called `Bump version to $tag`
+8. Push and wait for CI to complete (will take around 25 minutes)
+9. Run `cargo build --frozen`
 
 In the meantime, you can look through the previous commits to see if you missed
 anything.
@@ -125,6 +128,8 @@ anything.
     the unzipped versions if listed above)
 4. Hit `Publish release`
 5. profit
+6. Publish `neovide-derive` to crates.io if necessary `cargo publish -p neovide-derive`
+7. Publish `neovide` to crates.io `cargo publish -p neovide`
 
 Phew. Now, announce the new release anywhere you think is appropriate (like
 Reddit, Discord, whatever) ~~and go create a PR in nixpkgs~~.


### PR DESCRIPTION
Bump the `neovide-derive` version number. 
Add instructions
