### PR TITLE
fix: parsing neovim api function parameters

### DIFF
--- a/src/bridge/api_info.rs
+++ b/src/bridge/api_info.rs
@@ -151,6 +151,7 @@ impl ApiParameterType {
 pub struct ApiParameter {
     pub name: String,
     pub parameter_type: ApiParameterType,
+    pub optional: Option<bool>,
 }
 
 #[allow(unused)]
@@ -304,13 +305,22 @@ fn parse_parameter_type(
 
 fn parse_parameter(value: ValueRef) -> std::result::Result<ApiParameter, ApiInfoParseError> {
     let info: Vec<ValueRef> = value.try_into()?;
-    if let Some((t, n)) = info.into_iter().collect_tuple() {
+    let mut info_iter = info.into_iter();
+
+    let name = info_iter.next();
+    let parameter = info_iter.next();
+    let optional = info_iter
+        .next()
+        .and_then(|value| if let ValueRef::Boolean(b) = value { Some(b) } else { None });
+
+    if let (Some(t), Some(n)) = (name, parameter) {
         let name: Utf8StringRef = n.try_into()?;
         let name = name.as_str();
         let parameter_type = parse_parameter_type(t)?;
         Ok(ApiParameter {
             name: name.map_or(Err("name field is missing"), |v| Ok(v.to_owned()))?,
             parameter_type,
+            optional,
         })
     } else {
         Err("Invalid parameter".into())

--- a/src/bridge/api_info.rs
+++ b/src/bridge/api_info.rs
@@ -118,7 +118,7 @@ impl ApiParameterType {
             Some("Float") => ApiParameterType::Float,
             Some("String") => ApiParameterType::String,
             Some("Array") => ApiParameterType::Array,
-            Some("Dictionary") => ApiParameterType::Dictionary,
+            Some("Dict") | Some("Dictionary") => ApiParameterType::Dictionary,
             Some("Object") => ApiParameterType::Object,
             Some("Buffer") => ApiParameterType::Buffer,
             Some("Window") => ApiParameterType::Window,
@@ -305,25 +305,25 @@ fn parse_parameter_type(
 
 fn parse_parameter(value: ValueRef) -> std::result::Result<ApiParameter, ApiInfoParseError> {
     let info: Vec<ValueRef> = value.try_into()?;
-    let mut info_iter = info.into_iter();
 
-    let name = info_iter.next();
-    let parameter = info_iter.next();
-    let optional = info_iter
-        .next()
-        .and_then(|value| if let ValueRef::Boolean(b) = value { Some(b) } else { None });
+    match info.as_slice() {
+        [parameter_type, name, optional @ ..] => {
+            let optional = match optional {
+                [] => None,
+                [ValueRef::Boolean(optional)] => Some(*optional),
+                _ => return Err("unexpected optional field".into()),
+            };
 
-    if let (Some(t), Some(n)) = (name, parameter) {
-        let name: Utf8StringRef = n.try_into()?;
-        let name = name.as_str();
-        let parameter_type = parse_parameter_type(t)?;
-        Ok(ApiParameter {
-            name: name.map_or(Err("name field is missing"), |v| Ok(v.to_owned()))?,
-            parameter_type,
-            optional,
-        })
-    } else {
-        Err("Invalid parameter".into())
+            let name: Utf8StringRef = name.clone().try_into()?;
+            let parameter_type = parse_parameter_type(parameter_type.clone())?;
+
+            Ok(ApiParameter {
+                name: name.as_str().ok_or("name field is missing")?.to_owned(),
+                parameter_type,
+                optional,
+            })
+        }
+        _ => Err("Invalid parameter".into()),
     }
 }
 


### PR DESCRIPTION
Fix neovim API parsing failure after https://github.com/neovim/neovim/commit/dc8934482e72cdc885da69f7318eabc21a4e8757.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Fixes #3528.

## Did this PR introduce a breaking change? 
- No

## Details and Potential Improvements

Starting from https://github.com/neovim/neovim/commit/dc8934482e72cdc885da69f7318eabc21a4e8757, the parameter of functions in `nvim_get_api_info()` introduced a new item `optional`, causing the previous way to parse parameter to fail.

Ideally, according to neovim's documentation:

> Each function `parameters` item is a `[type, name, optional]` tuple.

it should be enough to just add a component in the original pattern matching code. But in actual testing, I found the `optional` item isn't always present, so I ended up with this kinda ugly approach of calling `next()` on iterator manually and pattern matching on the necessary components, leaving `optional` untouched since it's already an `Option`. Please let me know if someone has a better approach of parsing such stuff that can be either `[type, name]` or `[type, name, optional]`. I originally considered to reserve the original pattern matching idea and just add another branch of `else if` but that will ended up with a lot of duplicated code which is uglier in my humble opinion.

