### PR TITLE
fix: Remove unimplemented theme setting from the config file

### DIFF
--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -54,7 +54,6 @@ pub struct Config {
     pub no_multigrid: Option<bool>,
     pub srgb: Option<bool>,
     pub tabs: Option<bool>,
-    pub theme: Option<String>,
     pub mouse_cursor_icon: Option<String>,
     pub title_hidden: Option<bool>,
     pub vsync: Option<bool>,
@@ -112,9 +111,6 @@ impl Config {
         }
         if let Some(neovim_bin) = &self.neovim_bin {
             env::set_var("NEOVIM_BIN", neovim_bin.to_string_lossy().to_string());
-        }
-        if let Some(theme) = &self.theme {
-            env::set_var("NEOVIDE_THEME", theme);
         }
         if let Some(mouse_cursor_icon) = &self.mouse_cursor_icon {
             env::set_var("NEOVIDE_MOUSE_CURSOR_ICON", mouse_cursor_icon);

--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -39,7 +39,6 @@ neovim-bin = "/usr/bin/nvim" # in reality found dynamically on $PATH if unset
 no-multigrid = false
 srgb = false # platform-specific: false (Linux/macOS) or true (Windows)
 tabs = true
-theme = "auto"
 title-hidden = false
 vsync = true
 wsl = false


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The theme setting in the config file was never implemented and working on main and probably remained because the command-line support was removed from the original PR before it was merged. It probably worked before that because it relied on command-line functionality.

For more background information, see
* https://github.com/neovide/neovide/pull/1917

* fixes https://github.com/neovide/neovide/issues/3152

## Did this PR introduce a breaking change? 
- No
