### PR TITLE
fix: render COLRv1 fonts on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-test-data"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d99914ae8c4aee9e814f54be404e15182a9a5556eb2d37f4189e6cff44d5a63"
+dependencies = [
+ "font-types 0.12.2",
+]
+
+[[package]]
 name = "font-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +897,12 @@ checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "font-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
 
 [[package]]
 name = "foreign-types"
@@ -1605,6 +1620,7 @@ dependencies = [
  "derive-new",
  "dirs",
  "flexi_logger",
+ "font-test-data",
  "fork",
  "futures 0.3.31",
  "gl",
@@ -2545,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
- "font-types",
+ "font-types 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,9 +443,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"
@@ -761,12 +761,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1648,7 +1642,6 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "raw-window-handle",
- "regex",
  "rmpv",
  "rustc-hash",
  "rustix 1.1.2",
@@ -1666,9 +1659,7 @@ dependencies = [
  "tokio-util",
  "toml 0.9.8",
  "tracy-client-sys",
- "unicode-segmentation",
  "uzers",
- "which",
  "windows",
  "windows-registry",
  "winit",
@@ -2865,9 +2856,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skia-bindings"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+checksum = "eb325787c91b3f6c34a7c6f2b8a2297b20292d733ca53a08c233e5028aec49af"
 dependencies = [
  "bindgen",
  "cc",
@@ -2882,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+checksum = "c61cb643dac43067f3eb76c866635a74377ac0abca0ff2590674e1e295514c3d"
 dependencies = [
  "bitflags 2.10.0",
  "skia-bindings",
@@ -3672,18 +3663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "7.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
-dependencies = [
- "either",
- "env_home",
- "rustix 1.1.2",
- "winsafe",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,12 +4115,6 @@ checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml 0.5.11",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ winit = { version = "=0.30.13", features = ["serde"] }
 xdg = "3.0.0"
 
 [dev-dependencies]
+font-test-data = "0.7.0"
 scoped-env = "2.1.0"
 serial_test = "3.2.0"
 
@@ -110,7 +111,8 @@ csscolorparser = "0.7.0"
 shlex = "1.3.0"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
-skia-safe = { version = "0.97.2", features = ["gl", "textlayout"] }
+# A current embedded FreeType is required for Skia to render COLRv1 color fonts.
+skia-safe = { version = "0.97.2", features = ["embed-freetype", "gl", "textlayout"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 fork = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "neovide"
 version = "0.16.2"
 edition = "2024"
 description = "Neovide: No Nonsense Neovim Gui"
-readme = "README.md"
 homepage = "https://neovide.dev/"
 repository = "https://github.com/neovide/neovide"
 license = "MIT"
@@ -52,7 +51,6 @@ async-trait = "0.1.83"
 backtrace = "0.3.74"
 clap = { version = "4.5.23", features = ["cargo", "color", "derive", "env"] }
 copypasta = "0.10.2"
-csscolorparser = "0.7.0"
 derive-new = "0.7.0"
 dirs = "6.0.0"
 flexi_logger = { version = "0.31.2", default-features = false }
@@ -77,7 +75,6 @@ nvim-rs = { version = "0.9.2", features = ["use_tokio"] }
 parking_lot = "0.12.3"
 rand = "0.9.0"
 raw-window-handle = "0.6.2"
-regex = "1.11.1"
 rmpv = "1.3.0"
 rustc-hash = "2.0.0"
 serde = { version = "1.0.216", features = ["derive"] }
@@ -96,10 +93,7 @@ tracy-client-sys = { version = "0.28.0", default-features = false, features = [
   "fibers",
   "manual-lifetime",
 ], optional = true }
-unicode-segmentation = "1.12.0"
-which = "7.0.1"
 winit = { version = "=0.30.13", features = ["serde"] }
-xdg = "3.0.0"
 
 [dev-dependencies]
 font-test-data = "0.7.0"
@@ -107,16 +101,16 @@ scoped-env = "2.1.0"
 serial_test = "3.2.0"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-csscolorparser = "0.7.0"
 shlex = "1.3.0"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
 # A current embedded FreeType is required for Skia to render COLRv1 color fonts.
-skia-safe = { version = "0.99.0", features = ["embed-freetype", "gl", "textlayout"] }
+skia-safe = { version = "=0.153.3", features = ["embed-freetype", "gl", "textlayout"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 fork = "0.4.0"
 rustix = { version = "1.0.8", features = ["fs", "process"] }
+xdg = "3.0.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.1"
@@ -192,11 +186,12 @@ objc2-quartz-core = { version = "0.3.1", default-features = false, features = [
   "objc2-metal",
   "std",
 ] }
-skia-safe = { version = "0.99.0", features = ["gl", "metal", "textlayout"] }
+skia-safe = { version = "=0.153.3", features = ["gl", "metal", "textlayout"] }
 uzers = "0.12.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-skia-safe = { version = "0.99.0", features = ["d3d", "gl", "textlayout"] }
+csscolorparser = "0.7.0"
+skia-safe = { version = "=0.153.3", features = ["d3d", "gl", "textlayout"] }
 # This needs to match the version used by skia
 windows = { version = "0.62.0", features = [
   "Win32_Graphics_Direct3D",

--- a/neovide-derive/Cargo.toml
+++ b/neovide-derive/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 description = "Derive macros for the Neovide gui"
 homepage = "https://neovide.dev/"
 repository = "https://github.com/neovide/neovide"
-readme = "README.md"
 keywords = ["neovide", "neovim", "nvim", "gui", "macros"]
 
 [lib]

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -222,4 +222,28 @@ mod tests {
         assert!(loader.get_or_load(&missing_font).is_none());
         assert_eq!(loader.failed_fonts.len(), 1);
     }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn renders_colrv1_glyphs() {
+        use skia_safe::{Color, Paint, Point, surfaces};
+
+        let data = Data::new_copy(font_test_data::COLRV0V1);
+        let typeface = FontMgr::new().new_from_data(&data, 0).unwrap();
+        let font = Font::from_typeface(typeface, 96.0);
+        let mut surface = surfaces::raster_n32_premul((128, 128)).unwrap();
+        let canvas = surface.canvas();
+        canvas.clear(Color::TRANSPARENT);
+        canvas.draw_str("\u{f0100}", Point::new(8.0, 96.0), &font, &Paint::default());
+
+        let pixmap = surface.peek_pixels().unwrap();
+        let has_colored_pixel = (0..pixmap.height()).any(|y| {
+            (0..pixmap.width()).any(|x| {
+                let color = pixmap.get_color((x, y));
+                color.a() > 0 && (color.r() > 0 || color.g() > 0 || color.b() > 0)
+            })
+        });
+
+        assert!(has_colored_pixel, "Skia did not render the COLRv1 glyph in color");
+    }
 }

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -34,10 +34,10 @@ impl FontPair {
         skia_font.set_edging(font_edging(&key.edging));
 
         let typeface = skia_font.typeface();
-        let (font_data, index) = typeface.to_font_data()?;
+        let (font_data, index) = typeface.to_font_bytes()?;
         // Only the lower 16 bits are part of the index, the rest indicates named instances. But we
         // don't care about those here, since we are just loading the font, so ignore them
-        let index = index & 0xFFFF;
+        let index = (index & 0xFFFF) as usize;
         let swash_font = SwashFont::from_data(font_data, index)?;
 
         Some(Self { key, skia_font, swash_font })
@@ -97,7 +97,7 @@ impl FontLoader {
             FontPair::new(font_key, Font::from_typeface(typeface, self.font_size))
         } else {
             let data = Data::new_copy(DEFAULT_FONT);
-            let typeface = self.font_mgr.new_from_data(&data, 0)?;
+            let typeface = self.font_mgr.new_from_data(data, 0)?;
             FontPair::new(font_key, Font::from_typeface(typeface, self.font_size))
         }
     }
@@ -161,7 +161,7 @@ impl FontLoader {
             let font_key = FontKey::default();
             let data = Data::new_copy(LAST_RESORT_FONT);
 
-            let typeface = self.font_mgr.new_from_data(&data, 0)?;
+            let typeface = self.font_mgr.new_from_data(data, 0)?;
             let font_pair =
                 Rc::new(FontPair::new(font_key, Font::from_typeface(typeface, self.font_size))?);
 
@@ -229,7 +229,7 @@ mod tests {
         use skia_safe::{Color, Paint, Point, surfaces};
 
         let data = Data::new_copy(font_test_data::COLRV0V1);
-        let typeface = FontMgr::new().new_from_data(&data, 0).unwrap();
+        let typeface = FontMgr::new().new_from_data(data, 0).unwrap();
         let font = Font::from_typeface(typeface, 96.0);
         let mut surface = surfaces::raster_n32_premul((128, 128)).unwrap();
         let canvas = surface.canvas();

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -153,7 +153,7 @@ environment.systemPackages = with pkgs; [neovide];
 
      ```sh
      sudo apt install -y curl \
-         gnupg ca-certificates git \
+         gnupg ca-certificates git clang ninja-build \
          gcc-multilib g++-multilib cmake libssl-dev pkg-config \
          libfreetype6-dev libasound2-dev libexpat1-dev libxcb-composite0-dev \
          libbz2-dev libsndio-dev freeglut3-dev libxmu-dev libxi-dev libfontconfig1-dev \
@@ -163,7 +163,7 @@ environment.systemPackages = with pkgs; [neovide];
    - Fedora
 
      ```sh
-     sudo dnf install fontconfig-devel freetype-devel @development-tools \
+     sudo dnf install clang ninja-build fontconfig-devel freetype-devel @development-tools \
          libstdc++-static libstdc++-devel
      ```
 
@@ -172,7 +172,7 @@ environment.systemPackages = with pkgs; [neovide];
      Do note that an [AUR package](https://aur.archlinux.org/packages/neovide-git) already exists.
 
      ```sh
-     sudo pacman -S base-devel fontconfig freetype2 libglvnd sndio cmake \
+     sudo pacman -S base-devel clang ninja fontconfig freetype2 libglvnd sndio cmake \
          git gtk3 python sdl2 vulkan-intel libxkbcommon-x11
      ```
 


### PR DESCRIPTION
Closes #3493.

## Summary

- build Skia with its embedded FreeType on Linux so COLRv1 color glyph painting is compiled in
- add a renderer regression test using the official Fontations COLRv1 fixture
- document the additional Clang and Ninja dependencies for Linux source builds

## Root cause

Font lookup and shaping are working for the affected Noto Color Emoji release: swash and Skia resolve the same glyph ID. The glyph disappears later, when the cached Linux Skia library tries to paint it. That library does not contain Skia's FreeType COLRv1 paint path because the path is gated by the FreeType headers used at compile time.

Enabling `skia-safe`'s `embed-freetype` feature builds Skia against its bundled current FreeType. The same Noto font then renders, and the regression fixture changes from a monochrome outline fallback to a correctly colored COLRv1 glyph.

## Validation

- `cargo test --offline` (188 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --release --locked`
- verified the regression test fails without `embed-freetype` and passes with it
- reproduced and verified the fix with the current Noto Color Emoji COLRv1 font

## Build trade-off

rust-skia 0.97.2 does not currently publish a cached Linux binary for this `embed-freetype` feature combination, so a first Linux source build compiles Skia locally. The locked release build completed successfully in 8 minutes in my environment. The stripped release binary increased from 36,127,656 to 36,940,160 bytes (+812,504 bytes, about 2.25%). The installation docs now include the required Clang and Ninja packages.
