### PR TITLE
fix: Use the Neovim grid clustering rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,6 @@ dependencies = [
  "tokio-util",
  "toml 0.9.5",
  "tracy-client-sys",
- "unicode-segmentation",
  "uzers",
  "windows",
  "windows-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ tracy-client-sys = { version = "0.26.1", optional = true, default-features = fal
     "manual-lifetime",
     "fibers",
 ] }
-unicode-segmentation = "1.12.0"
 winit = { version = "=0.30.12", features = ["serde"] }
 xdg = "3.0.0"
 

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -213,8 +213,7 @@ impl Window {
 
         let line_fragment = LineFragment {
             text: text_range,
-            window_left: start as u64,
-            width: width as u64,
+            cells: start as u32..(start + width) as u32,
             style: style.clone(),
         };
 

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -197,33 +197,30 @@ impl Window {
 
             width += 1;
 
-            if cluster.is_empty() && !current_word.cells.is_empty() {
-                current_word.cells.end += 1;
-            }
             let is_whitespace = cluster
                 .chars()
                 .next()
                 .is_some_and(|char| char.is_whitespace());
             if is_whitespace {
-                if !current_word.cells.is_empty() {
+                if !current_word.cluster_sizes.is_empty() {
                     // Finish the current word
                     words.push(current_word);
                     current_word = Word::default();
                 }
-            } else if current_word.cells.is_empty() {
+            } else if current_word.cluster_sizes.is_empty() {
                 // Properly initialize a new word
-                current_word.cells = width - 1..width;
-                current_word.text = text.len() as u32..text.len() as u32 + cluster.len() as u32;
+                current_word.cell = width - 1;
+                current_word.cluster_sizes.push(cluster.len() as u8);
+                current_word.text = text.len() as u32;
             } else {
-                current_word.cells.end += 1;
-                current_word.text.end += cluster.len() as u32;
+                current_word.cluster_sizes.push(cluster.len() as u8);
             }
 
             // Add the grid cell to the cells to render.
             text.push_str(cluster);
             text_range.end += cluster.len() as u32;
         }
-        if !current_word.cells.is_empty() {
+        if !current_word.cluster_sizes.is_empty() {
             words.push(current_word);
         }
 

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
 use log::warn;
-use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     bridge::GridLineCell,
@@ -131,31 +130,25 @@ impl Window {
             None => previous_style.clone(),
         };
 
-        // Compute text.
-        let mut text = cell.text;
+        let text = cell.text;
         if let Some(times) = cell.repeat {
             // Repeats of zero times should be ignored, they are mostly useful for terminal Neovim
             // to distinguish between empty lines and lines ending with spaces.
             if times == 0 {
                 return;
             }
-            text = text.repeat(times as usize);
-        }
 
-        // Insert the contents of the cell into the grid.
-        if text.is_empty() {
-            if let Some(cell) = self.grid.get_cell_mut(*column_pos, row_index) {
-                *cell = (text, style.clone());
-            }
-            *column_pos += 1;
-        } else {
-            for character in text.graphemes(true) {
+            for _ in 0..times.saturating_sub(1) {
                 if let Some(cell) = self.grid.get_cell_mut(*column_pos, row_index) {
-                    *cell = (character.to_string(), style.clone());
+                    *cell = (text.clone(), style.clone());
                 }
                 *column_pos += 1;
             }
+        };
+        if let Some(cell) = self.grid.get_cell_mut(*column_pos, row_index) {
+            *cell = (text, style.clone());
         }
+        *column_pos += 1;
 
         *previous_style = style;
     }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -197,6 +197,15 @@ impl Window {
 
             width += 1;
 
+            if cluster.is_empty() {
+                // For double-width char, the empty cell should be part of the current word as a 0 cluster size
+                // Or ignored when it's part of whitespace
+                if !current_word.cluster_sizes.is_empty() {
+                    current_word.cluster_sizes.push(0);
+                }
+                continue;
+            }
+
             let is_whitespace = cluster
                 .chars()
                 .next()

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -6,7 +6,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::{
     bridge::GridLineCell,
     editor::{grid::CharacterGrid, style::Style, AnchorInfo, DrawCommand, DrawCommandBatcher},
-    renderer::{box_drawing, LineFragment, WindowDrawCommand},
+    renderer::{box_drawing, Line, LineFragment, WindowDrawCommand},
     units::{GridRect, GridSize},
 };
 
@@ -225,13 +225,10 @@ impl Window {
             current_start = next_start;
             line_fragments.push(line_fragment);
         }
-        self.send_command(
-            batcher,
-            WindowDrawCommand::DrawLine {
-                row,
-                line_fragments,
-            },
-        );
+        let line = Line {
+            fragments: line_fragments,
+        };
+        self.send_command(batcher, WindowDrawCommand::DrawLine { row, line });
     }
 
     pub fn draw_grid_line(

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -253,17 +253,7 @@ impl Window {
                 );
             }
 
-            // Due to the limitations of the current rendering strategy, some underlines get
-            // clipped by the line below. To mitigate that, we redraw the adjacent lines whenever
-            // an individual line is redrawn. Unfortunately, some clipping still happens.
-            // TODO: figure out how to solve this
-            if row < self.grid.height - 1 {
-                self.redraw_line(batcher, row + 1);
-            }
             self.redraw_line(batcher, row);
-            if row > 0 {
-                self.redraw_line(batcher, row - 1);
-            }
         } else {
             warn!("Draw command out of bounds");
         }

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -393,7 +393,7 @@ impl CursorRenderer {
         );
         if !box_char_drawn {
             let pos = (self.destination.x, self.destination.y + baseline_offset);
-            let blobs = &grid_renderer.shaper.shape_cached(character, coarse_style);
+            let blobs = &grid_renderer.shaper.shape_cached(&character, coarse_style);
             for blob in blobs.iter() {
                 canvas.draw_text_blob(blob, pos, &paint);
             }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -372,7 +372,7 @@ impl CachingShaper {
         set_font_cache_limit(FONT_CACHE_SIZE);
     }
 
-    pub fn shape(&mut self, text: String, style: CoarseStyle) -> Vec<TextBlob> {
+    pub fn shape(&mut self, text: &str, style: CoarseStyle) -> Vec<TextBlob> {
         let current_size = self.current_size();
         let glyph_width = self.font_base_dimensions().width;
 
@@ -380,7 +380,7 @@ impl CachingShaper {
 
         trace!("Shaping text: {text:?}");
 
-        for (cluster_group, font_pair) in self.build_clusters(&text, style) {
+        for (cluster_group, font_pair) in self.build_clusters(text, style) {
             let features = self.get_font_features(
                 font_pair
                     .as_ref()
@@ -435,9 +435,9 @@ impl CachingShaper {
         resulting_blobs
     }
 
-    pub fn shape_cached(&mut self, text: String, style: CoarseStyle) -> &Vec<TextBlob> {
+    pub fn shape_cached(&mut self, text: &str, style: CoarseStyle) -> &Vec<TextBlob> {
         tracy_zone!("shape_cached");
-        let key = ShapeKey::new(text.clone(), style);
+        let key = ShapeKey::new(text.to_string(), style);
 
         if !self.blob_cache.contains(&key) {
             let blobs = self.shape(text, style);

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -375,9 +375,6 @@ impl CachingShaper {
 
         let mut resulting_blobs = Vec::new();
 
-        let text = word.text();
-        trace!("Shaping text: {text:?}");
-
         for (cluster_group, font_pair) in self.build_clusters(word, style) {
             let features = self.get_font_features(
                 font_pair
@@ -439,6 +436,7 @@ impl CachingShaper {
         let key = ShapeKey::new(text.to_string(), style);
 
         if !self.blob_cache.contains(&key) {
+            trace!("Shaping text: {text:?}");
             let blobs = self.shape(word, style);
             self.blob_cache.put(key.clone(), blobs);
         }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -17,7 +17,10 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::{
     error_msg,
     profiling::tracy_zone,
-    renderer::fonts::{font_loader::*, font_options::*},
+    renderer::{
+        fonts::{font_loader::*, font_options::*},
+        RenderedWord,
+    },
     units::PixelSize,
 };
 
@@ -435,8 +438,13 @@ impl CachingShaper {
         resulting_blobs
     }
 
-    pub fn shape_cached(&mut self, text: &str, style: CoarseStyle) -> &Vec<TextBlob> {
+    pub fn shape_cached<'a>(
+        &mut self,
+        word: RenderedWord<'a>,
+        style: CoarseStyle,
+    ) -> &Vec<TextBlob> {
         tracy_zone!("shape_cached");
+        let text = word.text();
         let key = ShapeKey::new(text.to_string(), style);
 
         if !self.blob_cache.contains(&key) {

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -12,7 +12,6 @@ use swash::{
     },
     Metrics,
 };
-use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     error_msg,
@@ -238,31 +237,26 @@ impl CachingShaper {
 
     fn build_clusters(
         &mut self,
-        text: &str,
+        word: RenderedWord<'_>,
         style: CoarseStyle,
     ) -> Vec<(Vec<CharCluster>, Arc<FontPair>)> {
         let mut cluster = CharCluster::new();
 
         // Enumerate the characters storing the glyph index in the user data so that we can position
         // glyphs according to Neovim's grid rules
-        let mut character_index = 0;
         let mut parser = Parser::new(
             Script::Latin,
-            text.graphemes(true)
-                .enumerate()
-                .flat_map(|(glyph_index, unicode_segment)| {
-                    unicode_segment.chars().map(move |character| {
-                        let token = Token {
-                            ch: character,
-                            offset: character_index as u32,
-                            len: character.len_utf8() as u8,
-                            info: character.into(),
-                            data: glyph_index as u32,
-                        };
-                        character_index += 1;
-                        token
+            word.clusters().flat_map(|(cell_index, cluster)| {
+                cluster
+                    .char_indices()
+                    .map(move |(offset, character)| Token {
+                        ch: character,
+                        offset: offset as u32,
+                        len: character.len_utf8() as u8,
+                        info: character.into(),
+                        data: cell_index as u32,
                     })
-                }),
+            }),
         );
 
         let mut results = Vec::new();
@@ -375,15 +369,16 @@ impl CachingShaper {
         set_font_cache_limit(FONT_CACHE_SIZE);
     }
 
-    pub fn shape(&mut self, text: &str, style: CoarseStyle) -> Vec<TextBlob> {
+    pub fn shape(&mut self, word: RenderedWord<'_>, style: CoarseStyle) -> Vec<TextBlob> {
         let current_size = self.current_size();
         let glyph_width = self.font_base_dimensions().width;
 
         let mut resulting_blobs = Vec::new();
 
+        let text = word.text();
         trace!("Shaping text: {text:?}");
 
-        for (cluster_group, font_pair) in self.build_clusters(text, style) {
+        for (cluster_group, font_pair) in self.build_clusters(word, style) {
             let features = self.get_font_features(
                 font_pair
                     .as_ref()
@@ -438,17 +433,13 @@ impl CachingShaper {
         resulting_blobs
     }
 
-    pub fn shape_cached<'a>(
-        &mut self,
-        word: RenderedWord<'a>,
-        style: CoarseStyle,
-    ) -> &Vec<TextBlob> {
+    pub fn shape_cached(&mut self, word: RenderedWord<'_>, style: CoarseStyle) -> &Vec<TextBlob> {
         tracy_zone!("shape_cached");
         let text = word.text();
         let key = ShapeKey::new(text.to_string(), style);
 
         if !self.blob_cache.contains(&key) {
-            let blobs = self.shape(text, style);
+            let blobs = self.shape(word, style);
             self.blob_cache.put(key.clone(), blobs);
         }
 

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -8,7 +8,7 @@ use crate::{
     profiling::tracy_zone,
     renderer::{
         box_drawing::{self},
-        CachingShaper, LineFragment, RendererSettings,
+        CachingShaper, LineFragment, RenderedWord, RendererSettings,
     },
     settings::*,
     units::{
@@ -245,12 +245,15 @@ impl GridRenderer {
             }
             for word in &fragment.words {
                 let adjustment = PixelVec::new(
-                    word.cells.start as f32 * self.grid_scale.width(),
+                    word.cell as f32 * self.grid_scale.width(),
                     self.shaper.baseline_offset(),
                 );
-                let word_text = &line_text[word.text.start as usize..word.text.end as usize];
 
-                for blob in self.shaper.shape_cached(word_text, style.into()).iter() {
+                for blob in self
+                    .shaper
+                    .shape_cached(RenderedWord::new(word, line_text), style.into())
+                    .iter()
+                {
                     tracy_zone!("draw_text_blob");
                     text_canvas.draw_text_blob(
                         blob,

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    ops::Range,
-};
+use std::{ops::Range, sync::Arc};
 
 use log::trace;
 use skia_safe::{colors, dash_path_effect, BlendMode, Canvas, Color, Paint, Path, HSV};
@@ -222,32 +219,12 @@ impl GridRenderer {
         ) {
             return (text_drawn, true);
         } else if !text.is_empty() {
-            let mut paint = Paint::default();
-            paint.set_anti_alias(false);
-            paint.set_blend_mode(BlendMode::SrcOver);
             text_canvas.save();
 
             // We don't want to clip text in the x position, only the y so we add a buffer of 1
             // character on either side of the region so that we clip vertically but not horizontally.
             let wider_cells = cells.start.saturating_sub(1)..cells.end + 1;
             let clip_region = self.compute_text_region(&wider_cells);
-
-            if self.settings.get::<RendererSettings>().debug_renderer {
-                let random_hsv: HSV = (rand::random::<f32>() * 360.0, 1.0, 1.0).into();
-                let random_color = random_hsv.to_color(255);
-                paint.set_color(random_color);
-            } else {
-                paint.set_color(style.foreground(&self.default_style.colors).to_color());
-            }
-            paint.set_anti_alias(false);
-            if self.settings.get::<RendererSettings>().debug_renderer {
-                let random_hsv: HSV = (rand::random::<f32>() * 360.0, 1.0, 1.0).into();
-                let random_color = random_hsv.to_color(255);
-                paint.set_color(random_color);
-            } else {
-                paint.set_color(style.foreground(&self.default_style.colors).to_color());
-            }
-            paint.set_anti_alias(false);
             text_canvas.clip_rect(to_skia_rect(&clip_region), None, Some(false));
 
             let mut paint = Paint::default();
@@ -261,7 +238,6 @@ impl GridRenderer {
             } else {
                 paint.set_color(style.foreground(&self.default_style.colors).to_color());
             }
-            paint.set_anti_alias(false);
             // There's a lot of overhead for empty blobs in Skia, for some reason they never hit the
             // cache, so trim all the spaces
             let trimmed = text.trim_start();

--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -274,11 +274,7 @@ impl GridRenderer {
                 self.shaper.baseline_offset(),
             );
 
-            for blob in self
-                .shaper
-                .shape_cached(trimmed.to_string(), style.into())
-                .iter()
-            {
+            for blob in self.shaper.shape_cached(trimmed, style.into()).iter() {
                 tracy_zone!("draw_text_blob");
                 text_canvas.draw_text_blob(blob, to_skia_point(pos + adjustment), &paint);
                 text_drawn = true;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -59,7 +59,7 @@ use cursor_renderer::CursorRenderer;
 pub use fonts::caching_shaper::CachingShaper;
 pub use grid_renderer::GridRenderer;
 pub use rendered_window::{
-    Line, LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails, Word,
+    Line, LineFragment, RenderedWindow, RenderedWord, WindowDrawCommand, WindowDrawDetails, Word,
 };
 
 pub use vsync::VSync;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -58,7 +58,9 @@ use crate::profiling::GpuCtx;
 use cursor_renderer::CursorRenderer;
 pub use fonts::caching_shaper::CachingShaper;
 pub use grid_renderer::GridRenderer;
-pub use rendered_window::{LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails};
+pub use rendered_window::{
+    Line, LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails,
+};
 
 pub use vsync::VSync;
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -134,7 +134,7 @@ impl Default for RendererSettings {
 // window) are sorted as larger than the ones that should be handled later
 // So the order of the variants here matters so that the derive implementation can get
 // the order in the binary heap correct
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum DrawCommand {
     UpdateCursor(Cursor),
     FontChanged(String),

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -59,7 +59,7 @@ use cursor_renderer::CursorRenderer;
 pub use fonts::caching_shaper::CachingShaper;
 pub use grid_renderer::GridRenderer;
 pub use rendered_window::{
-    Line, LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails,
+    Line, LineFragment, RenderedWindow, WindowDrawCommand, WindowDrawDetails, Word,
 };
 
 pub use vsync::VSync;

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -29,8 +29,25 @@ pub struct LineFragment {
 
 #[derive(Debug, Default)]
 pub struct Word {
-    pub text: Range<u32>,
-    pub cells: Range<u32>,
+    pub text: u32,
+    pub cell: u32,
+    pub cluster_sizes: Vec<u8>,
+}
+
+pub struct RenderedWord<'a> {
+    text: &'a str,
+    word: &'a Word,
+}
+
+impl<'a> RenderedWord<'a> {
+    pub fn new(word: &'a Word, text: &'a str) -> Self {
+        Self { text, word }
+    }
+
+    pub fn text(&self) -> &str {
+        let size: usize = self.word.cluster_sizes.iter().map(|v| *v as usize).sum();
+        &self.text[self.word.text as usize..self.word.text as usize + size]
+    }
 }
 
 #[derive(Debug)]

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -22,8 +22,7 @@ pub struct Line {
 #[derive(Debug)]
 pub struct LineFragment {
     pub text: Range<u32>,
-    pub window_left: u64,
-    pub width: u64,
+    pub cells: Range<u32>,
     pub style: Option<Arc<Style>>,
 }
 
@@ -645,16 +644,13 @@ impl RenderedWindow {
 
             for line_fragment in line.line.fragments.iter() {
                 let LineFragment {
-                    window_left,
-                    width,
+                    cells,
                     style,
                     ..
                 } = line_fragment;
-                let grid_position = (i32::try_from(*window_left).unwrap(), 0).into();
                 let background_info = grid_renderer.draw_background(
                     canvas,
-                    grid_position,
-                    i32::try_from(*width).unwrap(),
+                    cells,
                     style,
                     opacity,
                 );
@@ -673,19 +669,16 @@ impl RenderedWindow {
             for line_fragment in &line.line.fragments {
                 let LineFragment {
                     text,
-                    window_left,
-                    width,
+                    cells,
                     style,
                 } = line_fragment;
                 let text: Range<usize> = text.start as usize..text.end as usize;
-                let grid_position = (i32::try_from(*window_left).unwrap(), 0).into();
 
                 let (frag_text_drawn, frag_box_drawn) = grid_renderer.draw_foreground(
                     text_canvas,
                     boxchar_canvas,
                     &line.line.text[text],
-                    grid_position,
-                    i32::try_from(*width).unwrap(),
+                    cells,
                     style,
                     position,
                 );

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -14,6 +14,11 @@ use crate::{
 };
 
 #[derive(Debug)]
+pub struct Line {
+    pub fragments: Vec<LineFragment>,
+}
+
+#[derive(Debug)]
 pub struct LineFragment {
     pub text: String,
     pub window_left: u64,
@@ -37,7 +42,7 @@ pub enum WindowDrawCommand {
     },
     DrawLine {
         row: usize,
-        line_fragments: Vec<LineFragment>,
+        line: Line,
     },
     Scroll {
         top: u64,
@@ -64,7 +69,7 @@ pub enum WindowDrawCommand {
 }
 
 struct RenderedLine {
-    line_fragments: Vec<LineFragment>,
+    line: Line,
     background_picture: Option<Picture>,
     foreground_picture: Option<Picture>,
     boxchar_picture: Option<(Picture, PixelPos<f32>)>,
@@ -398,14 +403,11 @@ impl RenderedWindow {
                     self.grid_destination = grid_position;
                 }
             }
-            WindowDrawCommand::DrawLine {
-                row,
-                line_fragments,
-            } => {
+            WindowDrawCommand::DrawLine { row, line } => {
                 tracy_zone!("draw_line_cmd", 0);
 
                 let line = RenderedLine {
-                    line_fragments,
+                    line,
                     background_picture: None,
                     foreground_picture: None,
                     boxchar_picture: None,
@@ -640,7 +642,7 @@ impl RenderedWindow {
             let mut has_transparency = false;
             let mut custom_background = false;
 
-            for line_fragment in line.line_fragments.iter() {
+            for line_fragment in line.line.fragments.iter() {
                 let LineFragment {
                     window_left,
                     width,
@@ -667,7 +669,7 @@ impl RenderedWindow {
                 boxchar_recorder.begin_recording(grid_rect.with_offset((position.x, 0.0)), false);
             let mut text_drawn = false;
             let mut boxchar_drawn = false;
-            for line_fragment in &line.line_fragments {
+            for line_fragment in &line.line.fragments {
                 let LineFragment {
                     text,
                     window_left,

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -24,6 +24,13 @@ pub struct LineFragment {
     pub text: Range<u32>,
     pub cells: Range<u32>,
     pub style: Option<Arc<Style>>,
+    pub words: Vec<Word>,
+}
+
+#[derive(Debug, Default)]
+pub struct Word {
+    pub text: Range<u32>,
+    pub cells: Range<u32>,
 }
 
 #[derive(Debug)]
@@ -658,15 +665,11 @@ impl RenderedWindow {
             let mut text_drawn = false;
             let mut boxchar_drawn = false;
             for line_fragment in &line.line.fragments {
-                let LineFragment { text, cells, style } = line_fragment;
-                let text: Range<usize> = text.start as usize..text.end as usize;
-
                 let (frag_text_drawn, frag_box_drawn) = grid_renderer.draw_foreground(
                     text_canvas,
                     boxchar_canvas,
-                    &line.line.text[text],
-                    cells,
-                    style,
+                    &line.line.text,
+                    &line_fragment,
                     position,
                 );
                 text_drawn |= frag_text_drawn;

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -13,7 +13,7 @@ use crate::{
     utils::RingBuffer,
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LineFragment {
     pub text: String,
     pub window_left: u64,
@@ -21,13 +21,13 @@ pub struct LineFragment {
     pub style: Option<Arc<Style>>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ViewportMargins {
     pub top: u64,
     pub bottom: u64,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum WindowDrawCommand {
     Position {
         grid_position: (f64, f64),
@@ -63,7 +63,6 @@ pub enum WindowDrawCommand {
     SortOrder(SortOrder),
 }
 
-#[derive(Clone)]
 struct Line {
     line_fragments: Vec<LineFragment>,
     background_picture: Option<Picture>,

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -643,17 +643,8 @@ impl RenderedWindow {
             let mut custom_background = false;
 
             for line_fragment in line.line.fragments.iter() {
-                let LineFragment {
-                    cells,
-                    style,
-                    ..
-                } = line_fragment;
-                let background_info = grid_renderer.draw_background(
-                    canvas,
-                    cells,
-                    style,
-                    opacity,
-                );
+                let LineFragment { cells, style, .. } = line_fragment;
+                let background_info = grid_renderer.draw_background(canvas, cells, style, opacity);
                 custom_background |= background_info.custom_color;
                 has_transparency |= background_info.transparent;
             }
@@ -667,11 +658,7 @@ impl RenderedWindow {
             let mut text_drawn = false;
             let mut boxchar_drawn = false;
             for line_fragment in &line.line.fragments {
-                let LineFragment {
-                    text,
-                    cells,
-                    style,
-                } = line_fragment;
+                let LineFragment { text, cells, style } = line_fragment;
                 let text: Range<usize> = text.start as usize..text.end as usize;
 
                 let (frag_text_drawn, frag_box_drawn) = grid_renderer.draw_foreground(

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -48,6 +48,19 @@ impl<'a> RenderedWord<'a> {
         let size: usize = self.word.cluster_sizes.iter().map(|v| *v as usize).sum();
         &self.text[self.word.text as usize..self.word.text as usize + size]
     }
+
+    pub fn clusters(&self) -> impl Iterator<Item = (usize, &'a str)> + Clone {
+        self.word
+            .cluster_sizes
+            .iter()
+            .enumerate()
+            .filter(|(_, size)| **size > 0)
+            .scan(self.word.text, |current_pos, (cell_nr, size)| {
+                let start = *current_pos;
+                *current_pos += *size as u32;
+                Some((cell_nr, &self.text[start as usize..*current_pos as usize]))
+            })
+    }
 }
 
 #[derive(Debug)]
@@ -686,7 +699,7 @@ impl RenderedWindow {
                     text_canvas,
                     boxchar_canvas,
                     &line.line.text,
-                    &line_fragment,
+                    line_fragment,
                     position,
                 );
                 text_drawn |= frag_text_drawn;

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{cell::RefCell, ops::Range, rc::Rc, sync::Arc};
 
 use skia_safe::{Canvas, Color, Matrix, Picture, PictureRecorder, Rect};
 
@@ -15,12 +15,13 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Line {
+    pub text: String,
     pub fragments: Vec<LineFragment>,
 }
 
 #[derive(Debug)]
 pub struct LineFragment {
-    pub text: String,
+    pub text: Range<u32>,
     pub window_left: u64,
     pub width: u64,
     pub style: Option<Arc<Style>>,
@@ -676,12 +677,13 @@ impl RenderedWindow {
                     width,
                     style,
                 } = line_fragment;
+                let text: Range<usize> = text.start as usize..text.end as usize;
                 let grid_position = (i32::try_from(*window_left).unwrap(), 0).into();
 
                 let (frag_text_drawn, frag_box_drawn) = grid_renderer.draw_foreground(
                     text_canvas,
                     boxchar_canvas,
-                    text,
+                    &line.line.text[text],
                     grid_position,
                     i32::try_from(*width).unwrap(),
                     style,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -71,7 +71,7 @@ const MAX_PERSISTENT_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
     height: 8192,
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum WindowCommand {
     TitleChanged(String),
     SetMouseEnabled(bool),
@@ -86,7 +86,7 @@ pub enum WindowCommand {
     UnregisterRightClick,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum UserEvent {
     DrawCommandBatch(Vec<DrawCommand>),
     WindowCommand(WindowCommand),


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
This is mostly a refactoring, but it might fix some edge cases with double width and ambiwidth characters, where the Neovim and unicode segmentation views don't match.

Previously we did our own clustering using the Unicode segmentation crate. But Neovim already has its own clustering rules and single/double width character detection. These changes that information in use and removes the Unicode segmentation dependency. 

The word splitting is also done on the editor, rather than the rendering side, and word-based shaping cache is in use, instead of the style based one.

Some minor code cleanup has also been done.

This in itself does not fix many things, but it will allow us to adjust the size of the fallback fonts https://github.com/neovide/neovide/pull/3220 and fix some edge cases with the emoji rendering. It will also make it much easier to add support for more advanced text script systems and add bidi support.


## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
