### PR TITLE
Add Go and Rust to Info.plist

### DIFF
--- a/extra/osx/Neovide.app/Contents/Info.plist
+++ b/extra/osx/Neovide.app/Contents/Info.plist
@@ -1052,6 +1052,26 @@
       <key>CFBundleTypeRole</key>
       <string>Editor</string>
     </dict>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>go</string>
+      </array>
+      <key>CFBundleTypeName</key>
+      <string>Go Source File</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+    </dict>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>rs</string>
+      </array>
+      <key>CFBundleTypeName</key>
+      <string>Rust Source File</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+    </dict>
   </array>
   <key>UTExportedTypeDeclarations</key>
   <array>
@@ -2429,6 +2449,40 @@
         <key>public.filename-extension</key>
         <array>
           <string>vh</string>
+        </array>
+      </dict>
+    </dict>
+    <dict>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.plain-text</string>
+      </array>
+      <key>UTTypeDescription</key>
+      <string>Go Source File</string>
+      <key>UTTypeIdentifier</key>
+      <string>org.golang.go-script</string>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>go</string>
+        </array>
+      </dict>
+    </dict>
+    <dict>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.plain-text</string>
+      </array>
+      <key>UTTypeDescription</key>
+      <string>Rust Source File</string>
+      <key>UTTypeIdentifier</key>
+      <string>org.rust-lang.rust-script</string>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>rs</string>
         </array>
       </dict>
     </dict>


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Feature

## Did this PR introduce a breaking change? 
- No

This adds Go and Rust to the macOS Info.plist file so that Neovide can be set as the default editor for them.  I didn't see any particular ordering to the dicts in the file, so I just added these entries to the bottoms of each array.