### PR TITLE
add --force-register-clipboard

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -200,10 +200,10 @@ async fn create_neovim_session(
 
     let cmdline_settings = settings.get::<CmdLineSettings>();
 
-    let remote = cmdline_settings.wsl || cmdline_settings.server.is_some();
     // This is too verbose to keep enabled all the time
     // log::info!("Api information {:#?}", api_information);
-    setup_neovide_specific_state(&session.neovim, remote, &api_information, &settings).await?;
+    setup_neovide_specific_state(&session.neovim, &cmdline_settings, &api_information, &settings)
+        .await?;
     if api_information.version.has_version(0, 12, 0, Some(1264)) {
         let mut window_settings = settings.get::<WindowSettings>();
         window_settings.has_mouse_grid_detection = true;

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -8,6 +8,7 @@ use super::{
 };
 use crate::{
     bridge::NeovimWriter,
+    cmd_line::CmdLineSettings,
     settings::{SettingLocation, Settings, config::config_path},
     version::BUILD_VERSION,
 };
@@ -26,7 +27,7 @@ pub async fn get_api_information(nvim: &Neovim<NeovimWriter>) -> Result<ApiInfor
 
 pub async fn setup_neovide_specific_state(
     nvim: &Neovim<NeovimWriter>,
-    remote: bool,
+    cmdline_settings: &CmdLineSettings,
     api_information: &ApiInformation,
     settings: &Settings,
 ) -> Result<()> {
@@ -54,7 +55,8 @@ pub async fn setup_neovide_specific_state(
     .await
     .context("Error setting client info")?;
 
-    let register_clipboard = remote;
+    let remote = cmdline_settings.wsl || cmdline_settings.server.is_some();
+    let register_clipboard = cmdline_settings.force_register_clipboard.unwrap_or(remote);
     let register_right_click = cfg!(target_os = "windows");
 
     let setting_locations = settings.setting_locations();

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -70,6 +70,10 @@ pub struct CmdLineSettings {
     #[arg(long, env = "NEOVIDE_WSL")]
     pub wsl: bool,
 
+    /// Force enable/disable the neovide clipboard provider
+    #[arg(long, value_name = "ENABLED")]
+    pub force_register_clipboard: Option<bool>,
+
     /// Which window decorations to use (do note that the window might not be resizable
     /// if this is "none")
     #[arg(long, env = "NEOVIDE_FRAME", default_value_t)]

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -330,6 +330,15 @@ Connects to the named pipe or socket at ADDRESS.
 
 Runs neovim from inside wsl rather than as a normal executable.
 
+### Force registering neovide clipboard provider
+
+```sh
+--force-register-clipboard <true|false>
+```
+
+Skip the heuristics on whether or not neovide should register its custom clipboard provider, and
+always/never enable it (based on the value provided).
+
 ### Neovim Binary
 
 ```sh


### PR DESCRIPTION
Related: https://github.com/neovide/neovide/pull/3393

The above PR enabled the workflow of `neovide --no-tabs --neovim-bin ssh -- SERVER nvim`. However, the heuristics for whether neovide registered its own custom clipboard provider made neovide think this is a local neovim session. It's not! So no clipboard provider would be registered, and I couldn't copy/paste.

There are many different ways of solving this "issue". This PR is trying out adding a new `--force-register-clipboard` commandline option, that skips the "is this neovim instance local" heuristics, and just uses the value provided instead. Works great for my use case, but, let me know if you'd prefer a different approach and I'm happy to explore alternatives!