### PR TITLE
fix: anchor touch scrolling to the window under the first contact point

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -220,6 +220,19 @@ impl MouseManager {
         Self::get_relative_position_at(self.window_position, window_details, editor_state)
     }
 
+    /// Move the cached pointer position without sending anything to Neovim.
+    ///
+    /// `handle_pointer_motion` also emits drag and mouse move commands, which is not wanted
+    /// when the position only needs to be established to pick a target window.
+    fn set_pointer_position(&mut self, position: PixelPos<f32>, editor_state: &EditorState) {
+        self.window_position = position;
+
+        if let Some(window_details) = self.get_window_details_under_mouse(editor_state) {
+            self.grid_position =
+                Self::get_relative_position_at(position, window_details, editor_state);
+        }
+    }
+
     pub fn clear_message_selection(&mut self) -> bool {
         let had_selection = self.message_selection.take().is_some();
         if had_selection {
@@ -557,6 +570,9 @@ impl MouseManager {
             }
             TouchPhase::Moved => {
                 let mut dragging_just_now = false;
+                // Anchor point and distance of a scroll gesture, collected while the trace is
+                // borrowed and applied once that borrow ends.
+                let mut scroll: Option<(PixelPos<f32>, PixelVec<f32>)> = None;
 
                 if let Some(trace) = self.touch_position.get_mut(&finger_id) {
                     if !trace.left_deadzone_once {
@@ -595,8 +611,17 @@ impl MouseManager {
                         // starting point
                         trace.last = location;
 
-                        self.handle_pixel_scroll(delta, editor_state, neovim_handler);
+                        scroll = Some((trace.start, delta));
                     }
+                }
+
+                // A scroll gesture stays with the window the finger first touched, the same way a
+                // drag stays with the window it started on. Touch input never reaches
+                // handle_pointer_motion, so without anchoring here the target would be picked from
+                // whatever window_position was left over from the last mouse move or tap.
+                if let Some((anchor, delta)) = scroll {
+                    self.set_pointer_position(anchor, editor_state);
+                    self.handle_pixel_scroll(delta, editor_state, neovim_handler);
                 }
 
                 if dragging_just_now {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## Did this PR introduce a breaking change?

No

---

## The bug

Touch scrolling is routed to the wrong window. On a touch-only session it always targets whatever window happens to sit at `PixelPos::default()` — the top-left one — regardless of where the finger actually is.

`handle_line_scroll` picks its target grid from `get_window_details_under_mouse`, which reads `self.window_position`. That field is only ever assigned in `handle_pointer_motion`, and the touch **scroll** path never calls it:

- `TouchPhase::Started` records a `TouchTrace` but sets no position.
- The scroll branch of `TouchPhase::Moved` calls `handle_pixel_scroll` directly.

So a scroll gesture inherits whatever `window_position` was left over from the last physical mouse move or touch tap. The `position` field sent alongside the scroll command is stale for the same reason, so this misroutes both with and without multigrid.

This is easy to miss on a machine with a mouse attached, since any stray pointer motion papers over it. It is consistent on a tablet.

## Why anchor to the first contact point

The other two touch gestures already anchor, and scrolling was the odd one out:

| Gesture | Anchor |
| --- | --- |
| Tap (never leaves deadzone) | `trace.start`, replayed on `TouchPhase::Ended` |
| Drag (held past `touch_drag_timeout`) | locked to the window it started on, via `drag_details` |
| Scroll (leaves deadzone first) | **none** |

Hit-testing every move event would fix the reported symptom but introduces a second problem: crossing a split boundary mid-flick would hand the rest of the gesture, and any momentum, to a different window. Wheel semantics are per-event so "window under the pointer" is right there, but a touch scroll is one continuous interaction. Anchoring matches the existing drag behaviour and what native toolkits do.

## The change

- Adds `set_pointer_position`, which updates `window_position`/`grid_position` without emitting anything to Neovim. `handle_pointer_motion` could not be reused because it also sends `Drag` and `MouseButton{button:"move"}` commands, and a scroll gesture should not generate hover events.
- The scroll branch captures `trace.start` and applies it before the scroll is sent.

The restructuring into a local `Option` is needed for the borrow checker: `trace` is still borrowed from `touch_position` at that point (`trace.last = location` follows on the next line), so a `&mut self` call cannot happen inline. The drag branch gets away with it only because `trace` is dead there.

## Testing

Verified by hand on Windows 11 ARM64 with a touchscreen, release build:

- Two vertical splits, cold start, no mouse movement — flick-scrolling in the right split now scrolls the right split. Previously it always scrolled the left.
- A flick that crosses the split divider stays with the window it began in.
- Tap-to-position-cursor and press-and-hold-to-select are unchanged.

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are both clean on this branch.
