### PR TITLE
fix: surface startup errors before first grid - 0.12+ only

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -71,7 +71,7 @@ pub struct GridLineCell {
 
 pub type StyledContent = Vec<(u64, String)>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MessageKind {
     Unknown,
     Confirm,
@@ -106,6 +106,33 @@ impl MessageKind {
             _ => MessageKind::Unknown,
         }
     }
+
+    pub fn is_error(self) -> bool {
+        matches!(
+            self,
+            MessageKind::Error
+                | MessageKind::EchoError
+                | MessageKind::LuaError
+                | MessageKind::RpcError
+        )
+    }
+
+    pub fn highlight_group(self) -> Option<&'static str> {
+        match self {
+            MessageKind::Warning => Some("WarningMsg"),
+            MessageKind::Error
+            | MessageKind::EchoError
+            | MessageKind::LuaError
+            | MessageKind::RpcError => Some("ErrorMsg"),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StartupMessage {
+    pub kind: MessageKind,
+    pub content: String,
 }
 
 #[allow(unused)]
@@ -417,6 +444,7 @@ pub enum RedrawEvent {
         kind: MessageKind,
         content: StyledContent,
         replace_last: bool,
+        append: bool,
     },
     MessageClear,
     #[allow(unused)]
@@ -436,6 +464,8 @@ pub enum RedrawEvent {
         entries: Vec<(MessageKind, StyledContent)>,
     },
     Suspend,
+    NeovimSessionStarted,
+    StartupMessageUiRestored,
     NeovideSetRedraw(bool),
     NeovideIntroBannerAllowed(bool),
 }
@@ -476,7 +506,7 @@ fn extract_values_with_optional<const REQ: usize, const OPT: usize>(
         for (index, value) in values.into_iter().enumerate() {
             if index < REQ {
                 required_values[index] = value;
-            } else {
+            } else if index - REQ < OPT {
                 optional_values[index - REQ] = Some(value);
             }
         }
@@ -992,12 +1022,14 @@ fn parse_cmdline_block_append(cmdline_block_append_arguments: Vec<Value>) -> Res
 }
 
 fn parse_msg_show(msg_show_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    let [kind, content, replace_last] = extract_values(msg_show_arguments)?;
+    let ([kind, content, replace_last], [_history, append, _id, _trigger]) =
+        extract_values_with_optional(msg_show_arguments)?;
 
     Ok(RedrawEvent::MessageShow {
         kind: MessageKind::parse(&parse_string(kind)?),
         content: parse_styled_content(content)?,
         replace_last: parse_bool(replace_last)?,
+        append: append.map(parse_bool).transpose()?.unwrap_or(false),
     })
 }
 
@@ -1121,4 +1153,62 @@ pub fn parse_progress_bar_event(value: Option<&Value>) -> Option<UserEvent> {
         .unwrap_or(0.0) as f32;
 
     Some(UserEvent::ShowProgressBar { percent })
+}
+
+#[cfg(test)]
+mod tests {
+    use rmpv::Value;
+
+    use super::{MessageKind, RedrawEvent, parse_msg_show};
+
+    #[test]
+    fn message_kind_marks_error_variants() {
+        assert!(MessageKind::Error.is_error());
+        assert!(MessageKind::EchoError.is_error());
+        assert!(MessageKind::LuaError.is_error());
+        assert!(MessageKind::RpcError.is_error());
+
+        assert!(!MessageKind::Echo.is_error());
+        assert!(!MessageKind::EchoMessage.is_error());
+        assert!(!MessageKind::Warning.is_error());
+    }
+
+    #[test]
+    fn message_kind_preserves_severity_highlights() {
+        assert_eq!(MessageKind::Error.highlight_group(), Some("ErrorMsg"));
+        assert_eq!(MessageKind::EchoError.highlight_group(), Some("ErrorMsg"));
+        assert_eq!(MessageKind::Warning.highlight_group(), Some("WarningMsg"));
+        assert_eq!(MessageKind::Echo.highlight_group(), None);
+    }
+
+    #[test]
+    fn msg_show_defaults_append_to_false_for_older_payloads() {
+        let event =
+            parse_msg_show(vec![Value::from("echo"), Value::Array(vec![]), Value::from(false)])
+                .unwrap();
+
+        match event {
+            RedrawEvent::MessageShow { append, .. } => assert!(!append),
+            event => panic!("expected MessageShow, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn msg_show_parses_append_from_newer_payloads() {
+        let event = parse_msg_show(vec![
+            Value::from("echo"),
+            Value::Array(vec![]),
+            Value::from(false),
+            Value::from(true),
+            Value::from(true),
+            Value::Nil,
+            Value::from(""),
+        ])
+        .unwrap();
+
+        match event {
+            RedrawEvent::MessageShow { append, .. } => assert!(append),
+            event => panic!("expected MessageShow, got {event:?}"),
+        }
+    }
 }

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -73,6 +73,7 @@ where
 struct NeovimState {
     nvim: Option<Neovim<NeovimWriter>>,
     can_support_ime_api: bool,
+    pre_attach_cmdheight: Option<Value>,
 }
 
 #[derive(Clone)]
@@ -151,6 +152,20 @@ impl NeovimHandler {
 
     pub fn mark_ui_command_started(&self) -> bool {
         self.ui_command_started.swap(true, Ordering::SeqCst)
+    }
+
+    pub fn set_pre_attach_cmdheight(&self, cmdheight: Value) {
+        if let Ok(mut guard) = self.current_neovim.write() {
+            guard.pre_attach_cmdheight = Some(cmdheight);
+        }
+    }
+
+    pub fn pre_attach_cmdheight(&self) -> Option<Value> {
+        self.current_neovim.read().ok().and_then(|guard| guard.pre_attach_cmdheight.clone())
+    }
+
+    pub fn send_redraw_event(&self, event: RedrawEvent) {
+        let _ = self.redraw_event_sender.send(event);
     }
 }
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -31,7 +31,7 @@ pub use handler::NeovimHandler;
 use itertools::Itertools;
 use log::info;
 use mundy::{Interest, Preferences};
-use nvim_rs::{Neovim, UiAttachOptions, Value, error::CallError};
+use nvim_rs::{Neovim, UiAttachOptions, Value, call_args, error::CallError, rpc::model::IntoVal};
 use rmpv::Utf8String;
 use session::{NeovimInstance, NeovimSession};
 use setup::{get_api_information, setup_neovide_specific_state};
@@ -56,6 +56,12 @@ pub use ui_commands::{
 };
 
 const NEOVIM_REQUIRED_VERSION: (u64, u64, u64) = (0, 10, 0);
+
+fn supports_startup_message_capture(version: &api_info::ApiVersion) -> bool {
+    // It's needed to keep the built-in message UI on nvim 0.10/0.11. since its external cmdline
+    // startup prompts can block before we have a rendered window.
+    version.has_version(0, 12, 0, None) || version.has_version(0, 12, 0, Some(0))
+}
 
 macro_rules! nvim_dict {
     ( $( $key:expr => $value:expr ),* $(,)? ) => {
@@ -137,7 +143,31 @@ pub async fn show_error_message(
             Value::String(error_msg_highlight.clone()),
         ]),
     );
-    nvim.echo(prepared_lines, true, nvim_dict! {}).await
+
+    let opts: Vec<(Value, Value)> = nvim_dict! {};
+    nvim.call("nvim_echo", call_args![prepared_lines, true, opts]).await??;
+
+    Ok(())
+}
+
+pub async fn show_startup_message(
+    nvim: &Neovim<NeovimWriter>,
+    message: &StartupMessage,
+) -> Result<(), Box<CallError>> {
+    let mut chunk = vec![Value::String(message.content.clone().add("\n").into())];
+    if let Some(highlight_group) = message.kind.highlight_group() {
+        chunk.push(Value::String(highlight_group.into()));
+    }
+
+    let mut opts: Vec<(Value, Value)> = nvim_dict! {};
+    if message.kind.is_error() {
+        opts.push((Value::from("err"), Value::from(true)));
+    }
+
+    // show the captured message without duplicating nvim message history.
+    nvim.call("nvim_echo", call_args![vec![Value::Array(chunk)], false, opts]).await??;
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -194,10 +224,28 @@ async fn create_neovim_session(
     settings.read_initial_values(&session.neovim).await?;
     set_background_if_allowed(background, &session.neovim).await;
 
+    let capture_startup_messages = supports_startup_message_capture(&api_information.version);
+    if capture_startup_messages {
+        let pre_attach_cmdheight = session
+            .neovim
+            .get_option("cmdheight")
+            .await
+            .context("Read pre-attach cmdheight failed")?;
+        handler.set_pre_attach_cmdheight(pre_attach_cmdheight);
+        handler.send_redraw_event(RedrawEvent::NeovimSessionStarted);
+    }
+
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
     options.set_multigrid_external(!cmdline_settings.no_multi_grid);
     options.set_rgb(true);
+    if capture_startup_messages {
+        // Temporarily externalize messages so startup errors before the first grid update are not
+        // lost behind a hit-enter prompt. After the first rendered batch, we restore nvim's
+        // message/cmdline screen space and replay the captured messages.
+        // See https://github.com/neovide/neovide/issues/3499
+        options.set_messages_externa(true);
+    }
     #[cfg(target_os = "macos")]
     options.set_hlstate_external(true);
     // We can close the handle here, as Neovim already owns it

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -14,7 +14,10 @@ use rmpv::Value;
 use strum::AsRefStr;
 use tokio::sync::mpsc::unbounded_channel;
 
-use super::{NeovimHandler, Settings, set_background_if_allowed, show_error_message};
+use super::{
+    NeovimHandler, RedrawEvent, Settings, StartupMessage, set_background_if_allowed,
+    show_error_message, show_startup_message,
+};
 use crate::{
     bridge::{NeovimWriter, nvim_dict},
     cmd_line::CmdLineSettings,
@@ -22,6 +25,10 @@ use crate::{
     utils::handle_wslpaths,
     window::RouteId,
 };
+
+// nvim_get_option_info2 reports this when an option
+// was last set through an API client, which is how ui_attach applies ext_messages.
+const SID_API_CLIENT: i64 = -9;
 
 /// Active handler pointer for places that do not carry a RouteId
 /// like global menu callbacks and a few legacy paths
@@ -267,6 +274,8 @@ pub enum ParallelCommand {
     DisplayAvailableFonts(Vec<String>),
     ShowError { lines: Vec<String> },
     SetBackground { background: String },
+    FlushStartupMessages { messages: Vec<StartupMessage> },
+    ReplayStartupMessages { messages: Vec<StartupMessage> },
 }
 
 async fn display_available_fonts(
@@ -312,8 +321,87 @@ async fn display_available_fonts(
     Ok(())
 }
 
+async fn disable_ui_option(nvim: &Neovim<NeovimWriter>, option: &'static str) -> Result<()> {
+    nvim.ui_set_option(option, Value::from(false))
+        .await
+        .with_context(|| format!("Disable {option} failed"))
+}
+
+fn cmdheight_to_restore(
+    pre_attach_cmdheight: Option<&Value>,
+    externalized_cmdheight: &Value,
+    last_set_sid: i64,
+) -> Option<Value> {
+    if externalized_cmdheight.as_u64() == Some(0) && !cmdheight_zero_was_user_set(last_set_sid) {
+        pre_attach_cmdheight.cloned()
+    } else {
+        Some(externalized_cmdheight.clone())
+    }
+}
+
+fn cmdheight_zero_was_user_set(last_set_sid: i64) -> bool {
+    // ext_messages sets cmdheight through the ui api during attach.
+    // older nvim versions may leave that source unset, so both sources are treated as a
+    // neovide temporary value.
+    !matches!(last_set_sid, 0 | SID_API_CLIENT)
+}
+
+async fn cmdheight_last_set_sid(nvim: &Neovim<NeovimWriter>) -> Result<i64> {
+    nvim.exec_lua(
+        "return vim.api.nvim_get_option_info2('cmdheight', {}).last_set_sid",
+        call_args![],
+    )
+    .await?
+    .as_i64()
+    .context("Read cmdheight option source failed")
+}
+
+async fn restore_builtin_message_ui(
+    nvim: &Neovim<NeovimWriter>,
+    pre_attach_cmdheight: Option<Value>,
+) -> Result<()> {
+    let cmdheight = nvim.get_option("cmdheight").await.context("Read cmdheight failed")?;
+    let last_set_sid = cmdheight_last_set_sid(nvim).await?;
+    let restored_cmdheight =
+        cmdheight_to_restore(pre_attach_cmdheight.as_ref(), &cmdheight, last_set_sid);
+    disable_ui_option(nvim, "ext_messages").await?;
+    disable_ui_option(nvim, "ext_cmdline").await?;
+    if let Some(cmdheight) = restored_cmdheight {
+        nvim.set_option("cmdheight", cmdheight).await.context("Restore cmdheight failed")?;
+    }
+
+    Ok(())
+}
+
+async fn replay_startup_messages(
+    nvim: &Neovim<NeovimWriter>,
+    messages: Vec<StartupMessage>,
+) -> Result<()> {
+    for message in messages {
+        show_startup_message(nvim, &message).await.context("Show startup message failed")?;
+    }
+
+    Ok(())
+}
+
+async fn flush_startup_messages(
+    nvim: &Neovim<NeovimWriter>,
+    handler: &NeovimHandler,
+    messages: Vec<StartupMessage>,
+) -> Result<()> {
+    restore_builtin_message_ui(nvim, handler.pre_attach_cmdheight()).await?;
+    let result = replay_startup_messages(nvim, messages).await;
+    handler.send_redraw_event(RedrawEvent::StartupMessageUiRestored);
+    result
+}
+
 impl ParallelCommand {
-    async fn execute(self, nvim: &Neovim<NeovimWriter>, settings: &Settings) {
+    async fn execute(
+        self,
+        nvim: &Neovim<NeovimWriter>,
+        settings: &Settings,
+        handler: &NeovimHandler,
+    ) {
         // Don't panic here unless there's absolutely no chance of continuing the program, Instead
         // just log the error and hope that it's something temporary or recoverable A normal reason
         // for failure is when neovim has already quit, and a command, for example mouse move is
@@ -367,6 +455,12 @@ impl ParallelCommand {
             ParallelCommand::SetBackground { background } => {
                 set_background_if_allowed(&background, nvim).await;
                 Ok(())
+            }
+            ParallelCommand::FlushStartupMessages { messages } => {
+                flush_startup_messages(nvim, handler, messages).await
+            }
+            ParallelCommand::ReplayStartupMessages { messages } => {
+                replay_startup_messages(nvim, messages).await
             }
         };
 
@@ -437,7 +531,9 @@ pub fn start_ui_command_handler(
                     let settings = settings_for_parallel.clone();
                     tokio::spawn(async move {
                         if let Some(ui_command_nvim) = handler_for_command.clone_current_neovim() {
-                            parallel_command.execute(&ui_command_nvim, settings.as_ref()).await;
+                            parallel_command
+                                .execute(&ui_command_nvim, settings.as_ref(), &handler_for_command)
+                                .await;
                         } else {
                             log::warn!("Parallel command received without an active Neovim handle");
                         }
@@ -501,5 +597,56 @@ pub fn unregister_route_handler(route_id: RouteId) {
         active.replace(handler);
     } else {
         active.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cmdheight_to_restore;
+    use rmpv::Value;
+
+    #[test]
+    fn cmdheight_restore_uses_pre_attach_value_for_ext_messages_zero() {
+        assert_eq!(
+            cmdheight_to_restore(Some(&Value::from(1)), &Value::from(0), super::SID_API_CLIENT),
+            Some(Value::from(1))
+        );
+    }
+
+    #[test]
+    fn cmdheight_restore_uses_pre_attach_value_for_unset_zero_source() {
+        assert_eq!(
+            cmdheight_to_restore(Some(&Value::from(1)), &Value::from(0), 0),
+            Some(Value::from(1))
+        );
+    }
+
+    #[test]
+    fn cmdheight_restore_preserves_user_zero_value() {
+        assert_eq!(
+            cmdheight_to_restore(Some(&Value::from(1)), &Value::from(0), 42),
+            Some(Value::from(0))
+        );
+    }
+
+    #[test]
+    fn cmdheight_restore_preserves_startup_nonzero_value() {
+        assert_eq!(
+            cmdheight_to_restore(Some(&Value::from(1)), &Value::from(2), super::SID_API_CLIENT),
+            Some(Value::from(2))
+        );
+    }
+
+    #[test]
+    fn cmdheight_restore_preserves_pre_attach_zero() {
+        assert_eq!(
+            cmdheight_to_restore(Some(&Value::from(0)), &Value::from(0), super::SID_API_CLIENT),
+            Some(Value::from(0))
+        );
+    }
+
+    #[test]
+    fn cmdheight_restore_skips_zero_without_pre_attach_value() {
+        assert_eq!(cmdheight_to_restore(None, &Value::from(0), super::SID_API_CLIENT), None);
     }
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -20,7 +20,10 @@ use winit::event_loop::EventLoopProxy;
 use winit::window::Theme;
 
 use crate::{
-    bridge::{EditorMode, GridLineCell, GuiOption, NeovimHandler, RedrawEvent, WindowAnchor},
+    bridge::{
+        EditorMode, GridLineCell, GuiOption, MessageKind, NeovimHandler, RedrawEvent,
+        StartupMessage, StyledContent, WindowAnchor,
+    },
     clipboard::ClipboardHandle,
     profiling::{tracy_named_frame, tracy_zone},
     renderer::{DrawCommand, WindowDrawCommand, rendered_window::BASE_GRID_ID},
@@ -37,6 +40,31 @@ pub use window::*;
 
 use intro::{IntroMessageExtender, IntroProcessing};
 pub const MSG_ZINDEX: u64 = 200; // See the documenation for nvim_open_win
+
+fn styled_content_to_plain_text(content: StyledContent) -> String {
+    content.into_iter().map(|(_, text)| text).collect()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StartupMessageCapture {
+    BeforeFirstGrid,
+    UntilFirstFlush(StartupFlushReason),
+    RestoringMessageUi,
+    MessageUiRestored,
+    Finished,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StartupFlushReason {
+    Prompt,
+    FirstGrid,
+}
+
+impl StartupMessageCapture {
+    fn is_active(self) -> bool {
+        self != Self::Finished
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SortOrder {
@@ -116,6 +144,7 @@ pub struct Editor {
     pub current_mode_index: Option<u64>,
     current_mode: EditorMode,
     pub ui_ready: bool,
+    startup_message_capture: StartupMessageCapture,
     event_loop_proxy: EventLoopProxy<EventPayload>,
     route_id: RouteId,
     #[allow(dead_code)]
@@ -159,6 +188,7 @@ impl Editor {
             current_mode_index: None,
             current_mode: EditorMode::Normal,
             ui_ready: false,
+            startup_message_capture: StartupMessageCapture::BeforeFirstGrid,
             settings,
             event_loop_proxy,
             route_id,
@@ -228,6 +258,7 @@ impl Editor {
                 trace!("Image flushed");
                 tracy_named_frame!("neovim draw command flush");
                 self.send_cursor_info();
+                self.advance_startup_capture_on_flush();
 
                 {
                     trace!("send_batch");
@@ -390,6 +421,29 @@ impl Editor {
             } => {
                 tracy_zone!("EditorMessageSetPosition");
                 self.set_message_position(grid, row, scrolled, z_index, comp_index)
+            }
+            RedrawEvent::MessageShow { kind, content, replace_last, append } => {
+                tracy_zone!("EditorMessageShow");
+                self.handle_startup_message(kind, content, replace_last, append);
+            }
+            RedrawEvent::CommandLineShow { .. } | RedrawEvent::CommandLineBlockShow { .. } => {
+                tracy_zone!("EditorCommandLineShow");
+                self.finish_startup_capture_on_prompt();
+            }
+            RedrawEvent::MessageClear => {
+                tracy_zone!("EditorMessageClear");
+                self.clear_startup_messages();
+            }
+            RedrawEvent::NeovimSessionStarted => {
+                tracy_zone!("EditorNeovimSessionStarted");
+                self.reset_startup_message_capture();
+            }
+            RedrawEvent::StartupMessageUiRestored => {
+                tracy_zone!("EditorStartupMessageUiRestored");
+                self.replay_startup_messages();
+                if self.startup_message_capture == StartupMessageCapture::RestoringMessageUi {
+                    self.startup_message_capture = StartupMessageCapture::MessageUiRestored;
+                }
             }
             RedrawEvent::WindowViewport {
                 grid,
@@ -1193,8 +1247,74 @@ impl Editor {
     fn set_ui_ready(&mut self) {
         if !self.ui_ready {
             self.ui_ready = true;
-            self.draw_command_batcher.queue(DrawCommand::UIReady);
+            self.startup_message_capture =
+                StartupMessageCapture::UntilFirstFlush(StartupFlushReason::FirstGrid);
         }
+    }
+
+    fn reset_startup_message_capture(&mut self) {
+        self.ui_ready = false;
+        self.startup_message_capture = StartupMessageCapture::BeforeFirstGrid;
+    }
+
+    fn handle_startup_message(
+        &mut self,
+        kind: MessageKind,
+        content: StyledContent,
+        replace_last: bool,
+        append: bool,
+    ) {
+        if !self.startup_message_capture.is_active() {
+            return;
+        }
+
+        if kind == MessageKind::ReturnPrompt {
+            self.finish_startup_capture_on_prompt();
+        }
+
+        let content = styled_content_to_plain_text(content);
+        if content.is_empty() {
+            return;
+        }
+
+        self.draw_command_batcher.queue(DrawCommand::StartupMessage {
+            message: StartupMessage { kind, content },
+            replace_last,
+            append,
+        });
+    }
+
+    fn clear_startup_messages(&mut self) {
+        if self.startup_message_capture.is_active() {
+            self.draw_command_batcher.queue(DrawCommand::ClearStartupMessages);
+        }
+    }
+
+    fn advance_startup_capture_on_flush(&mut self) {
+        if let StartupMessageCapture::UntilFirstFlush(reason) = self.startup_message_capture {
+            let command = match reason {
+                StartupFlushReason::Prompt => DrawCommand::StartupPrompt,
+                StartupFlushReason::FirstGrid => DrawCommand::UIReady,
+            };
+            self.draw_command_batcher.queue(command);
+            self.startup_message_capture = StartupMessageCapture::RestoringMessageUi;
+        } else if self.startup_message_capture == StartupMessageCapture::MessageUiRestored {
+            self.draw_command_batcher.queue(DrawCommand::ReplayStartupMessages);
+            self.startup_message_capture = StartupMessageCapture::Finished;
+        }
+    }
+
+    fn finish_startup_capture_on_prompt(&mut self) {
+        if self.startup_message_capture == StartupMessageCapture::BeforeFirstGrid {
+            self.startup_message_capture =
+                StartupMessageCapture::UntilFirstFlush(StartupFlushReason::Prompt);
+        }
+    }
+
+    fn replay_startup_messages(&self) {
+        let batch = vec![DrawCommand::ReplayStartupMessages];
+        let payload = EventPayload::for_route(batch.into(), self.route_id);
+        let _ = self.event_loop_proxy.send_event(payload);
     }
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -35,7 +35,7 @@ use winit::{
 
 use crate::{
     WindowSettings,
-    bridge::EditorMode,
+    bridge::{EditorMode, StartupMessage},
     cmd_line::CmdLineSettings,
     editor::{Cursor, Style, WindowType},
     profiling::{tracy_create_gpu_context, tracy_named_frame, tracy_zone},
@@ -70,6 +70,7 @@ pub use vsync::VSync;
 use self::fonts::font_options::FontOptions;
 
 const MESSAGE_SELECTION_ALPHA: f32 = 0.35;
+const STARTUP_MESSAGE_LIMIT: usize = 4;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct MessageSelection {
@@ -151,8 +152,18 @@ pub enum DrawCommand {
     LineSpaceChanged(f32),
     DefaultStyleChanged(Style),
     ModeChanged(EditorMode),
+    StartupMessage { message: StartupMessage, replace_last: bool, append: bool },
+    ClearStartupMessages,
+    StartupPrompt,
+    ReplayStartupMessages,
     UIReady,
     Window { grid_id: u64, command: WindowDrawCommand },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StartupMessageFlush {
+    RestoreMessageUi,
+    Replay,
 }
 
 pub struct Renderer {
@@ -171,12 +182,16 @@ pub struct Renderer {
 
     settings: Arc<Settings>,
     message_selection: Option<MessageSelection>,
+    startup_messages: Vec<StartupMessage>,
+    startup_message_ui_restored: bool,
 }
 
 /// Results of processing the draw commands from the command channel.
 pub struct DrawCommandResult {
     pub font_changed: bool,
     pub should_show: bool,
+    pub startup_message_flush: Option<StartupMessageFlush>,
+    pub startup_messages: Vec<StartupMessage>,
 }
 
 impl Renderer {
@@ -213,6 +228,8 @@ impl Renderer {
             user_scale_factor,
             settings,
             message_selection: None,
+            startup_messages: Vec::new(),
+            startup_message_ui_restored: false,
         }
     }
 
@@ -500,12 +517,26 @@ impl Renderer {
 
     pub fn handle_draw_commands(&mut self, batch: Vec<DrawCommand>) -> DrawCommandResult {
         let settings = self.settings.get::<RendererSettings>();
-        let mut result = DrawCommandResult { font_changed: false, should_show: false };
+        let mut result = DrawCommandResult {
+            font_changed: false,
+            should_show: false,
+            startup_message_flush: None,
+            startup_messages: vec![],
+        };
 
         for draw_command in batch {
             self.handle_draw_command(draw_command, &mut result);
             tracy_named_frame!("neovim draw batch processed");
         }
+
+        if self.should_auto_replay_startup_messages(&result) {
+            result.startup_message_flush = Some(StartupMessageFlush::Replay);
+        }
+
+        if result.startup_message_flush.is_some() {
+            result.startup_messages = self.take_startup_messages();
+        }
+
         self.flush(&settings);
 
         result
@@ -585,10 +616,65 @@ impl Renderer {
             DrawCommand::ModeChanged(new_mode) => {
                 self.current_mode = new_mode;
             }
+            DrawCommand::StartupMessage { message, replace_last, append } => {
+                self.push_startup_message(message, replace_last, append);
+            }
+            DrawCommand::ClearStartupMessages => {
+                self.startup_messages.pop();
+            }
+            DrawCommand::StartupPrompt => {
+                result.should_show = true;
+                result.startup_message_flush = Some(StartupMessageFlush::RestoreMessageUi);
+            }
+            DrawCommand::ReplayStartupMessages => {
+                self.startup_message_ui_restored = true;
+                result.startup_message_flush = Some(StartupMessageFlush::Replay);
+            }
             DrawCommand::UIReady => {
                 result.should_show = true;
+                result.startup_message_flush = Some(StartupMessageFlush::RestoreMessageUi);
             }
         }
+    }
+
+    fn should_auto_replay_startup_messages(&self, result: &DrawCommandResult) -> bool {
+        self.startup_message_ui_restored
+            && result.startup_message_flush.is_none()
+            && !self.startup_messages.is_empty()
+    }
+
+    fn push_startup_message(&mut self, message: StartupMessage, replace_last: bool, append: bool) {
+        match (append, replace_last, self.startup_messages.last_mut()) {
+            (true, _, Some(last_message)) => last_message.content.push_str(&message.content),
+            (_, true, Some(last_message)) => *last_message = message,
+            _ => {
+                self.startup_messages.push(message);
+                self.trim_startup_messages();
+            }
+        }
+    }
+
+    fn trim_startup_messages(&mut self) {
+        let overflow = self.startup_messages.len().saturating_sub(STARTUP_MESSAGE_LIMIT);
+        if overflow > 0 {
+            self.startup_messages.drain(..overflow);
+        }
+    }
+
+    fn take_startup_messages(&mut self) -> Vec<StartupMessage> {
+        std::mem::take(&mut self.startup_messages)
+            .into_iter()
+            .flat_map(|message| {
+                let kind = message.kind;
+                message
+                    .content
+                    .lines()
+                    .map(str::trim_end)
+                    .filter(|line| !line.is_empty())
+                    .map(move |line| StartupMessage { kind, content: line.to_string() })
+                    .collect_vec()
+            })
+            .collect()
     }
 
     pub fn flush(&mut self, renderer_settings: &RendererSettings) {
@@ -602,6 +688,8 @@ impl Renderer {
         self.progress_bar = ProgressBar::new();
         self.current_mode = EditorMode::Unknown(String::new());
         self.message_selection = None;
+        self.startup_messages.clear();
+        self.startup_message_ui_restored = false;
     }
 
     pub fn get_cursor_destination(&self) -> PixelPos<f32> {
@@ -733,11 +821,17 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::bridge::MessageKind;
 
     fn create_renderer() -> Renderer {
         let settings = Arc::new(Settings::new());
         settings.register::<WindowSettings>();
+        settings.register::<RendererSettings>();
         Renderer::new(2.0, Config::default(), settings)
+    }
+
+    fn startup_message(content: &str) -> StartupMessage {
+        StartupMessage { kind: MessageKind::Error, content: content.to_string() }
     }
 
     #[test]
@@ -767,5 +861,210 @@ mod tests {
 
         assert_eq!(renderer.user_scale_factor, 1.5);
         assert_eq!(renderer.grid_renderer.shaper.current_size(), initial_size * 1.5);
+    }
+
+    #[test]
+    fn startup_messages_are_kept_until_ui_ready() {
+        let mut renderer = create_renderer();
+
+        let result = renderer.handle_draw_commands(vec![DrawCommand::StartupMessage {
+            message: startup_message("boom"),
+            replace_last: false,
+            append: false,
+        }]);
+
+        assert!(!result.should_show);
+        assert_eq!(result.startup_message_flush, None);
+        assert!(result.startup_messages.is_empty());
+
+        let result = renderer.handle_draw_commands(vec![DrawCommand::UIReady]);
+
+        assert!(result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::RestoreMessageUi));
+        assert_eq!(result.startup_messages, vec![startup_message("boom")]);
+    }
+
+    #[test]
+    fn startup_messages_after_ui_ready_in_same_batch_are_included() {
+        let mut renderer = create_renderer();
+
+        let result = renderer.handle_draw_commands(vec![
+            DrawCommand::UIReady,
+            DrawCommand::StartupMessage {
+                message: startup_message("boom"),
+                replace_last: false,
+                append: false,
+            },
+        ]);
+
+        assert!(result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::RestoreMessageUi));
+        assert_eq!(result.startup_messages, vec![startup_message("boom")]);
+    }
+
+    #[test]
+    fn startup_prompt_flushes_startup_messages() {
+        let mut renderer = create_renderer();
+
+        let result = renderer.handle_draw_commands(vec![
+            DrawCommand::StartupMessage {
+                message: startup_message("boom"),
+                replace_last: false,
+                append: false,
+            },
+            DrawCommand::StartupPrompt,
+        ]);
+
+        assert!(result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::RestoreMessageUi));
+        assert_eq!(result.startup_messages, vec![startup_message("boom")]);
+    }
+
+    #[test]
+    fn startup_message_clear_drops_only_latest_message() {
+        let mut renderer = create_renderer();
+
+        let result = renderer.handle_draw_commands(vec![
+            DrawCommand::StartupMessage {
+                message: startup_message("boom"),
+                replace_last: false,
+                append: false,
+            },
+            DrawCommand::StartupMessage {
+                message: startup_message("progress"),
+                replace_last: false,
+                append: false,
+            },
+            DrawCommand::ClearStartupMessages,
+            DrawCommand::UIReady,
+        ]);
+
+        assert!(result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::RestoreMessageUi));
+        assert_eq!(result.startup_messages, vec![startup_message("boom")]);
+    }
+
+    #[test]
+    fn startup_messages_can_replay_after_message_ui_restore() {
+        let mut renderer = create_renderer();
+
+        let result = renderer.handle_draw_commands(vec![
+            DrawCommand::StartupMessage {
+                message: startup_message("boom"),
+                replace_last: false,
+                append: false,
+            },
+            DrawCommand::ReplayStartupMessages,
+        ]);
+
+        assert!(!result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::Replay));
+        assert_eq!(result.startup_messages, vec![startup_message("boom")]);
+    }
+
+    #[test]
+    fn startup_messages_auto_replay_after_message_ui_restore() {
+        let mut renderer = create_renderer();
+
+        renderer.handle_draw_commands(vec![DrawCommand::ReplayStartupMessages]);
+        let result = renderer.handle_draw_commands(vec![DrawCommand::StartupMessage {
+            message: startup_message("boom"),
+            replace_last: false,
+            append: false,
+        }]);
+
+        assert!(!result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::Replay));
+        assert_eq!(result.startup_messages, vec![startup_message("boom")]);
+    }
+
+    #[test]
+    fn startup_message_replay_state_is_reset_on_clear() {
+        let mut renderer = create_renderer();
+
+        renderer.handle_draw_commands(vec![DrawCommand::ReplayStartupMessages]);
+        renderer.clear();
+        let result = renderer.handle_draw_commands(vec![DrawCommand::StartupMessage {
+            message: startup_message("boom"),
+            replace_last: false,
+            append: false,
+        }]);
+
+        assert!(!result.should_show);
+        assert_eq!(result.startup_message_flush, None);
+        assert!(result.startup_messages.is_empty());
+    }
+
+    #[test]
+    fn startup_messages_can_replace_last_message() {
+        let mut renderer = create_renderer();
+
+        let result = renderer.handle_draw_commands(vec![
+            DrawCommand::StartupMessage {
+                message: startup_message("old"),
+                replace_last: false,
+                append: false,
+            },
+            DrawCommand::StartupMessage {
+                message: startup_message("new"),
+                replace_last: true,
+                append: false,
+            },
+            DrawCommand::UIReady,
+        ]);
+
+        assert!(result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::RestoreMessageUi));
+        assert_eq!(result.startup_messages, vec![startup_message("new")]);
+    }
+
+    #[test]
+    fn startup_messages_can_append_to_previous_message() {
+        let mut renderer = create_renderer();
+
+        let result = renderer.handle_draw_commands(vec![
+            DrawCommand::StartupMessage {
+                message: startup_message("hello"),
+                replace_last: false,
+                append: false,
+            },
+            DrawCommand::StartupMessage {
+                message: startup_message(" world"),
+                replace_last: false,
+                append: true,
+            },
+            DrawCommand::UIReady,
+        ]);
+
+        assert!(result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::RestoreMessageUi));
+        assert_eq!(result.startup_messages, vec![startup_message("hello world")]);
+    }
+
+    #[test]
+    fn startup_messages_keep_only_recent_entries() {
+        let mut renderer = create_renderer();
+        let mut commands = (0..(STARTUP_MESSAGE_LIMIT + 2))
+            .map(|i| DrawCommand::StartupMessage {
+                message: startup_message(&format!("message {i}")),
+                replace_last: false,
+                append: false,
+            })
+            .collect_vec();
+        commands.push(DrawCommand::UIReady);
+
+        let result = renderer.handle_draw_commands(commands);
+
+        assert!(result.should_show);
+        assert_eq!(result.startup_message_flush, Some(StartupMessageFlush::RestoreMessageUi));
+        assert_eq!(
+            result.startup_messages,
+            vec![
+                startup_message("message 2"),
+                startup_message("message 3"),
+                startup_message("message 4"),
+                startup_message("message 5")
+            ]
+        );
     }
 }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -1,6 +1,7 @@
 use std::{
     cell::RefCell,
     fmt,
+    mem::take,
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
@@ -15,6 +16,8 @@ use winit::{
     event_loop::{ActiveEventLoop, EventLoopProxy},
     window::{Cursor, Fullscreen, Theme, Window, WindowId},
 };
+
+use approx::AbsDiffEq;
 
 #[cfg(target_os = "windows")]
 use super::settings::CornerPreference;
@@ -42,14 +45,14 @@ use crate::{
     CmdLineSettings,
     bridge::{
         NeovimHandler, NeovimRuntime, OpenArgs, OpenMode, ParallelCommand, RestartDetails,
-        SerialCommand, send_ui, set_active_route_handler, unregister_route_handler,
+        SerialCommand, StartupMessage, send_ui, set_active_route_handler, unregister_route_handler,
     },
     clipboard::ClipboardHandle,
     cmd_line::{GeometryArgs, MouseCursorIcon},
     profiling::{tracy_frame, tracy_gpu_collect, tracy_gpu_zone, tracy_plot, tracy_zone},
     renderer::{
-        DrawCommand, MessageSelection, Renderer, RendererSettingsChanged, SkiaRenderer, VSync,
-        create_skia_renderer,
+        DrawCommand, DrawCommandResult, MessageSelection, Renderer, RendererSettingsChanged,
+        SkiaRenderer, StartupMessageFlush, VSync, create_skia_renderer,
     },
     running_tracker::RunningTracker,
     settings::{
@@ -72,12 +75,31 @@ use {
 
 const GRID_TOLERANCE: f32 = 1e-3;
 
+impl StartupMessageFlush {
+    fn into_command(self, messages: Vec<StartupMessage>) -> Option<ParallelCommand> {
+        match self {
+            Self::Replay if messages.is_empty() => None,
+            Self::Replay => Some(ParallelCommand::ReplayStartupMessages { messages }),
+            Self::RestoreMessageUi => Some(ParallelCommand::FlushStartupMessages { messages }),
+        }
+    }
+}
+
+fn flush_startup_messages_if_ready(result: &mut DrawCommandResult, neovim_handler: &NeovimHandler) {
+    let Some(flush) = result.startup_message_flush else {
+        return;
+    };
+
+    let messages = take(&mut result.startup_messages);
+    if let Some(command) = flush.into_command(messages) {
+        send_ui(command, neovim_handler);
+    }
+}
+
 fn round_or_op<Op: FnOnce(f32) -> f32>(v: f32, op: Op) -> f32 {
     let rounded = v.round();
     if v.abs_diff_eq(&rounded, GRID_TOLERANCE) { rounded } else { op(v) }
 }
-
-use approx::AbsDiffEq;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct WindowPadding {
@@ -1855,10 +1877,15 @@ impl WinitWindowWrapper {
             return;
         };
 
-        let handle_draw_commands_result = {
+        let mut handle_draw_commands_result = {
             let mut renderer = route.window.renderer.borrow_mut();
             renderer.handle_draw_commands(batch)
         };
+
+        flush_startup_messages_if_ready(
+            &mut handle_draw_commands_result,
+            &route.window.neovim_handler,
+        );
 
         if let Some(route) = self.routes.get_mut(&window_id) {
             route.state.font_changed_last_frame |= handle_draw_commands_result.font_changed;
@@ -1884,12 +1911,16 @@ impl WinitWindowWrapper {
             return;
         };
 
-        let handle_draw_commands_result = {
+        let mut handle_draw_commands_result = {
             let mut renderer = route_core.renderer.borrow_mut();
             renderer.handle_draw_commands(batch)
         };
 
         route_core.font_changed_last_frame |= handle_draw_commands_result.font_changed;
+        flush_startup_messages_if_ready(
+            &mut handle_draw_commands_result,
+            &route_core.neovim_handler,
+        );
 
         if handle_draw_commands_result.should_show {
             route_core.should_show_observed = true;


### PR DESCRIPTION
fixes https://github.com/neovide/neovide/issues/3499

neovim can hit wait-return during startup before the first grid update. at that point we have no message area to show the error and no useful window to accept the Enter that would let startup continue.

now temporarily we request external messages during startup, capture msg_show events until the first rendered batch, restore the built-in message and cmdline UI, then replay the captured messages through nvim_echo without duplicating message history.

_we keep this path gated to nvim **0.12+**, since 0.10/0.11 externalize cmdline prompts in ways we do not render during startup_, so we preserve cmdheight across the temporary external-message mode where the startup capture does not silently rewrite the user's message area.