### PR TITLE
Fix/mac window focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,6 +1446,7 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "objc2-metal",
  "objc2-quartz-core",
+ "once_cell",
  "parking_lot",
  "rand 0.9.1",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ winit = { version = "=0.30.9", features = ["serde"] }
 xdg = "2.5.2"
 notify-debouncer-full = "0.5.0"
 regex = "1.11.1"
+once_cell = "1.21.3"
 
 [dev-dependencies]
 scoped-env = "2.1.0"

--- a/src/window/macos.rs
+++ b/src/window/macos.rs
@@ -15,6 +15,8 @@ use objc2_foundation::{
     ns_string, MainThreadMarker, NSArray, NSData, NSDictionary, NSObject, NSPoint, NSProcessInfo,
     NSRect, NSSize, NSString, NSUserDefaults,
 };
+use once_cell::unsync::OnceCell;
+pub static mut WINDOW_FEATURE: OnceCell<MacosWindowFeature> = OnceCell::new();
 
 use csscolorparser::Color;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -40,7 +40,7 @@ use {
 };
 
 #[cfg(target_os = "macos")]
-use super::macos::MacosWindowFeature;
+use super::macos::{MacosWindowFeature, WINDOW_FEATURE};
 
 const GRID_TOLERANCE: f32 = 1e-3;
 
@@ -509,10 +509,12 @@ impl WinitWindowWrapper {
         // It's important that this is created before the window is resized, since it can change the padding and affect the size
         #[cfg(target_os = "macos")]
         {
-            self.macos_feature = Some(MacosWindowFeature::from_winit_window(
-                window,
-                self.settings.clone(),
-            ));
+            let feature = MacosWindowFeature::from_winit_window(window, self.settings.clone());
+            WINDOW_FEATURE.with(|cell| {
+                cell.set(feature.clone())
+                    .expect("WINDOW_FEATURE already set");
+            });
+            self.macos_feature = Some(feature);
         }
 
         let scale_factor = window.scale_factor();


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No

## Previous Behaviour
- On Mac
- Open file with Neovide from a different desktop will **not** focus you on Neovide's window
- You will remain on your old desktop

https://github.com/user-attachments/assets/5654be91-b34b-495b-a332-ce8bef73e15d

## New Behaviour
- Your are moved to Neovide's active desktop

https://github.com/user-attachments/assets/4b32eb32-ef7c-47e9-aebe-92ebeb344f25

## Notes:
- I have absolutely no idea what I'm doing in Rust :D :P