### PR TITLE
chore: avoid overriding icon in Dock for bundled app launches

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -298,13 +298,22 @@ fn load_icon_from_default_bytes() -> Option<Retained<NSImage>> {
     }
 }
 
+fn is_running_from_app_bundle() -> bool {
+    std::env::current_exe().is_ok_and(|exe| {
+        exe.ancestors().any(|path| path.extension().is_some_and(|extension| extension == "app"))
+    })
+}
+
 fn load_neovide_icon(custom_icon_path: Option<&String>) -> Option<Retained<NSImage>> {
-    custom_icon_path
-        .and_then(|path| {
+    if let Some(path) = custom_icon_path {
+        return {
             let expanded = expand_tilde(path);
             load_icon_from_custom_path(&expanded)
-        })
-        .or_else(load_icon_from_default_bytes)
+        };
+    }
+
+    // Bundled apps should keep the icon resolved by macOS, including user-customized icons.
+    (!is_running_from_app_bundle()).then(load_icon_from_default_bytes).flatten()
 }
 
 fn open_external_url(url: &str) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix / Chore

## Did this PR introduce a breaking change? 
- No

## Description

This PR is for macOS only.

Neovide currently calls `setApplicationIconImage` with the embedded icon (`include_bytes!` backed, not replacable) during startup. For bundled `.app` launches this **overrides** the icon _resolved_ by macOS, including user-customized app icons, so the pinned Dock icon and running Dock icon can **differ**.

This is because a user can drag a new `icns` to replace in `.app` bundle's right click menu "Get Info" entry; in macOS convention, this is intended to override all icons for all presence.

Since the new icon of Neovide is still in decision, this will first allow the user to override desktop installation first; it will also make it possible to look good on macOS 26/27's new icon style "Transparent".

The original problematic look is like:

<img width="929" height="418" alt="image" src="https://github.com/user-attachments/assets/d9ed6356-3f19-4bc3-921f-1caa12de02e5" />

## Fix

Just detect if it is launched from an app bundle and skip replacement for it; this fix does not affect launch from a terminal shell or `cargo run` path. After this fix, running state icon would align with the normal not running (even user does not customize one), system managed state.