### PR TITLE
add startup-message capture settings

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -224,7 +224,8 @@ async fn create_neovim_session(
     settings.read_initial_values(&session.neovim).await?;
     set_background_if_allowed(background, &session.neovim).await;
 
-    let capture_startup_messages = supports_startup_message_capture(&api_information.version);
+    let capture_startup_messages = cmdline_settings.startup_message_capture
+        && supports_startup_message_capture(&api_information.version);
     if capture_startup_messages {
         let pre_attach_cmdheight = session
             .neovim

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -217,6 +217,14 @@ pub struct CmdLineSettings {
     #[arg(long = "no-vsync", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
     _no_vsync: bool,
 
+    /// Temporarily capture startup messages before the first grid render [DEFAULT]
+    #[arg(long = "startup-message-capture", env = "NEOVIDE_STARTUP_MESSAGE_CAPTURE", action = ArgAction::SetTrue, default_value = "1", value_parser = FalseyValueParser::new())]
+    pub startup_message_capture: bool,
+
+    /// Do not temporarily capture startup messages before the first grid render
+    #[arg(long = "no-startup-message-capture", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
+    _no_startup_message_capture: bool,
+
     /// Which NeoVim binary to invoke headlessly instead of `nvim` found on $PATH
     #[arg(long = "neovim-bin", env = "NEOVIM_BIN")]
     pub neovim_bin: Option<String>,
@@ -341,6 +349,10 @@ pub fn handle_command_line_arguments(args: Vec<String>, settings: &Settings) -> 
 
     if cmdline._no_vsync {
         cmdline.vsync = false;
+    }
+
+    if cmdline._no_startup_message_capture {
+        cmdline.startup_message_capture = false;
     }
 
     settings.set::<CmdLineSettings>(&cmdline);

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -188,7 +188,7 @@ impl Editor {
             current_mode_index: None,
             current_mode: EditorMode::Normal,
             ui_ready: false,
-            startup_message_capture: StartupMessageCapture::BeforeFirstGrid,
+            startup_message_capture: StartupMessageCapture::Finished,
             settings,
             event_loop_proxy,
             route_id,

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -84,6 +84,7 @@ pub struct Config {
     pub neovim_bin: Option<PathBuf>,
     pub no_multigrid: Option<bool>,
     pub srgb: Option<bool>,
+    pub startup_message_capture: Option<bool>,
     pub tabs: Option<bool>,
     pub system_native_tabs: Option<bool>,
     pub mouse_cursor_icon: Option<String>,
@@ -181,6 +182,11 @@ impl Config {
         }
         if let Some(srgb) = self.srgb {
             unsafe { env::set_var("NEOVIDE_SRGB", srgb.to_string()) };
+        }
+        if let Some(startup_message_capture) = self.startup_message_capture {
+            unsafe {
+                env::set_var("NEOVIDE_STARTUP_MESSAGE_CAPTURE", startup_message_capture.to_string())
+            };
         }
         if let Some(fork) = self.fork {
             unsafe { env::set_var("NEOVIDE_FORK", fork.to_string()) };

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -211,6 +211,19 @@ tabs to avoid confusing new users. `--no-tabs` disables this behavior.
 Note: Even if files are opened in tabs, they're buffers anyways. It's just about them being visible
 or not.
 
+### Startup Message Capture
+
+```sh
+--no-startup-message-capture, --startup-message-capture or $NEOVIDE_STARTUP_MESSAGE_CAPTURE=0|1
+```
+
+**Nightly.**
+
+By default, Neovide temporarily captures startup messages on supported Neovim versions so errors can
+be shown before the first grid render. `--no-startup-message-capture` disables that temporary
+external message UI path for plugins that need to initialize without another UI client advertising
+`ext_messages` or `ext_cmdline`
+
 ### Reuse Existing Instance (macOS Only)
 
 ```sh

--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -44,6 +44,7 @@ no-multigrid = false
 opengl = false # macOS/Windows only
 # server = "/tmp/nvim.sock" # or "127.0.0.1:7777"
 srgb = false # platform-specific: false (Linux/macOS) or true (Windows)
+startup-message-capture = true
 tabs = true
 system-native-tabs = false # macOS only
 system-pinned-hotkey = "cmd+ctrl+z" # macOS only


### PR DESCRIPTION
neovide started temporarily requesting external messages in #3504 so startup errors from #3499 would not disappear behind a hit-enter prompt before the first grid was rendered.

losing early startup errors is a bad failure mode and users should not have to guess why Neovim is stuck before neovide has a real message area.

but this also made neovide advertise ext_messages and ext_cmdline during plugin startup. [noice.nvim](https://github.com/folke/noice.nvim) explicitly checks nvim_list_uis() before attaching its own UI and refuses to handle messages or the cmdline when another UI client already owns those extensions.
