### PR TITLE
Fix: drag events outside window

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -122,9 +122,6 @@ impl MouseManager {
         let window_size = editor_state.window.inner_size();
         let window_size = PixelSize::new(window_size.width as f32, window_size.height as f32);
         let relative_window_rect = PixelRect::from_size(window_size);
-        if !relative_window_rect.contains(&position) {
-            return;
-        }
 
         self.window_position = position;
 
@@ -136,6 +133,10 @@ impl MouseManager {
                 .iter()
                 .find(|details| details.id == drag_details.draw_details.id)
         } else {
+            if !relative_window_rect.contains(&position) {
+                return;
+            }
+
             self.get_window_details_under_mouse(editor_state)
         };
 


### PR DESCRIPTION
Allow mouse drags to continue even when the mouse has left the bounds of the window

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

Fixes https://github.com/neovide/neovide/issues/3198
