### PR TITLE
chore: Improve the CI caching behaviour

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         run: cargo binstall -y cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
+        shared-key: test-and-clippy
         save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Test
@@ -114,6 +115,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         save-if: ${{ github.ref == 'refs/heads/master' }}
+        shared-key: test-and-clippy
 
       - name: Show toolchain info
         run: cargo --version --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         run: cargo binstall -y cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
+        save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Test
         env:
@@ -112,6 +113,7 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
+        save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Show toolchain info
         run: cargo --version --verbose
@@ -191,6 +193,7 @@ jobs:
           neovim: true
 
       - uses: Swatinem/rust-cache@v2
+        save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Build (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,9 @@ jobs:
         run: cargo binstall -y cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
-        shared-key: test-and-clippy
-        save-if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          shared-key: test-and-clippy
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Test
         env:
@@ -114,8 +115,9 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
-        save-if: ${{ github.ref == 'refs/heads/master' }}
-        shared-key: test-and-clippy
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          shared-key: test-and-clippy
 
       - name: Show toolchain info
         run: cargo --version --verbose
@@ -195,7 +197,8 @@ jobs:
           neovim: true
 
       - uses: Swatinem/rust-cache@v2
-        save-if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Build (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,12 @@ jobs:
       - name: Install Cargo Binstall
         uses: cargo-bins/cargo-binstall@main
 
+      # This is needed for building skia from source
+      - name: Setup github long path support (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          git config --system core.longpaths true
+
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: |
@@ -190,10 +196,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         env:
           RUSTFLAGS: "-Ctarget-feature=+crt-static" 
-        # The file paths are to long, so we need to vendor the dependencies
         run: |
-          mkdir .cargo
-          cargo vendor ../c > .cargo/config.toml
           cargo wix --nocapture --output target/release/neovide.msi --package neovide
 
       - name: Build (macOS)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
* Long paths are enabled for Git to allow Skia to build on windows without vendoring. And the result can therefore be cached
* Don't save caches on pull requests, we only have 10 GB available, and PRs can therefore evict the caches from main
  * Only pull requests that updates dependencies would benefit from this anyway. I think we can change this to save only when cargo.lock or cargo.toml has been changed.
* Share the clippy and test caches

NOTE: Caches of nightly builds does not work well, due to new caches being needed each time the toolchain is updated. To fix this we should run an automated build every night. And maybe even generated nightly releases.

## Did this PR introduce a breaking change? 
- No
