### PR TITLE
Consolidate window blur logic into WinitWindowWrapper::set_blur

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -439,9 +439,11 @@ impl WinitWindowWrapper {
         let window = route.window.winit_window.clone();
 
         #[cfg(target_os = "windows")]
-        window.set_system_backdrop(
-            if blur { BackdropType::TransientWindow } else { BackdropType::Auto },
-        );
+        window.set_system_backdrop(if blur {
+            BackdropType::TransientWindow
+        } else {
+            BackdropType::Auto
+        });
 
         #[cfg(not(target_os = "windows"))]
         window.set_blur(blur);

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -431,6 +431,22 @@ impl WinitWindowWrapper {
         }
     }
 
+    pub fn set_blur(&mut self, window_id: WindowId, blur: bool) {
+        let Some(route) = self.routes.get(&window_id) else {
+            return;
+        };
+
+        let window = route.window.winit_window.clone();
+
+        #[cfg(target_os = "windows")]
+        window.set_system_backdrop(
+            if blur { BackdropType::TransientWindow } else { BackdropType::Auto },
+        );
+
+        #[cfg(not(target_os = "windows"))]
+        window.set_blur(blur);
+    }
+
     #[cfg(target_os = "windows")]
     fn set_corner_preference(&self, window_id: WindowId, option: CornerPreference) {
         let Some(route) = self.routes.get(&window_id) else {
@@ -730,10 +746,7 @@ impl WinitWindowWrapper {
                 let WindowSettings { opacity, .. } = self.settings.get::<WindowSettings>();
                 let transparent = opacity < 1.0;
                 for window_id in window_ids.iter() {
-                    if let Some(route) = self.routes.get(window_id) {
-                        let window = route.window.winit_window.clone();
-                        window.set_blur(blur && transparent);
-                    }
+                    self.set_blur(*window_id, blur && transparent);
                 }
             }
             WindowSettingsChanged::MessageAreaDragSelection(enabled) if !enabled => {
@@ -1755,12 +1768,7 @@ impl WinitWindowWrapper {
             renderer.borrow().grid_renderer.grid_scale
         );
 
-        window.set_blur(window_blurred && opacity.min(normal_opacity) < 1.0);
-
-        #[cfg(target_os = "windows")]
-        if window_blurred {
-            window.set_system_backdrop(BackdropType::TransientWindow); // Acrylic blur
-        }
+        self.set_blur(window.id(), window_blurred && opacity.min(normal_opacity) < 1.0);
 
         if fullscreen {
             let handle = window.current_monitor();


### PR DESCRIPTION
<img width="2029" height="1336" alt="image" src="https://github.com/user-attachments/assets/52606c45-7a3e-41b8-9451-e309f99988bf" />

Winit doesn't support window.set_blur() for windows, but the Acrylic effect works about the same, which can be set by window.set_system_backdrop(). This was implemented by #3021, but did not work properly. I put the unified blur logic into WinitWindowWrapper::set_blur, which implements that fix.