### PR TITLE
fix: ignore unrelated config directory events

### DIFF
--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -2,7 +2,7 @@
 
 use std::{env, fs, sync::mpsc, time::Duration};
 
-use notify_debouncer_full::{new_debouncer, notify::RecursiveMode};
+use notify_debouncer_full::{DebouncedEvent, new_debouncer, notify::RecursiveMode};
 use serde::{
     Deserialize, Deserializer,
     de::{Error as DeError, Unexpected},
@@ -314,8 +314,21 @@ fn watcher_thread(init_config: Config, event_loop_proxy: EventLoopProxy<EventPay
 
     let mut previous_config = init_config;
     loop {
-        if let Err(e) = rx.recv() {
-            eprintln!("Error while watching config file: {e}");
+        let events = match rx.recv() {
+            Ok(Ok(events)) => events,
+            Ok(Err(errors)) => {
+                for error in errors {
+                    log::warn!("Error while watching config file: {error}");
+                }
+                continue;
+            }
+            Err(error) => {
+                log::warn!("Config file watcher stopped: {error}");
+                return;
+            }
+        };
+
+        if !events_relevant_to_config(&events, &config_path) {
             continue;
         }
 
@@ -402,5 +415,59 @@ fn watcher_thread(init_config: Config, event_loop_proxy: EventLoopProxy<EventPay
             }
         }
         previous_config = config;
+    }
+}
+
+fn events_relevant_to_config(events: &[DebouncedEvent], config_path: &Path) -> bool {
+    events.iter().any(|event| {
+        event.event.need_rescan() || event.event.paths.iter().any(|path| path == config_path)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use notify_debouncer_full::{
+        DebouncedEvent,
+        notify::{Event, EventKind, event::Flag},
+    };
+
+    use super::*;
+
+    fn event_with_paths(paths: &[&str]) -> DebouncedEvent {
+        let event = paths
+            .iter()
+            .fold(Event::new(EventKind::Any), |event, path| event.add_path(PathBuf::from(path)));
+        DebouncedEvent::new(event, Instant::now())
+    }
+
+    #[test]
+    fn ignores_events_for_other_files_in_config_directory() {
+        let events = [event_with_paths(&["/tmp/.config.toml.swp"])];
+
+        assert!(!events_relevant_to_config(&events, Path::new("/tmp/config.toml")));
+    }
+
+    #[test]
+    fn accepts_events_for_config_file() {
+        let events = [event_with_paths(&["/tmp/config.toml"])];
+
+        assert!(events_relevant_to_config(&events, Path::new("/tmp/config.toml")));
+    }
+
+    #[test]
+    fn accepts_atomic_rename_to_config_file() {
+        let events = [event_with_paths(&["/tmp/config.toml.tmp", "/tmp/config.toml"])];
+
+        assert!(events_relevant_to_config(&events, Path::new("/tmp/config.toml")));
+    }
+
+    #[test]
+    fn accepts_events_that_require_a_rescan() {
+        let event = Event::new(EventKind::Any).set_flag(Flag::Rescan);
+        let events = [DebouncedEvent::new(event, Instant::now())];
+
+        assert!(events_relevant_to_config(&events, Path::new("/tmp/config.toml")));
     }
 }


### PR DESCRIPTION
Closes #3532.

## Summary

- reload `config.toml` only when a debounced event targets the config path
- keep atomic-save renames and watcher rescan events working
- report watcher errors without treating them as config changes, and stop cleanly if the watcher channel disconnects
- cover direct writes, unrelated directory files, atomic renames, and rescans with focused tests

## Root cause

Neovide watches the config file's parent directory so that deleting and recreating `config.toml` does not break hot reload. The receive loop discarded the event batch, though, and parsed the config after every event in that directory. While an invalid config error was displayed, editor swap or temporary-file activity could therefore parse the same invalid file again and queue another `nvim_echo` message, trapping the user behind repeated hit-enter prompts.

The new relevance check inspects every path in the debounced batch. A rename whose destination is `config.toml` remains relevant, and pathless rescan events still force a reload so missed filesystem notifications cannot leave stale settings.

## What kind of change does this PR introduce?

- Fix

## Did this PR introduce a breaking change?

- No

## Validation

- `cargo test` (191 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- verified the unrelated-file regression test fails when the watcher uses the previous all-directory behavior and passes with path filtering
