### PR TITLE
profile scroll command pressure without tracy fibers

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -18,10 +18,12 @@ use super::{
     NeovimHandler, RedrawEvent, Settings, StartupMessage, set_background_if_allowed,
     show_error_message, show_startup_message,
 };
+#[cfg(feature = "profiling")]
+use crate::profiling::scroll_tick_count;
 use crate::{
     bridge::{NeovimWriter, nvim_dict},
     cmd_line::CmdLineSettings,
-    profiling::{tracy_dynamic_zone, tracy_fiber_enter, tracy_fiber_leave},
+    profiling::tracy_dynamic_zone,
     utils::handle_wslpaths,
     window::RouteId,
 };
@@ -225,8 +227,10 @@ impl SerialCommand {
                 grid_id,
                 position: (grid_x, grid_y),
                 modifier_string,
-            } => nvim
-                .input_mouse(
+            } => {
+                #[cfg(feature = "profiling")]
+                scroll_tick_count(1);
+                nvim.input_mouse(
                     "wheel",
                     &direction,
                     &modifier_string,
@@ -235,7 +239,8 @@ impl SerialCommand {
                     grid_x as i64,
                 )
                 .await
-                .context("Mouse Scroll Failed"),
+                .context("Mouse Scroll Failed")
+            }
             SerialCommand::Drag {
                 button,
                 grid_id,
@@ -547,10 +552,11 @@ pub fn start_ui_command_handler(
 
     let handler_for_serial = handler.clone();
     tokio::spawn(async move {
-        tracy_fiber_enter!("Serial command");
         while let Some(serial_command) = serial_rx.recv().await {
-            tracy_dynamic_zone!(serial_command.as_ref());
-            tracy_fiber_leave();
+            {
+                tracy_dynamic_zone!(serial_command.as_ref());
+            }
+
             match handler_for_serial.clone_current_neovim_with_ime() {
                 Some((serial_nvim, ime_api)) => {
                     serial_command.execute(&serial_nvim, ime_api).await;
@@ -560,7 +566,6 @@ pub fn start_ui_command_handler(
                     break;
                 }
             }
-            tracy_fiber_enter!("Serial command");
         }
         log::info!("serial command receiver finished");
     });

--- a/src/profiling/mod.rs
+++ b/src/profiling/mod.rs
@@ -2,6 +2,8 @@
 mod profiling_disabled;
 #[cfg(feature = "profiling")]
 mod profiling_enabled;
+#[cfg(feature = "profiling")]
+mod scroll;
 
 #[cfg(all(feature = "gpu_profiling", target_os = "windows"))]
 pub mod d3d;
@@ -12,3 +14,5 @@ pub mod opengl;
 pub use profiling_disabled::*;
 #[cfg(feature = "profiling")]
 pub use profiling_enabled::*;
+#[cfg(feature = "profiling")]
+pub use scroll::scroll_tick_count;

--- a/src/profiling/profiling_disabled.rs
+++ b/src/profiling/profiling_disabled.rs
@@ -33,16 +33,7 @@ macro_rules! tracy_plot {
     ($name: expr, $dt: expr) => {};
 }
 
-#[macro_export]
-macro_rules! tracy_fiber_enter {
-    ($name: expr) => {};
-}
-
-#[inline(always)]
-pub fn tracy_fiber_leave() {}
-
 pub(crate) use tracy_dynamic_zone;
-pub(crate) use tracy_fiber_enter;
 pub(crate) use tracy_gpu_zone;
 pub(crate) use tracy_named_frame;
 pub(crate) use tracy_plot;

--- a/src/profiling/profiling_enabled.rs
+++ b/src/profiling/profiling_enabled.rs
@@ -5,8 +5,8 @@ use std::{os::raw::c_char, ptr::null};
 use tracy_client_sys::{
     ___tracy_alloc_srcloc_name, ___tracy_c_zone_context, ___tracy_connected,
     ___tracy_emit_frame_mark, ___tracy_emit_plot, ___tracy_emit_zone_begin,
-    ___tracy_emit_zone_begin_alloc, ___tracy_emit_zone_end, ___tracy_fiber_enter,
-    ___tracy_fiber_leave, ___tracy_source_location_data, ___tracy_startup_profiler,
+    ___tracy_emit_zone_begin_alloc, ___tracy_emit_zone_end, ___tracy_source_location_data,
+    ___tracy_startup_profiler,
 };
 
 use crate::renderer::SkiaRenderer;
@@ -235,20 +235,6 @@ pub fn _tracy_plot(name: &std::ffi::CStr, value: f64) {
     }
 }
 
-#[inline(always)]
-pub fn _tracy_fiber_enter(name: &std::ffi::CStr) {
-    unsafe {
-        ___tracy_fiber_enter(name.as_ptr());
-    }
-}
-
-#[inline(always)]
-pub fn tracy_fiber_leave() {
-    unsafe {
-        ___tracy_fiber_leave();
-    }
-}
-
 #[macro_export]
 macro_rules! location_data {
     ($name: expr, $color: expr) => {{
@@ -317,18 +303,10 @@ macro_rules! tracy_plot {
     };
 }
 
-#[macro_export]
-macro_rules! tracy_fiber_enter {
-    ($name: expr) => {
-        $crate::profiling::_tracy_fiber_enter($crate::profiling::cstr!($name))
-    };
-}
-
 pub(crate) use cstr;
 pub(crate) use file_cstr;
 pub(crate) use location_data;
 pub(crate) use tracy_dynamic_zone;
-pub(crate) use tracy_fiber_enter;
 pub(crate) use tracy_gpu_zone;
 pub(crate) use tracy_named_frame;
 pub(crate) use tracy_plot;

--- a/src/profiling/scroll.rs
+++ b/src/profiling/scroll.rs
@@ -1,0 +1,13 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::tracy_plot;
+
+static SCROLL_WHEEL_TICKS_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Records how much wheel input is represented by one executed scroll command.
+pub fn scroll_tick_count(count: u32) {
+    tracy_plot!("scroll wheel ticks per command", count as f64);
+
+    let total = SCROLL_WHEEL_TICKS_TOTAL.fetch_add(count as u64, Ordering::Relaxed) + count as u64;
+    tracy_plot!("scroll wheel ticks total", total as f64);
+}


### PR DESCRIPTION
tracy fibers describe execution on one native thread, but tokio tasks are owned by the scheduler and can move across runtime threads after an await. that made the old serial command instrumentation invalid.

also we add a profiling only scroll metric for what we actually need to compare for the follow up patch targeting batch wheel scrolls. error:

	Instrumentation failure: Fiber execution stopped on a thread which is not executing a fiber.

