### PR TITLE
Resolve relative paths earlier

### DIFF
--- a/src/ipc/handoff.rs
+++ b/src/ipc/handoff.rs
@@ -27,8 +27,8 @@ const LISTENER_POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub struct HandoffRequest {
     pub version: String,
     pub files_to_open: Vec<String>,
+    /// Directory to start nvim in, accounting for --chdir
     pub cwd: Option<String>,
-    pub caller_cwd: Option<String>,
     pub tabs: bool,
     pub new_window: bool,
     #[serde(default)]
@@ -44,7 +44,6 @@ impl HandoffRequest {
             version: BUILD_VERSION.to_owned(),
             files_to_open: Vec::new(),
             cwd: None,
-            caller_cwd: None,
             tabs: true,
             new_window: false,
             neovim_bin: None,
@@ -225,7 +224,6 @@ fn handle_request(
             payload: UserEvent::OpenFiles {
                 files: request.files_to_open,
                 cwd: request.cwd,
-                caller_cwd: request.caller_cwd,
                 tabs: request.tabs,
                 new_window: request.new_window,
                 neovim_bin: request.neovim_bin,
@@ -294,7 +292,6 @@ mod tests {
         assert_eq!(request.version, BUILD_VERSION);
         assert!(request.files_to_open.is_empty());
         assert!(request.cwd.is_none());
-        assert!(request.caller_cwd.is_none());
         assert!(request.tabs);
         assert!(!request.new_window);
     }
@@ -304,7 +301,6 @@ mod tests {
         let request = HandoffRequest {
             files_to_open: vec!["~/project".into()],
             cwd: Some("/path/to/user".into()),
-            caller_cwd: Some("/path/to/worktree".into()),
             tabs: false,
             new_window: true,
             ..HandoffRequest::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ use crate::{
 };
 
 #[cfg(target_os = "macos")]
-use crate::utils::resolved_cwd;
+use crate::utils::{resolve_relative_path, resolved_cwd};
 
 pub use profiling::startup_profiler;
 
@@ -316,11 +316,16 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
     let CmdLineSettings { files_to_open, tabs, new_window, neovim_bin, neovim_args, .. } =
         cmdline_settings;
 
+    let cwd = std::env::current_dir().ok();
+    let files_to_open = files_to_open
+        .into_iter()
+        .map(|path| resolve_relative_path(&path, cwd.as_deref()))
+        .collect();
+
     let request = ipc::handoff::HandoffRequest {
         version: BUILD_VERSION.to_owned(),
         files_to_open,
         cwd: resolved_cwd(cmd_line::argv_chdir().as_deref()),
-        caller_cwd: resolved_cwd(None),
         tabs,
         new_window,
         neovim_bin,

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -6,7 +6,6 @@ use std::{
 #[cfg(target_os = "macos")]
 use {
     crate::bridge::{OpenArgs, send_or_queue_file_drop, set_active_route_handler},
-    crate::utils::resolve_relative_path,
     std::path::Path,
 };
 
@@ -709,26 +708,9 @@ impl ApplicationHandler<EventPayload> for Application {
         match payload {
             UserEvent::ConfigsChanged(config) => self.handle_config_changed(target, *config),
             #[cfg(target_os = "macos")]
-            UserEvent::OpenFiles {
-                files,
-                cwd,
-                caller_cwd,
-                tabs,
-                new_window,
-                neovim_bin,
-                neovim_args,
-            } => {
+            UserEvent::OpenFiles { files, cwd, tabs, new_window, neovim_bin, neovim_args } => {
                 let cwd = cwd.as_deref().map(Path::new);
-                let caller_cwd = caller_cwd.as_deref().map(Path::new);
-                let open_args = OpenArgs {
-                    files_to_open: files
-                        .into_iter()
-                        .map(|path| resolve_relative_path(&path, caller_cwd))
-                        .collect(),
-                    tabs,
-                    neovim_bin,
-                    neovim_args,
-                };
+                let open_args = OpenArgs { files_to_open: files, tabs, neovim_bin, neovim_args };
 
                 self.prepare_open_files(event_loop, new_window, cwd, open_args);
             }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -136,7 +136,6 @@ pub enum UserEvent {
     OpenFiles {
         files: Vec<String>,
         cwd: Option<String>,
-        caller_cwd: Option<String>,
         tabs: bool,
         new_window: bool,
         neovim_bin: Option<String>,


### PR DESCRIPTION
This is a minor cleanup PR. It removes `caller_cwd` from the handoff message. It is only used to resolve filenames before giving them to nvim, but there's no reason to do that; we can just resolve the paths in the calling process.


## What kind of change does this PR introduce?
- Codestyle

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
