### PR TITLE
Fix the CI caching behaviour from #3226

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: test-and-clippy
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Test
         env:
@@ -116,7 +116,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-if: false
           shared-key: test-and-clippy
 
       - name: Show toolchain info
@@ -198,7 +198,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build (Windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
#3226 had a couple of issues which are fixed here
1. It used `master` as ref instead of `main`. 
2. The cache was marked for saving for clippy, while only the test step should save

## Did this PR introduce a breaking change? 
- No
